### PR TITLE
Elevar LTMD al estándar científico y visual común

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -1,0 +1,77 @@
+name: Scientific release preflight
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scientific-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate scientific publication surface
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import pathlib
+          import re
+          import sys
+
+          root = pathlib.Path('.')
+          required = [
+              'README.md',
+              'CITATION.cff',
+              'codemeta.json',
+              'LICENSE',
+              'DATA_LICENSE.md',
+              'VERSION',
+              'CHANGELOG.md',
+              'CONTRIBUTING.md',
+              'CODE_OF_CONDUCT.md',
+              'SECURITY.md',
+              'GOVERNANCE.md',
+              'PROVENANCE.md',
+              'FAIR_ASSESSMENT.md',
+              'SCIENTIFIC_REPOSITORY_STANDARD.md',
+          ]
+
+          missing = [name for name in required if not (root / name).exists()]
+          if missing:
+              print('Missing required scientific publication files:')
+              for name in missing:
+                  print(f' - {name}')
+              sys.exit(1)
+
+          codemeta = json.loads((root / 'codemeta.json').read_text(encoding='utf-8'))
+          for key in ('@context', '@type', 'name', 'codeRepository', 'version', 'license', 'author'):
+              if key not in codemeta:
+                  raise SystemExit(f'codemeta.json is missing required project field: {key}')
+
+          version = (root / 'VERSION').read_text(encoding='utf-8').strip()
+          cff = (root / 'CITATION.cff').read_text(encoding='utf-8')
+          match = re.search(r'^version:\s*["\']?([^"\'\n]+)', cff, flags=re.MULTILINE)
+          if not match:
+              raise SystemExit('CITATION.cff does not expose a version field')
+          cff_version = match.group(1).strip()
+          if version != cff_version:
+              raise SystemExit(f'VERSION ({version}) != CITATION.cff version ({cff_version})')
+          if codemeta.get('version') != version:
+              raise SystemExit(f'VERSION ({version}) != codemeta.json version ({codemeta.get("version")})')
+
+          readme = (root / 'README.md').read_text(encoding='utf-8')
+          for marker in ('FAIR_ASSESSMENT.md', 'GOVERNANCE.md', 'PROVENANCE.md', 'CITATION.cff', 'codemeta.json'):
+              if marker not in readme:
+                  raise SystemExit(f'README.md does not link to {marker}')
+
+          print('Scientific publication surface: OK')
+          print(f'Version alignment: {version}')
+          PY

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,20 @@
+# Código de conducta
+
+Libro de Texto Mexicano Digital es un proyecto académico abierto. Se espera que toda interacción —issues, pull requests, revisiones y discusiones— mantenga un trato profesional, respetuoso y centrado en evidencia.
+
+## Conducta esperada
+
+- discutir métodos, datos y argumentos sin ataques personales;
+- distinguir crítica científica de descalificación;
+- reconocer autoría, procedencia y trabajo previo;
+- no publicar información personal, confidencial o restringida;
+- tratar con especial cuidado materiales educativos, históricos y culturales cuyo contexto pueda requerir explicación adicional;
+- declarar conflictos de interés relevantes para una contribución o revisión.
+
+## Conducta no aceptable
+
+No se toleran hostigamiento, discriminación, amenazas, doxxing, suplantación, manipulación deliberada de evidencia, ocultamiento intencional de procedencia ni atribución falsa.
+
+## Aplicación
+
+El responsable del repositorio puede moderar, cerrar o rechazar contribuciones que violen estas reglas. Las decisiones de moderación no sustituyen la discusión científica: los desacuerdos metodológicos bien fundamentados son bienvenidos y deben quedar documentados.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contribuir a Libro de Texto Mexicano Digital
+
+LTMD recibe contribuciones que mejoren datos, código, documentación, reproducibilidad y revisión metodológica sin borrar incertidumbre ni procedencia.
+
+## Antes de proponer cambios
+
+- abra o vincule un issue cuando el cambio modifique metodología, contratos, cobertura o resultados;
+- identifique la fuente o evidencia que sustenta la modificación;
+- no incorpore libros, páginas, imágenes u otros materiales de terceros al repositorio sin base jurídica clara;
+- mantenga separadas correcciones técnicas, propuestas semánticas y validaciones humanas.
+
+## Requisitos mínimos
+
+Toda contribución debe:
+
+1. ser reproducible o explicar por qué no puede serlo;
+2. conservar identificadores documentales y relaciones de fuente;
+3. incluir o actualizar pruebas, manifiestos o documentación cuando cambie comportamiento verificable;
+4. actualizar `CHANGELOG.md` cuando afecte una release futura o una interfaz científica;
+5. no elevar automáticamente un estado técnico a `semantic_ready`;
+6. documentar incertidumbres, excepciones y resultados negativos relevantes.
+
+## Pull requests
+
+Los pull requests deben ser pequeños y auditables cuando sea posible. El título debe indicar el área modificada y la descripción debe incluir: propósito, evidencia, archivos afectados, pruebas ejecutadas y consecuencias científicas o de compatibilidad.
+
+## Atribución
+
+Las contribuciones sustantivas deben reconocerse de acuerdo con su naturaleza y alcance. Cuando una contribución tenga relevancia académica, puede documentarse con roles CRediT u otro esquema apropiado en una release posterior.
+
+## Conducta y seguridad
+
+Consulte `CODE_OF_CONDUCT.md` y `SECURITY.md`. Los problemas de seguridad no deben publicarse con detalles explotables antes de que exista una vía razonable de mitigación.

--- a/FAIR_ASSESSMENT.md
+++ b/FAIR_ASSESSMENT.md
@@ -1,0 +1,29 @@
+# Autoevaluación FAIR / FAIR4RS
+
+Esta autoevaluación describe el estado de **Libro de Texto Mexicano Digital (LTMD)** como objeto digital de investigación. No constituye certificación externa.
+
+| Dimensión | Estado | Evidencia / acción |
+|---|---|---|
+| Findable | parcial-avanzado | Repositorio público, `CITATION.cff`, `codemeta.json`, versionado y releases. Falta asignar DOI real a la release cuando exista depósito efectivo en Zenodo. |
+| Accessible | avanzado | Código, documentación y derivados publicables accesibles en GitHub; fuentes de terceros se reconstruyen de acuerdo con las restricciones documentadas. |
+| Interoperable | parcial-avanzado | Metadatos legibles por máquina, CSV/JSON y contratos metodológicos; la interoperabilidad semántica depende de cada capa y no se presume antes de validación. |
+| Reusable | avanzado con límites | Licencia Apache-2.0 para software propio, `DATA_LICENSE.md` para derivados licenciables, procedencia, versiones, protocolos y documentación de incertidumbre. |
+| FAIR4RS: identificación | parcial-avanzado | Releases y tags distinguen versiones; el DOI persistente se incorporará únicamente tras un depósito real. |
+| FAIR4RS: metadatos | avanzado | `CITATION.cff` + CodeMeta 3.1 + README + documentación metodológica. |
+| FAIR4RS: ejecutabilidad/reproducibilidad | avanzado | Dependencias de release, scripts versionados, GitHub Actions, manifiestos, hashes y reportes de integridad. |
+| FAIR4RS: comunidad/contribución | mejorado en esta revisión | `CONTRIBUTING.md`, gobernanza, seguridad y reglas para cambios metodológicos. |
+
+## Evidencia de madurez
+
+LTMD conserva explícitamente versiones, denominadores, excepciones, relaciones documentales, integridad criptográfica y límites de la automatización. La distinción `corpus_ready` / `semantic_ready` es un control epistemológico central: la completitud técnica no se comunica como validez semántica.
+
+## Brechas abiertas
+
+1. **DOI de versión**: pendiente hasta que exista un depósito real en un archivo de preservación; no debe anticiparse en metadatos.
+2. **Validación humana semántica**: continúa pendiente donde el protocolo la exige; los estados técnicos no deben promoverse automáticamente.
+3. **Preservación externa adicional**: conviene mantener releases archivadas y, cuando el corte sea estable, registrar preservación complementaria además de GitHub.
+4. **Metadatos de datos específicos**: las futuras releases pueden añadir JSON-LD/Dataset metadata por producto cuando la granularidad lo justifique.
+
+## Criterio de actualización
+
+Esta autoevaluación debe revisarse en cada release mayor o cuando cambien persistent identifiers, licencias, contratos de datos, política de acceso o alcance de validación.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,43 @@
+# Gobernanza de Libro de Texto Mexicano Digital
+
+## Alcance
+
+Este documento define la gobernanza mínima de **Libro de Texto Mexicano Digital (LTMD)** como infraestructura de investigación. Su finalidad es mantener separadas la evidencia documental, el procesamiento computacional, la validación humana y las interpretaciones histórico-educativas.
+
+## Autoridad de las capas
+
+LTMD distingue, al menos, cinco niveles de autoridad:
+
+1. **fuente institucional o documental**, que conserva la identidad del objeto de origen;
+2. **resolución técnica**, que documenta activos, rutas, hashes, OCR y segmentación;
+3. **datos derivados**, que pueden ser reproducibles sin ser todavía evidencia semántica validada;
+4. **validación humana**, que debe quedar identificada, fechada y vinculada con el protocolo aplicado;
+5. **interpretación histórica**, que solo puede apoyarse en capas cuyo alcance y limitaciones estén explícitos.
+
+`corpus_ready` no implica `semantic_ready`. Ningún cierre técnico autoriza por sí mismo una afirmación histórica, curricular o semántica.
+
+## Decisiones y cambios
+
+Los cambios que alteren definiciones, denominadores, contratos de datos, criterios de inclusión, procedimientos de validación o resultados publicados deben:
+
+- quedar versionados en Git;
+- documentarse en `CHANGELOG.md` o en una nota metodológica específica;
+- conservar trazabilidad hacia la evidencia previa;
+- evitar reescrituras retrospectivas de releases publicadas;
+- declarar cualquier ruptura de compatibilidad o cambio de estimando.
+
+## Datos de terceros y derechos
+
+El repositorio no presume derechos sobre libros, páginas, imágenes, texto fuente, marcas u otros materiales de SEP/CONALITEG o de terceros. Las licencias del repositorio cubren únicamente software y productos derivados respecto de los cuales exista capacidad jurídica para licenciarlos. Véase `DATA_LICENSE.md`.
+
+## Revisión humana y automatización
+
+La automatización puede ampliar cobertura, verificar integridad y producir candidatos; no sustituye la validación humana cuando el constructo investigado la requiere. Los resultados negativos, ambiguos o retenidos se conservan como parte de la evidencia metodológica y no se corrigen mediante imputación silenciosa.
+
+## Responsabilidad académica
+
+La coordinación del proyecto mantiene la responsabilidad sobre releases, documentación metodológica, integridad de la procedencia y comunicación pública de las limitaciones. Contribuciones externas deben seguir `CONTRIBUTING.md` y quedar atribuidas de forma verificable.
+
+## Evolución
+
+Esta política es versionada. Toda modificación sustantiva debe acompañar la evolución científica del proyecto y preservar la interpretabilidad de las versiones anteriores.

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -1,0 +1,48 @@
+# Procedencia y trazabilidad
+
+**Libro de Texto Mexicano Digital (LTMD)** adopta una cadena de procedencia explícita para que cada resultado pueda interpretarse de acuerdo con la evidencia que lo sustenta.
+
+## Cadena de procedencia
+
+```text
+catálogo / visor institucional
+        ↓
+identidad documental
+        ↓
+resolución de activos
+        ↓
+hash SHA-256 y verificación
+        ↓
+OCR temporal
+        ↓
+PAGESTRUCT
+        ↓
+FRAGSEG
+        ↓
+derivados computacionales
+        ↓
+validación humana, cuando corresponda
+        ↓
+análisis histórico
+```
+
+## Principios
+
+- La identidad documental no se fusiona por similitud de título, año, grado o contenido.
+- Un alias o relación de fuente debe apoyarse en evidencia verificable; cuando se utiliza identidad byte a byte, se conserva la prueba criptográfica correspondiente.
+- Los activos fuente de terceros no se convierten por defecto en contenido redistribuible del repositorio.
+- OCR, segmentación, clasificación y validación humana son capas distintas.
+- Las excepciones de routing, huecos, fallos de fuente y ambigüedades permanecen visibles.
+- Una release conserva el estado metodológico y científico de su fecha; el avance posterior de `main` no modifica retrospectivamente ese corte.
+
+## Identificadores y evidencia
+
+Los artefactos técnicos deben conservar, cuando aplique, `book_id`, `viewer_key`, ruta o identificador de origen, hashes, fecha o corte de adquisición, versión del pipeline y relaciones documentales. Los scripts y manifiestos son parte de la evidencia reproducible.
+
+## Reutilización documental
+
+LTMD modela explícitamente la dependencia entre objetos cuando existen páginas o fragmentos reutilizados, revisados, reemplazados o byte-idénticos. La independencia estadística o histórica no se presume a partir de diferencias de catálogo.
+
+## Trazabilidad de cambios
+
+Las transformaciones sustantivas deben poder seguirse desde la fuente hasta el producto derivado mediante Git, manifiestos, reportes de integridad, documentación de ola y, en releases, artefactos congelados. La ausencia de evidencia suficiente debe representarse como ausencia o incertidumbre, no como dato inferido silenciosamente.

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,110 @@
+<p align="center">
+  <img src="assets/repository-header-es.svg" alt="Libro de Texto Mexicano Digital — open research infrastructure" width="100%">
+</p>
+
+<p align="center">
+  <strong>Open research infrastructure for the longitudinal study of Mexican textbooks through history of education, digital humanities, computational analysis, and open science.</strong><br>
+  <sub>Document identity · SHA-256 integrity · OCR · segmentation · documentary dependence · human validation · reproducibility</sub>
+</p>
+
+<p align="center">
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1"><img src="https://img.shields.io/badge/release-v0.1.0--rc.1-172033?style=flat-square" alt="Release v0.1.0-rc.1"></a>
+  <a href="CITATION.cff"><img src="https://img.shields.io/badge/citation-CFF%201.2-4b5563?style=flat-square" alt="CFF 1.2"></a>
+  <a href="codemeta.json"><img src="https://img.shields.io/badge/metadata-CodeMeta%203.1-3b5b92?style=flat-square" alt="CodeMeta 3.1"></a>
+  <a href="FAIR_ASSESSMENT.md"><img src="https://img.shields.io/badge/FAIR%2FFAIR4RS-self--assessment-2d6a4f?style=flat-square" alt="FAIR FAIR4RS"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/software-Apache--2.0-172033?style=flat-square" alt="Apache 2.0"></a>
+  <a href="DATA_LICENSE.md"><img src="https://img.shields.io/badge/derivatives-CC%20BY%204.0-7a263a?style=flat-square" alt="CC BY 4.0"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/actions"><img src="https://img.shields.io/github/actions/workflow/status/fersandovalgtz/libro-texto-mexicano-digital/release-preflight.yml?branch=main&style=flat-square&label=CI%20%2F%20QA" alt="CI QA"></a>
+  <img src="https://img.shields.io/badge/U1%20universe-542%20viewers-455B55?style=flat-square" alt="542 U1 viewers">
+  <img src="https://img.shields.io/badge/technical%20coverage-329%2F542%20·%2060.70%25-455B55?style=flat-square" alt="329 of 542 technical coverage">
+  <img src="https://img.shields.io/badge/canonical-298%2F542%20·%2054.98%25-5b4b8a?style=flat-square" alt="298 canonical objects">
+  <img src="https://img.shields.io/badge/human%20semantic%20validation-0%2F542-b7791f?style=flat-square" alt="0 of 542 human semantic validation">
+</p>
+
+<p align="center"><a href="README.md">Español</a> · <a href="FAIR_ASSESSMENT.md">FAIR</a> · <a href="GOVERNANCE.md">Governance</a> · <a href="PROVENANCE.md">Provenance</a> · <a href="CONTRIBUTING.md">Contributing</a></p>
+
+## What LTMD is
+
+**Libro de Texto Mexicano Digital (LTMD)** is a research infrastructure for building a traceable historical-computational corpus of Mexican textbooks and studying long-term transformations in curriculum, pedagogical language, school activities, values, social representations, and visual resources.
+
+The project keeps **document identity**, **asset resolution**, **technical processing**, **derived data**, **human validation**, and **historical interpretation** as distinct layers of evidence.
+
+> [!IMPORTANT]
+> `corpus_ready` does **not** mean `semantic_ready`. Technical completion can be reproducible and complete within its declared scope without constituting human-validated semantic evidence.
+
+## Scientific status
+
+Reference cut: **17 August 2026**.
+
+| Indicator | Status |
+|---|---:|
+| LTMD-U1 historical universe | **542 / 542 viewers inventoried** |
+| Closed or resolved technical coverage | **329 / 542 (60.70%)** |
+| Canonical processing objects | **298 / 542 (54.98%)** |
+| Human semantic validation | **0 / 542** |
+| Published methodological release | **v0.1.0-rc.1** |
+| LTMD DOI | **pending; not pre-declared** |
+
+## Evidence architecture
+
+```text
+institutional catalog
+        ↓
+document identity / viewer_key / book_id
+        ↓
+asset resolution + SHA-256
+        ↓
+temporary OCR
+        ↓
+PAGESTRUCT
+        ↓
+FRAGSEG
+        ↓
+metadata, relations, and hashes
+        ↓
+human validation of the construct
+        ↓
+validated classification
+        ↓
+historical analysis
+```
+
+LTMD preserves relations of reuse, revision, replacement, and aliasing rather than assuming independence among editorial generations. See [`PROVENANCE.md`](PROVENANCE.md) and [`GOVERNANCE.md`](GOVERNANCE.md).
+
+## Reproducibility and quality
+
+The infrastructure uses versioned scripts, GitHub Actions, manifests, SHA-256 hashes, wave-specific documentation, and integrity reports. The public methodological candidate [`v0.1.0-rc.1`](https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1) preserves a reproducible historical cut of the project.
+
+The publication standard is defined in [`SCIENTIFIC_REPOSITORY_STANDARD.md`](SCIENTIFIC_REPOSITORY_STANDARD.md), and FAIR/FAIR4RS status is documented in [`FAIR_ASSESSMENT.md`](FAIR_ASSESSMENT.md).
+
+## Scholarly metadata
+
+LTMD exposes human- and machine-readable metadata through:
+
+- [`CITATION.cff`](CITATION.cff);
+- [`codemeta.json`](codemeta.json), using CodeMeta 3.1;
+- [`VERSION`](VERSION) and [`CHANGELOG.md`](CHANGELOG.md);
+- GitHub releases and reproducibility records;
+- governance, provenance, contribution, and licensing documentation.
+
+A DOI will only be added after a real and verifiable archival deposit exists.
+
+## Rights and licenses
+
+Original LTMD software is distributed under **Apache License 2.0**. Original derived data that the project is legally able to license follow [`DATA_LICENSE.md`](DATA_LICENSE.md).
+
+These licenses do **not** automatically apply to source books, PDFs, JPEGs, covers, illustrations, source text, trademarks, or other third-party materials. The project prioritizes reconstruction, integrity verification, and non-redistribution of restricted source materials.
+
+## Citation
+
+GitHub can generate citation formats from [`CITATION.cff`](CITATION.cff). For the published methodological candidate:
+
+> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, version 0.1.0-rc.1. GitHub release. https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1
+
+## Project lead
+
+**Fernando Sandoval Gutierrez**  
+ORCID: [0000-0002-3168-6725](https://orcid.org/0000-0002-3168-6725)

--- a/README.md
+++ b/README.md
@@ -1,102 +1,91 @@
-# Libro de Texto Mexicano Digital
+<p align="center">
+  <img src="assets/repository-header-es.svg" alt="Libro de Texto Mexicano Digital — infraestructura abierta de investigación" width="100%">
+</p>
 
-Infraestructura abierta de investigación para estudiar longitudinalmente los libros de texto mexicanos mediante historia de la educación, humanidades digitales, análisis computacional y ciencia abierta.
+<p align="center">
+  <strong>Infraestructura abierta para estudiar longitudinalmente los libros de texto mexicanos con historia de la educación, humanidades digitales, análisis computacional y ciencia abierta.</strong><br>
+  <sub>Identidad documental · integridad SHA-256 · OCR · segmentación · dependencia documental · validación humana · reproducibilidad</sub>
+</p>
 
-## Estado actual
+<p align="center">
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1"><img src="https://img.shields.io/badge/release-v0.1.0--rc.1-172033?style=flat-square" alt="Release v0.1.0-rc.1"></a>
+  <a href="CITATION.cff"><img src="https://img.shields.io/badge/citación-CFF%201.2-4b5563?style=flat-square" alt="CFF 1.2"></a>
+  <a href="codemeta.json"><img src="https://img.shields.io/badge/metadatos-CodeMeta%203.1-3b5b92?style=flat-square" alt="CodeMeta 3.1"></a>
+  <a href="FAIR_ASSESSMENT.md"><img src="https://img.shields.io/badge/FAIR%2FFAIR4RS-autoevaluación-2d6a4f?style=flat-square" alt="FAIR FAIR4RS"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/software-Apache--2.0-172033?style=flat-square" alt="Apache 2.0"></a>
+  <a href="DATA_LICENSE.md"><img src="https://img.shields.io/badge/derivados-CC%20BY%204.0-7a263a?style=flat-square" alt="CC BY 4.0"></a>
+</p>
 
-**LTMD adopta como objetivo de su primera gran fase la cobertura integral del universo histórico disponible en el snapshot U1 del Catálogo Histórico de CONALITEG: 542 visores. W1 Ciencias Naturales, W3 Español/Lengua, W4 Ciencias Sociales, W5 Historia y W6 Geografía/Atlas están cerradas técnicamente; W2 Matemáticas conserva cuatro excepciones de routing sin imputación; W7 Formación Cívica y Ética tiene cierre técnico de su cohorte fuente-admitida (25/30), con cinco identidades retenidas explícitamente por limitaciones de fuente.**
+<p align="center">
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/actions"><img src="https://img.shields.io/github/actions/workflow/status/fersandovalgtz/libro-texto-mexicano-digital/release-preflight.yml?branch=main&style=flat-square&label=CI%20%2F%20QA" alt="CI QA"></a>
+  <img src="https://img.shields.io/badge/universo%20U1-542%20visores-455B55?style=flat-square" alt="542 visores U1">
+  <img src="https://img.shields.io/badge/cobertura%20técnica-329%2F542%20·%2060.70%25-455B55?style=flat-square" alt="329 de 542 cobertura técnica">
+  <img src="https://img.shields.io/badge/canónicos-298%2F542%20·%2054.98%25-5b4b8a?style=flat-square" alt="298 objetos canónicos">
+  <img src="https://img.shields.io/badge/validación%20semántica%20humana-0%2F542-b7791f?style=flat-square" alt="0 de 542 validados semánticamente por humanos">
+</p>
 
-Corte documental de esta actualización: **17 de agosto de 2026**.
+<p align="center">
+  <a href="https://orcid.org/0000-0002-3168-6725"><img src="https://img.shields.io/badge/ORCID-0000--0002--3168--6725-A6CE39?style=flat-square&logo=orcid&logoColor=white" alt="ORCID"></a>
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/commits/main"><img src="https://img.shields.io/github/last-commit/fersandovalgtz/libro-texto-mexicano-digital?style=flat-square&label=último%20commit" alt="Último commit"></a>
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/stargazers"><img src="https://img.shields.io/github/stars/fersandovalgtz/libro-texto-mexicano-digital?style=flat-square&logo=github" alt="Stars"></a>
+  <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/issues"><img src="https://img.shields.io/github/issues/fersandovalgtz/libro-texto-mexicano-digital?style=flat-square" alt="Issues"></a>
+</p>
 
-El tablero reproducible `LTMD_U1_COVERAGE_0.8`, recompuesto desde la cola maestra y las actas/cortes técnicos W1–W7, reporta:
+<p align="center">
+  <a href="#qué-es-ltmd"><strong>Qué es</strong></a> ·
+  <a href="#estado-científico"><strong>Estado científico</strong></a> ·
+  <a href="#arquitectura-de-evidencia">Arquitectura</a> ·
+  <a href="#reproducibilidad">Reproducibilidad</a> ·
+  <a href="#derechos-y-licencias">Derechos</a> ·
+  <a href="#citación">Citar</a> ·
+  <a href="FAIR_ASSESSMENT.md">FAIR</a> ·
+  <a href="GOVERNANCE.md">Gobernanza</a> ·
+  <a href="PROVENANCE.md">Procedencia</a> ·
+  <a href="README.en.md">English</a>
+</p>
 
-- universo U1 censado: **542/542** identidades documentales;
-- cobertura técnica efectiva cerrada o resuelta: **329/542 (60.70%)**;
-- objetos canónicos de procesamiento: **298/542 (54.98%)**;
-- cobertura semántica humana validada: **0/542**;
-- W7 Formación Cívica y Ética: **25/30** identidades técnicamente procesadas y **5/30** retenidas sin imputación.
+## Qué es LTMD
 
-`corpus_ready` **no equivale** a `semantic_ready`. Las ocurrencias técnicas de fragmento tampoco equivalen a observaciones históricas independientes: LTMD representa explícitamente reutilización, revisión, reemplazo, aliases y dependencia documental.
+**Libro de Texto Mexicano Digital (LTMD)** es una infraestructura de investigación para construir un corpus histórico-computacional trazable de libros de texto mexicanos y estudiar cambios en currículo, lenguaje pedagógico, actividades escolares, valores, representaciones sociales y recursos visuales.
 
-## Objetivo maestro LTMD-U1: 542/542
+El proyecto no trata un visor de catálogo, un archivo, una generación editorial y un contenido textual como si fueran la misma unidad. Mantiene separadas la **identidad documental**, la **resolución de activos**, el **procesamiento técnico**, los **datos derivados**, la **validación humana** y la **interpretación histórica**.
 
-El universo operativo **LTMD-U1** está fijado en **542 visores únicos**. El tablero vivo [`data/catalog/ltmd_u1_coverage.md`](data/catalog/ltmd_u1_coverage.md) mantiene dos denominadores distintos: identidades documentales técnicamente representadas y objetos canónicos realmente procesados. Esta distinción impide inflar el corpus cuando una identidad se resuelve mediante un alias o una ruta criptográficamente demostrada.
+> [!IMPORTANT]
+> `corpus_ready` **no equivale** a `semantic_ready`. Una ola técnicamente cerrada puede ser reproducible y completa dentro de su alcance sin constituir todavía evidencia semántica validada por personas expertas.
 
-| Ola | Dominio operacional | Plan | Cobertura efectiva | Canónicos | Estado |
-|---|---|---:|---:|---:|---|
-| W1 | `ciencias_naturales` | 40 | 40 | 36 | cerrada |
-| W2 | `matematicas` | 64 | 60 | 57 | parcial; 4 excepciones preservadas |
-| W3 | `espanol_lengua` | 130 | 130 | 114 | cerrada |
-| W4 | `ciencias_sociales` | 14 | 14 | 14 | cerrada |
-| W5 | `historia` | 18 | 18 | 15 | cerrada |
-| W6 | `geografia_atlas` | 42 | 42 | 37 | cerrada |
-| W7 | `civica_etica` | 30 | 25 | 25 | parcial; 5 retenciones de fuente preservadas |
-| W8 | `artes` | 20 | 0 | 0 | en cola |
-| W9 | `educacion_fisica` | 4 | 0 | 0 | en cola |
-| W10 | `integrados_multiarea` | 69 | 0 | 0 | en cola |
-| W11 | `otros_no_clasificados` | 111 | 0 | 0 | en cola |
+## Estado científico
 
-La meta U1 es alcanzar **542/542 visores técnicamente representados**, mediante procesamiento directo o relaciones de fuente demostradas, conservando siempre identidad documental y excepciones. Este objetivo no autoriza a extrapolar clasificadores semánticos de un dominio a otro sin validación humana propia.
+Corte documental de referencia: **17 de agosto de 2026**.
 
-El programa completo está en **[`docs/LTMD_U1_MASTER_PLAN_0_1.md`](docs/LTMD_U1_MASTER_PLAN_0_1.md)**, el tablero vivo en **[`data/catalog/ltmd_u1_coverage.md`](data/catalog/ltmd_u1_coverage.md)** y la cola integral en `data/catalog/ltmd_u1_wave_queue.csv`.
+| Indicador | Estado |
+|---|---:|
+| Universo histórico operativo LTMD-U1 | **542 / 542 visores censados** |
+| Cobertura técnica efectiva cerrada o resuelta | **329 / 542 (60.70%)** |
+| Objetos canónicos de procesamiento | **298 / 542 (54.98%)** |
+| Validación semántica humana | **0 / 542** |
+| Release metodológica publicada | **v0.1.0-rc.1** |
+| DOI de LTMD | **pendiente; no se anticipa** |
 
-### U1-W1 — Ciencias Naturales: CERRADA
+### Cobertura U1
 
-El dominio operativo `ciencias_naturales` contiene **40 visores** y queda en **40/40 de cobertura efectiva**. Treinta y seis están procesados directamente hasta FRAGSEG y cuatro son aliases 2018→2019 demostrados byte por byte. El cierre detallado está en [`docs/LTMD_U1_W1_COMPLETION_2026-08-15.md`](docs/LTMD_U1_W1_COMPLETION_2026-08-15.md).
+| Ola | Dominio | Estado |
+|---|---|---|
+| W1 | Ciencias Naturales | cerrada técnicamente |
+| W2 | Matemáticas | parcial; 4 excepciones de routing preservadas |
+| W3 | Español / Lengua | cerrada técnicamente |
+| W4 | Ciencias Sociales | cerrada técnicamente |
+| W5 | Historia | cerrada técnicamente |
+| W6 | Geografía / Atlas | cerrada técnicamente |
+| W7 | Formación Cívica y Ética | cohorte fuente-admitida cerrada; 5 identidades retenidas |
+| W8–W11 | Artes, Educación Física, Integrados y Otros | programa U1 en evolución |
 
-W1 incorporó además dos materiales de *Estudio de la Naturaleza* de 1966 y resolvió criptográficamente las tres posiciones internas no servidas de los dos libros 2008 sin borrar la anomalía original ni falsear procedencia.
-
-### U1-W2 — Matemáticas: PARCIAL CON EXCEPCIONES PRESERVADAS
-
-W2 está congelada en **64 visores**. Tiene **60/64 identidades con activos efectivamente resueltos** y **57 objetos canónicos computados**. Cuatro visores DMA 2018 conservan excepciones de routing no resueltas; no se imputan ni se sustituyen por similitud de título, año o cardinalidad. La capa FRAGSEG directamente computada contiene **135,727 fragmentos técnicos**. El cierre vigente está en [`docs/LTMD_U1_W2_COMPLETION.md`](docs/LTMD_U1_W2_COMPLETION.md).
-
-### U1-W3 — Español/Lengua: CERRADA
-
-W3 cubre **130/130 identidades** mediante **114 objetos canónicos** y 16 aliases/provenance relations demostradas. Se verificaron **20,765 páginas**, PAGESTRUCT habilitó **17,337 páginas** y FRAGSEG produjo **222,490 fragmentos técnicos**. El análisis de reutilización exacta conserva la dependencia documental en lugar de asumir independencia entre generaciones. Véase [`docs/LTMD_U1_W3_COMPLETION.md`](docs/LTMD_U1_W3_COMPLETION.md).
-
-### U1-W4 — Ciencias Sociales: CERRADA
-
-W4 cubre **14/14 identidades y objetos canónicos**. Se procesaron **2,414 páginas**, PAGESTRUCT habilitó **2,018 páginas** y FRAGSEG produjo **21,380 fragmentos técnicos**. Véase [`docs/LTMD_U1_W4_COMPLETION.md`](docs/LTMD_U1_W4_COMPLETION.md).
-
-### U1-W5 — Historia: CERRADA
-
-W5 cubre **18/18 identidades históricas** mediante **15 objetos canónicos**. Tres entradas 2018 se resuelven operacionalmente a rutas 2019 después de revalidar **523/523 activos** por SHA-256 y tamaño, sin fusionar las identidades documentales de catálogo. OCR verificó **2,653/2,653 páginas**, PAGESTRUCT habilitó **2,243** y FRAGSEG produjo **32,645 fragmentos técnicos**. El análisis de reutilización exacta obtuvo **25,492 unidades textuales exactas únicas** y **105 pares de visores** con al menos una unidad compartida. Véase [`docs/LTMD_U1_W5_COMPLETION.md`](docs/LTMD_U1_W5_COMPLETION.md).
-
-### U1-W6 — Geografía/Atlas: CERRADA
-
-W6 está congelada en **42 identidades** y queda en **42/42 de cobertura técnica efectiva**, mediante **37 objetos canónicos**. La ola conserva sus relaciones de fuente y excepciones documentales de manera explícita; su cierre eleva la cobertura U1 sin modificar el estado `WAITING_HUMAN_REFERENCE` ni convertir procesamiento técnico en validación semántica.
-
-### U1-W7 — Formación Cívica y Ética: COHORTE ADMISIBLE CERRADA; 5 RETENCIONES
-
-W7 preserva **30/30 identidades históricas**. La cohorte con fuente admisible comprende **25/30 identidades**, todas procesadas técnicamente como **25 objetos canónicos**. Sobre **3,261 páginas fuente** se verificaron **3,261/3,261 SHA-256**; OCR detectó texto en **3,255 (99.82%)** y FRAGSEG produjo **33,451 fragmentos técnicos**. El cierre detallado está en [`docs/LTMD_U1_W7_COMPLETION.md`](docs/LTMD_U1_W7_COMPLETION.md).
-
-Este cierre **no equivale a 30/30 histórico**. Permanecen retenidas `H2014P5FCA` —224/225 JPEG institucionales servidos, con hueco en la página lógica 104— y `H2018P3FCA`–`H2018P6FCA`, cuyos visores/configuración institucionales están presentes pero cuyo subárbol oficial de activos observado no se sirve. No se crean aliases por semejanza, cardinalidad o proximidad temporal.
-
-La investigación de fuente continúa bajo umbral estricto. El corte [`docs/LTMD_U1_W7_WITHHELD_SOURCE_RESEARCH_0_4.md`](docs/LTMD_U1_W7_WITHHELD_SOURCE_RESEARCH_0_4.md) registra reproducciones externas contemporáneas del ciclo 2018–2019 como **candidatas de investigación**, sin incorporarlas como fuente canónica ni modificar `ocr_source_admitted`.
-
-## Release publicada
-
-La primera release candidate metodológica pública es **[`v0.1.0-rc.1`](https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1)**.
-
-Antes de crear el tag, el preflight reproducible demostró `rc_technical_ready=true`, `publish_ready=true`, cero failures/blockers, `LTMD_INTEGRITY_0.6` 166/166 y recomputación SHA-256 completa en PASS. El tag conserva ese corte histórico; el programa U1 posterior evoluciona en `main` y no modifica retroactivamente la release.
-
-**El DOI de Zenodo está pendiente hasta que exista un registro real del depósito.** LTMD no anticipa ni inventa identificadores persistentes.
-
-Documentos del paquete de release:
-
-- [`VERSION`](VERSION)
-- [`CHANGELOG.md`](CHANGELOG.md)
-- [`LICENSE`](LICENSE) — software propio, Apache License 2.0
-- [`DATA_LICENSE.md`](DATA_LICENSE.md) — derivados originales licenciables, CC BY 4.0
-- [`docs/RELEASE_NOTES_v0.1.0-rc.1.md`](docs/RELEASE_NOTES_v0.1.0-rc.1.md)
-- [`docs/REPRODUCIBILITY_REPORT_v0.1.0-rc.1.md`](docs/REPRODUCIBILITY_REPORT_v0.1.0-rc.1.md)
-- [`data/derived/release_candidate_preflight.json`](data/derived/release_candidate_preflight.json)
+El tablero reproducible se mantiene en [`data/catalog/ltmd_u1_coverage.md`](data/catalog/ltmd_u1_coverage.md) y el programa general en [`docs/LTMD_U1_MASTER_PLAN_0_1.md`](docs/LTMD_U1_MASTER_PLAN_0_1.md).
 
 ## Pregunta general
 
-¿Cómo se transforman, a través del tiempo, el currículo, el lenguaje pedagógico, las actividades escolares, los valores, las representaciones sociales y los recursos visuales presentes en los libros de texto mexicanos?
+> ¿Cómo se transforman, a través del tiempo, el currículo, el lenguaje pedagógico, las actividades escolares, los valores, las representaciones sociales y los recursos visuales presentes en los libros de texto mexicanos?
 
-## Arquitectura científica
+## Arquitectura de evidencia
 
 ```text
 catálogo institucional
@@ -111,77 +100,72 @@ PAGESTRUCT
         ↓
 FRAGSEG
         ↓
-metadatos y hashes
+metadatos, relaciones y hashes
         ↓
-validación humana de constructo
+validación humana del constructo
         ↓
 clasificación validada
         ↓
 análisis histórico
 ```
 
-Para dependencia documental se mantienen vistas reversibles: **object view**, **unique-content view** y **revision view**.
+LTMD conserva relaciones de reutilización, revisión, reemplazo y alias en lugar de presumir independencia entre generaciones editoriales. Las vistas de objeto, contenido único y revisión permiten estudiar dependencia documental sin borrar la identidad histórica de los visores.
 
-## Ciencias Naturales — primer dominio U1 cerrado
+Consulte [`PROVENANCE.md`](PROVENANCE.md) y [`GOVERNANCE.md`](GOVERNANCE.md).
 
-La familia estricta contiene 37 visores; la taxonomía operativa U1 incorpora además materiales afines de *Estudio de la Naturaleza*, para un dominio de **40 visores**.
+## Principios de integridad científica
 
-El cierre W1 dejó:
+1. **La fuente no se corrige silenciosamente.** Fallos, huecos y excepciones permanecen documentados.
+2. **La similitud no crea identidad documental.** Los aliases requieren evidencia verificable.
+3. **La automatización no fabrica referencia humana.** Las etiquetas humanas solo existen cuando fueron producidas mediante el protocolo correspondiente.
+4. **Los resultados negativos cuentan.** Incertidumbre, baja precisión o ausencia de evidencia se preservan como resultados metodológicos.
+5. **Una release es un corte histórico.** El avance posterior de `main` no se atribuye retroactivamente a un tag publicado.
 
-- 40/40 activos completamente resueltos;
-- 36/40 procesados directamente hasta FRAGSEG;
-- 4/40 cubiertos mediante aliases 2018→2019 byte-idénticos;
-- 0/40 restantes efectivos.
+## Reproducibilidad
 
-Los cuatro aliases 2018→2019 se fundamentan en **652/652 pares byte-idénticos**. Los dos libros 2008 originalmente presentaban tres posiciones internas no servidas; las tres fueron recuperadas unívocamente mediante alineamiento criptográfico con seis anchors vecinos y cero discrepancias, preservando en el manifiesto reconciliado tanto la URL original fallida como la fuente efectiva.
+La infraestructura utiliza scripts versionados, GitHub Actions, manifiestos, hashes SHA-256, documentación por ola y reportes de integridad. La candidata metodológica pública [`v0.1.0-rc.1`](https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1) conserva un corte reproducible anterior a la expansión U1 posterior.
 
-## Piloto CN5 y SEMB
+Para reconstrucción de releases se documentan dependencias en [`requirements-release.txt`](requirements-release.txt). Los protocolos, manuales, reportes y planes científicos se encuentran en [`docs/`](docs/).
 
-El piloto utiliza _Ciencias Naturales_ de quinto grado en generaciones 1972, 1988, 1993 y 2014. Es la única capa que llega actualmente a Rule A, SEMB 0.2 y comparación semántica exploratoria.
+La política general de calidad está en [`SCIENTIFIC_REPOSITORY_STANDARD.md`](SCIENTIFIC_REPOSITORY_STANDARD.md) y la autoevaluación FAIR/FAIR4RS en [`FAIR_ASSESSMENT.md`](FAIR_ASSESSMENT.md).
 
-SEMB 0.2 produjo **99.49% de incertidumbre global** y se conserva como resultado metodológico negativo/diagnóstico. No se bajaron umbrales retrospectivamente para maximizar diferencias históricas.
+## Publicación y metadatos
 
-## SEMB 0.3: referencia humana preregistrada
+LTMD expone metadatos para humanos y máquinas mediante:
 
-La infraestructura prehumana contiene **480 casos**: 320 `development`, 160 `locked_validation` y 120 reservados para doble codificación de fiabilidad. Los criterios de aceptación, arquitecturas candidatas y stage gates quedaron congelados antes de observar anotaciones humanas.
+- [`CITATION.cff`](CITATION.cff), compatible con la función **Cite this repository** de GitHub;
+- [`codemeta.json`](codemeta.json), en CodeMeta 3.1;
+- [`VERSION`](VERSION) y [`CHANGELOG.md`](CHANGELOG.md);
+- releases de GitHub con notas y reportes de reproducibilidad;
+- documentación de procedencia, gobernanza y licencias.
 
-Etapa actual: **`WAITING_HUMAN_REFERENCE`**.
+**No se declara DOI de LTMD hasta que exista un depósito real y verificable.** Esta decisión evita crear identificadores ficticios o inconsistentes entre GitHub y un archivo de preservación.
 
-La expansión U1 puede continuar técnicamente, pero no se usa para fabricar etiquetas humanas ni para transformar tendencias exploratorias de SEMB 0.2 en narrativa histórica confirmada. Matemáticas, Español, Historia y otros dominios requerirán validación semántica específica cuando sus preguntas analíticas lo exijan.
+## Derechos y licencias
 
-## Dependencia documental
+El software original de LTMD se distribuye bajo **Apache License 2.0**. Los datos derivados originales sobre los que exista capacidad jurídica para licenciar se ofrecen bajo las condiciones descritas en [`DATA_LICENSE.md`](DATA_LICENSE.md).
 
-LTMD no supone independencia por `catalog_generation`. En CN4 1972↔1988, 188/214 páginas alineables son byte-idénticas en la misma posición. Las relaciones documentales, reutilizaciones, reemplazos y aliases forman parte del estimando y de la trazabilidad.
+Estas licencias **no** se extienden automáticamente a libros, PDF, JPEG, portadas, ilustraciones, texto fuente, marcas u otros materiales de SEP/CONALITEG o terceros. La estrategia de procesamiento prioriza reconstrucción temporal, verificación de integridad y no redistribución de fuentes cuando los derechos no lo permiten.
 
-## Catálogo maestro reproducible
+## Contribución y gobernanza
 
-El snapshot institucional indexado contiene **542 claves de visor, 542/542 visores alcanzables, 542/542 títulos recuperados y 191 familias de título nuclear**. La identidad documental se fundamenta en `book_id` + `viewer_key`; `catalog_generation` no se usa automáticamente como `edition_year`.
-
-## Derechos, licencias y reutilización
-
-El software original de LTMD se distribuye bajo **Apache License 2.0**. Los datos derivados originales sobre los cuales el licenciante posea o controle derechos necesarios se ofrecen bajo **CC BY 4.0**.
-
-Estas licencias no se aplican a libros, PDF, JPEG, páginas, portadas, ilustraciones, texto fuente, OCR sustitutivo, marcas ni otros materiales de CONALITEG/SEP o terceros. Las fuentes necesarias se reconstruyen temporalmente, se verifican contra SHA-256 y se eliminan después del procesamiento.
-
-## Reproducibilidad e integridad científica
-
-El corte publicado `v0.1.0-rc.1` utiliza `LTMD_INTEGRITY_0.6`. Los artefactos U1 posteriores pertenecen a la evolución de `main` y deberán integrarse en un corte de integridad posterior; nunca se atribuyen retroactivamente al tag publicado.
-
-## Publicación científica
-
-LTMD separa dos productos:
-
-1. **artículo de método/recurso digital** — [`docs/METHODS_ARTICLE_DRAFT_0_2.md`](docs/METHODS_ARTICLE_DRAFT_0_2.md);
-2. **artículo histórico-educativo** — bloqueado hasta superar SEMB 0.3 y reconstruir la inferencia bajo unidades documentales defendibles.
-
-## Documentación central
-
-La entrada recomendada es el **[Índice maestro de método](docs/METHOD_INDEX.md)**. Para la expansión integral, consulte el **[Plan Maestro LTMD-U1](docs/LTMD_U1_MASTER_PLAN_0_1.md)**, el **[tablero vivo](data/catalog/ltmd_u1_coverage.md)** y las actas/cortes técnicos W1–W7.
-
-## Regla epistemológica
-
-LTMD privilegia una regla sencilla: **una cifra reproducible no es automáticamente una afirmación válida**. Cada salto —fuente, identidad documental, OCR, estructura, fragmentación, clasificación e inferencia— debe conservar evidencia suficiente para ser auditado independientemente.
+Las contribuciones son bienvenidas cuando preservan procedencia, reproducibilidad y separación entre estados técnicos y semánticos. Véanse [`CONTRIBUTING.md`](CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), [`SECURITY.md`](SECURITY.md) y [`GOVERNANCE.md`](GOVERNANCE.md).
 
 ## Citación
 
-Mientras no exista un DOI versionado real, use la metadata de [`CITATION.cff`](CITATION.cff), el tag `v0.1.0-rc.1` y la GitHub Release correspondiente. Cuando Zenodo archive la release, deberá utilizarse el DOI versionado real de ese corte científico.
+GitHub puede generar citas desde [`CITATION.cff`](CITATION.cff). Para la candidata metodológica publicada:
+
+> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, versión 0.1.0-rc.1. GitHub release. https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.1.0-rc.1
+
+Cuando exista un depósito real en Zenodo u otro archivo con identificador persistente, el DOI deberá incorporarse de forma coherente a `CITATION.cff`, `codemeta.json`, la release y esta sección.
+
+## Responsable
+
+**Fernando Sandoval Gutierrez**  
+ORCID: [0000-0002-3168-6725](https://orcid.org/0000-0002-3168-6725)
+
+---
+
+<p align="center">
+  <strong>LTMD documenta lo que sabe, lo que infiere y lo que todavía no puede afirmar.</strong>
+</p>

--- a/SCIENTIFIC_REPOSITORY_STANDARD.md
+++ b/SCIENTIFIC_REPOSITORY_STANDARD.md
@@ -1,0 +1,52 @@
+# Estándar científico del repositorio
+
+Este documento fija el estándar mínimo de publicación para **Libro de Texto Mexicano Digital (LTMD)**. Se inspira en prácticas de ciencia abierta, FAIR/FAIR4RS y metadatos legibles por máquina, pero se adapta al problema específico de estudiar documentos educativos históricos con materiales fuente de terceros.
+
+## 1. Metadatos científicos
+
+Una release científica debe mantener consistentes:
+
+- `CITATION.cff`;
+- `codemeta.json`;
+- `VERSION`;
+- licencia de software y estrategia de licencia de datos;
+- fecha, tag y notas de release;
+- identificador persistente solo cuando exista realmente.
+
+## 2. Reproducibilidad
+
+La release debe declarar dependencias, pipeline, entradas permitidas, artefactos generados, hashes o manifiestos de integridad y comandos suficientes para reproducir los resultados dentro del alcance publicado.
+
+## 3. Procedencia
+
+Toda transformación debe conservar una ruta verificable hacia la identidad documental y la fuente. Los aliases, sustituciones de ruta, páginas faltantes, fallos de servidor y excepciones no pueden resolverse mediante imputación silenciosa.
+
+## 4. Separación epistemológica
+
+LTMD distingue fuente, procesamiento técnico, derivado computacional, validación humana e interpretación histórica. `corpus_ready` no implica `semantic_ready`; un pipeline completo no convierte automáticamente una señal computacional en evidencia histórica confirmada.
+
+## 5. Calidad de datos y software
+
+Antes de una release deben ejecutarse las validaciones automatizadas aplicables y documentarse failures, blockers y excepciones. Los cambios en definiciones, contratos, denominadores o reglas de análisis requieren documentación explícita.
+
+## 6. FAIR / FAIR4RS
+
+Cada release debe maximizar descubribilidad, acceso, interoperabilidad y reutilización mediante identificadores, metadatos, formatos documentados, licencias, procedencia y versionado. `FAIR_ASSESSMENT.md` debe actualizarse cuando cambien estas condiciones.
+
+## 7. Comunicación científica
+
+El README debe permitir comprender en pocos minutos: qué investiga LTMD, qué estado científico tiene, qué está validado y qué no, cómo reproducir el trabajo, cómo citarlo y dónde encontrar la documentación técnica. La complejidad detallada debe enlazarse a `docs/` en lugar de convertir la portada del repositorio en un cuaderno de laboratorio completo.
+
+## 8. Releases
+
+Una release pública debe incluir como mínimo:
+
+- tag y versión coherentes;
+- metadatos científicos actualizados;
+- notas de release;
+- reporte de reproducibilidad o integridad;
+- documentación de limitaciones y cambios;
+- artefactos o rutas de reconstrucción suficientes;
+- DOI solo después de un depósito real y verificable.
+
+Este estándar es normativo para la publicación del repositorio, no una afirmación de certificación externa.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Política de seguridad
+
+## Versiones
+
+La rama `main` y la release pública más reciente reciben atención de seguridad. Los tags históricos se preservan como registros inmutables y no se reescriben.
+
+## Reporte responsable
+
+No publique inicialmente secretos, credenciales, datos personales, rutas privadas, información que facilite explotación o material de terceros restringido. Para vulnerabilidades técnicas, utilice los mecanismos privados de reporte de seguridad de GitHub cuando estén habilitados o contacte al responsable del repositorio por un canal institucional verificable.
+
+## Alcance
+
+Son relevantes, entre otros:
+
+- exposición accidental de credenciales o tokens;
+- workflows con permisos excesivos;
+- dependencias vulnerables con impacto reproducible;
+- escritura o publicación no intencional de materiales fuente restringidos;
+- fallos que comprometan integridad, hashes, manifiestos o trazabilidad de resultados.
+
+Las discrepancias científicas, problemas de datos y propuestas metodológicas ordinarias deben gestionarse mediante issues o pull requests, no como vulnerabilidades de seguridad.
+
+## Principio de mínimo privilegio
+
+Los workflows, tokens y acciones automatizadas deben operar con el menor conjunto de permisos necesario. Los secretos no deben almacenarse en el repositorio ni incorporarse a artefactos de release.

--- a/assets/repository-header-es.svg
+++ b/assets/repository-header-es.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="300" viewBox="0 0 1200 300" role="img" aria-labelledby="title desc">
+  <title id="title">Libro de Texto Mexicano Digital</title>
+  <desc id="desc">Cabecera visual para la infraestructura científica LTMD</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#101827"/>
+      <stop offset="0.55" stop-color="#172033"/>
+      <stop offset="1" stop-color="#5f2033"/>
+    </linearGradient>
+    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
+      <path d="M36 0H0V36" fill="none" stroke="#ffffff" stroke-opacity="0.055" stroke-width="1"/>
+    </pattern>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#d4b56a"/>
+      <stop offset="1" stop-color="#f0dfae"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="300" rx="24" fill="url(#bg)"/>
+  <rect width="1200" height="300" rx="24" fill="url(#grid)"/>
+  <circle cx="1055" cy="68" r="155" fill="#ffffff" opacity="0.025"/>
+  <circle cx="1100" cy="255" r="190" fill="#000000" opacity="0.09"/>
+
+  <g transform="translate(72 54)">
+    <rect x="0" y="0" width="92" height="120" rx="9" fill="none" stroke="url(#accent)" stroke-width="3"/>
+    <path d="M18 25h54M18 45h54M18 65h40M18 91h22" stroke="#f0dfae" stroke-opacity="0.8" stroke-width="4" stroke-linecap="round"/>
+    <path d="M105 12v99M105 111c28-22 53-22 81 0V12c-28-22-53-22-81 0Zm0 0c-28-22-53-22-81 0" transform="translate(16 4)" fill="none" stroke="#d4b56a" stroke-width="2.5" opacity="0.72"/>
+  </g>
+
+  <text x="286" y="102" fill="#ffffff" font-family="Arial, Helvetica, sans-serif" font-size="48" font-weight="700" letter-spacing="0.2">Libro de Texto Mexicano Digital</text>
+  <text x="289" y="140" fill="#f0dfae" font-family="Arial, Helvetica, sans-serif" font-size="21" font-weight="600" letter-spacing="1.2">LTMD · INFRAESTRUCTURA ABIERTA DE INVESTIGACIÓN</text>
+  <text x="289" y="181" fill="#dce3ee" font-family="Arial, Helvetica, sans-serif" font-size="19">Historia de la educación · humanidades digitales · análisis computacional · ciencia abierta</text>
+
+  <g transform="translate(289 215)" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="600">
+    <rect width="145" height="34" rx="17" fill="#ffffff" opacity="0.09"/><text x="72.5" y="22" text-anchor="middle" fill="#ffffff">542 visores U1</text>
+    <rect x="158" width="188" height="34" rx="17" fill="#ffffff" opacity="0.09"/><text x="252" y="22" text-anchor="middle" fill="#ffffff">procedencia verificable</text>
+    <rect x="359" width="175" height="34" rx="17" fill="#ffffff" opacity="0.09"/><text x="446.5" y="22" text-anchor="middle" fill="#ffffff">reproducibilidad</text>
+    <rect x="547" width="212" height="34" rx="17" fill="#ffffff" opacity="0.09"/><text x="653" y="22" text-anchor="middle" fill="#ffffff">validación diferenciada</text>
+  </g>
+</svg>

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,0 +1,30 @@
+{
+  "@context": "https://w3id.org/codemeta/3.1",
+  "@type": "SoftwareSourceCode",
+  "name": "Libro de Texto Mexicano Digital",
+  "alternateName": "LTMD",
+  "description": "Infraestructura abierta de investigación para el estudio longitudinal de los libros de texto mexicanos mediante historia de la educación, humanidades digitales, análisis computacional y ciencia abierta.",
+  "codeRepository": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital",
+  "issueTracker": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/issues",
+  "version": "0.1.0-rc.1",
+  "datePublished": "2026-08-15",
+  "developmentStatus": "active",
+  "programmingLanguage": ["Python"],
+  "license": "https://spdx.org/licenses/Apache-2.0",
+  "author": {
+    "@type": "Person",
+    "givenName": "Fernando",
+    "familyName": "Sandoval Gutierrez",
+    "@id": "https://orcid.org/0000-0002-3168-6725"
+  },
+  "keywords": [
+    "libros de texto",
+    "historia de la educación",
+    "humanidades digitales",
+    "análisis computacional",
+    "ciencia abierta",
+    "México"
+  ],
+  "continuousIntegration": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/actions",
+  "readme": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/blob/main/README.md"
+}


### PR DESCRIPTION
Esta propuesta refuerza la superficie pública y científica de LTMD sin modificar corpus ni resultados. Añade CodeMeta 3.1, gobernanza, procedencia, autoevaluación FAIR/FAIR4RS, contribución, seguridad, código de conducta, estándar científico, README bilingüe, cabecera visual y un preflight de publicación que verifica archivos obligatorios y coherencia de versión entre VERSION, CITATION.cff y codemeta.json. Se mantiene explícito que corpus_ready no equivale a semantic_ready y no se declara ningún DOI inexistente.