### PR TITLE
FTRL: bind run manifests to exact Git and CI execution

### DIFF
--- a/.github/workflows/validate-ftrl-w5-real-pilot.yml
+++ b/.github/workflows/validate-ftrl-w5-real-pilot.yml
@@ -10,6 +10,7 @@ on:
       - 'scripts/validate_ocr_corpus.py'
       - 'scripts/summarize_ftrl_run.py'
       - 'scripts/run_ftrl_w5_pilot.py'
+      - 'schemas/ltmd_ftrl_run_manifest.schema.json'
       - 'data/catalog/ltmd_u1_w5_history_asset_manifest.csv'
       - 'data/catalog/ltmd_u1_w5_history_processing_inventory.csv'
   workflow_dispatch:
@@ -59,6 +60,15 @@ jobs:
           assert row['database']['sqlite_integrity'] == 'ok'
           assert row['corpus']['waves'] == ['W5']
           assert row['corpus']['source_byte_size_missing_pages'] == 0
+          vcs = row['execution']['vcs']
+          ci = row['execution']['ci']
+          assert vcs['system'] == 'git'
+          assert len(vcs['commit']) == 40
+          assert vcs['dirty_tracked_worktree'] is False
+          assert ci['provider'] == 'github-actions'
+          assert ci['repository'] == 'fersandovalgtz/libro-texto-mexicano-digital'
+          assert ci['run_id']
+          assert ci['sha'] == vcs['commit']
           print(json.dumps({
               'status': row['status'],
               'page_records': row['corpus']['page_records'],
@@ -69,6 +79,9 @@ jobs:
               'ocr_confidence': row['corpus']['ocr_confidence'],
               'historical_identities': row['database']['historical_identities'],
               'sqlite_integrity': row['database']['sqlite_integrity'],
+              'git_commit': vcs['commit'],
+              'git_ref': vcs['ref'],
+              'ci_run_id': ci['run_id'],
           }, ensure_ascii=False, sort_keys=True))
           PY
 

--- a/.github/workflows/validate-full-text-research-layer.yml
+++ b/.github/workflows/validate-full-text-research-layer.yml
@@ -61,6 +61,12 @@ jobs:
             scripts/run_ftrl_query_protocol.py \
             scripts/run_ftrl_w5_pilot.py
           python -m json.tool schemas/ltmd_ftrl_run_manifest.schema.json >/dev/null
+          python - <<'PY'
+          import json
+          schema = json.load(open('schemas/ltmd_ftrl_run_manifest.schema.json', encoding='utf-8'))
+          assert 'execution' in schema['properties']
+          assert 'execution' not in schema['required'], '0.1 historical manifests must remain valid'
+          PY
       - name: Build synthetic page corpus
         run: |
           mkdir -p local
@@ -143,6 +149,15 @@ jobs:
           assert row["corpus"]["page_records"] == 2
           assert row["database"]["page_rows"] == 2
           assert row["database"]["fts_rows"] == 2
+          vcs = row["execution"]["vcs"]
+          ci = row["execution"]["ci"]
+          assert vcs["system"] == "git"
+          assert len(vcs["commit"]) == 40
+          assert vcs["dirty_tracked_worktree"] is False
+          assert ci["provider"] == "github-actions"
+          assert ci["run_id"]
+          assert ci["repository"] == "fersandovalgtz/libro-texto-mexicano-digital"
+          assert ci["sha"] == vcs["commit"]
           PY
       - name: Execute preregistered query protocol on synthetic index
         run: |

--- a/docs/LTMD_FTRL_RUN_PROVENANCE.md
+++ b/docs/LTMD_FTRL_RUN_PROVENANCE.md
@@ -5,7 +5,7 @@ Estado: **especificación operativa para ejecuciones locales FTRL**.
 
 ## Propósito
 
-Cada ejecución de la Full-Text Research Layer debe producir, además del corpus OCR local y del índice SQLite FTS5, un **manifiesto de corrida sin texto fuente**. El manifiesto registra qué artefactos y versiones intervinieron, qué cardinalidades resultaron, qué entorno de software se observó y qué hashes identifican las entradas y salidas locales.
+Cada ejecución de la Full-Text Research Layer debe producir, además del corpus OCR local y del índice SQLite FTS5, un **manifiesto de corrida sin texto fuente**. El manifiesto registra qué artefactos y versiones intervinieron, qué cardinalidades resultaron, qué entorno de software se observó, qué código se ejecutó y qué hashes identifican las entradas y salidas locales.
 
 El objetivo es que una afirmación del tipo “la búsqueda se ejecutó sobre W5” pueda traducirse a una cadena auditable: manifiesto de activos → inventario de procesamiento → corpus OCR → índice FTS5 → manifiesto de corrida → protocolo de consulta → verificación humana de candidatos.
 
@@ -51,7 +51,22 @@ El manifiesto registra:
 - páginas con `search_text` vacío;
 - integridad SQLite, cardinalidad FTS e identidades históricas representadas.
 
+Las ejecuciones producidas con el código actual añaden además `execution`, un bloque de procedencia computacional con:
+
+- commit Git exacto del árbol ejecutado;
+- ref conocida —por ejemplo, `refs/pull/<n>/merge` en GitHub Actions— cuando existe;
+- señal de cambios rastreados sin confirmar en el worktree;
+- contexto de GitHub Actions cuando la corrida ocurre en CI: repositorio, workflow, `run_id`, intento, evento, ref y SHA.
+
+No se registra la URL remota de Git ni variables de entorno arbitrarias, para evitar capturar credenciales o rutas privadas. El contexto CI se limita a identificadores públicos y técnicos explícitamente permitidos.
+
 Los paths se serializan de forma portable: se prefieren rutas relativas al repositorio y, si una entrada se encuentra fuera de él, se conserva sólo el nombre de archivo para evitar filtrar rutas personales del sistema.
+
+## Compatibilidad dentro de `LTMD_FTRL_RUN_0.1`
+
+El bloque `execution` es una extensión **aditiva y opcional** del contrato 0.1. Los manifiestos 0.1 producidos antes de incorporar esta captura —incluida la evidencia preservada del primer piloto real de 10 páginas— siguen siendo válidos frente al esquema actual. Las nuevas corridas sí deben emitir `execution`, salvo que no exista un repositorio Git detectable; en ese caso `vcs` puede ser `null`. Fuera de GitHub Actions, `ci` es `null`.
+
+Un cambio que hiciera obligatoria una propiedad ausente de los manifiestos 0.1 históricos o alterara el significado de campos existentes requeriría una nueva versión de esquema.
 
 ## Validaciones duras
 
@@ -78,6 +93,8 @@ La versión inicial es `LTMD_FTRL_RUN_0.1`. Cambios incompatibles requieren una 
 
 Este manifiesto operacionaliza el principio de que los datos y metadatos reutilizables deben conservar procedencia detallada y, cuando sea posible, legible por máquina. No pretende sustituir un modelo formal completo de procedencia; sirve como capa mínima y verificable que puede mapearse posteriormente a PROV-O o empaquetarse dentro de un RO-Crate.
 
+La captura de commit/ref y del identificador de corrida CI hace posible enlazar un resultado derivado con el árbol de código realmente ejecutado, no sólo con la versión declarada del pipeline. Esta distinción es importante en PRs, donde GitHub Actions puede probar un merge ref distinto del SHA de la rama de trabajo.
+
 ## Límites epistemológicos
 
 El manifiesto no convierte:
@@ -87,4 +104,4 @@ El manifiesto no convierte:
 - ausencia de hits en ausencia demostrada;
 - alias técnico en equivalencia bibliográfica o semántica.
 
-Su función es hacer reproducible **qué se procesó, con qué versión y con qué integridad**, manteniendo separada la interpretación.
+Su función es hacer reproducible **qué se procesó, con qué código, en qué entorno y con qué integridad**, manteniendo separada la interpretación.

--- a/schemas/ltmd_ftrl_run_manifest.schema.json
+++ b/schemas/ltmd_ftrl_run_manifest.schema.json
@@ -32,6 +32,50 @@
       },
       "additionalProperties": false
     },
+    "execution": {
+      "description": "Optional additive execution context introduced within 0.1; omitted by historical 0.1 manifests produced before VCS/CI capture was added.",
+      "type": "object",
+      "required": ["vcs", "ci"],
+      "properties": {
+        "vcs": {
+          "oneOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "required": ["system", "commit", "ref", "dirty_tracked_worktree"],
+              "properties": {
+                "system": {"const": "git"},
+                "commit": {"type": "string", "pattern": "^[0-9a-fA-F]{40}$"},
+                "ref": {"type": ["string", "null"]},
+                "dirty_tracked_worktree": {"type": ["boolean", "null"]}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "ci": {
+          "oneOf": [
+            {"type": "null"},
+            {
+              "type": "object",
+              "required": ["provider"],
+              "properties": {
+                "provider": {"const": "github-actions"},
+                "repository": {"type": "string", "minLength": 1},
+                "workflow": {"type": "string", "minLength": 1},
+                "run_id": {"type": "string", "minLength": 1},
+                "run_attempt": {"type": "string", "minLength": 1},
+                "event_name": {"type": "string", "minLength": 1},
+                "ref": {"type": "string", "minLength": 1},
+                "sha": {"type": "string", "pattern": "^[0-9a-fA-F]{40}$"}
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "files": {
       "type": "object",
       "required": ["ocr_jsonl", "sqlite_index"],

--- a/scripts/summarize_ftrl_run.py
+++ b/scripts/summarize_ftrl_run.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import platform
 import sqlite3
 import statistics
+import subprocess
 from collections import Counter
 from datetime import datetime, timezone
 from pathlib import Path
@@ -29,6 +31,56 @@ def portable_path(path: Path) -> str:
         return str(resolved.relative_to(Path.cwd().resolve()))
     except ValueError:
         return path.name
+
+
+def git_command(*args: str) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=Path.cwd(),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False, ""
+    return result.returncode == 0, result.stdout.strip()
+
+
+def execution_context() -> dict:
+    ok_commit, commit = git_command("rev-parse", "HEAD")
+    vcs = None
+    if ok_commit and commit:
+        ok_ref, symbolic_ref = git_command("symbolic-ref", "--quiet", "--short", "HEAD")
+        ok_status, tracked_status = git_command(
+            "status", "--porcelain", "--untracked-files=no"
+        )
+        vcs = {
+            "system": "git",
+            "commit": commit,
+            "ref": os.environ.get("GITHUB_REF") or (symbolic_ref if ok_ref else None),
+            "dirty_tracked_worktree": bool(tracked_status) if ok_status else None,
+        }
+
+    ci = None
+    if os.environ.get("GITHUB_ACTIONS", "").lower() == "true":
+        ci = {"provider": "github-actions"}
+        env_fields = {
+            "repository": "GITHUB_REPOSITORY",
+            "workflow": "GITHUB_WORKFLOW",
+            "run_id": "GITHUB_RUN_ID",
+            "run_attempt": "GITHUB_RUN_ATTEMPT",
+            "event_name": "GITHUB_EVENT_NAME",
+            "ref": "GITHUB_REF",
+            "sha": "GITHUB_SHA",
+        }
+        for output_key, env_key in env_fields.items():
+            value = os.environ.get(env_key)
+            if value:
+                ci[output_key] = value
+
+    return {"vcs": vcs, "ci": ci}
 
 
 def summarize_jsonl(path: Path) -> dict:
@@ -209,6 +261,7 @@ def main() -> None:
             "sqlite_version": sqlite3.sqlite_version,
             "platform": platform.platform(),
         },
+        "execution": execution_context(),
         "files": files,
         "corpus": corpus,
         "database": database,
@@ -228,6 +281,8 @@ def main() -> None:
                 "run_manifest": portable_path(args.output),
                 "page_records": corpus["page_records"],
                 "historical_identities": database["historical_identities"],
+                "git_commit": (manifest["execution"]["vcs"] or {}).get("commit"),
+                "ci_run_id": (manifest["execution"]["ci"] or {}).get("run_id"),
             },
             ensure_ascii=False,
             sort_keys=True,


### PR DESCRIPTION
## Propósito

Cerrar una laguna de procedencia antes de escalar W5: los manifiestos FTRL ya registraban datos, hashes, software y cardinalidades, pero no el árbol exacto de código ejecutado.

## Cambios

- `scripts/summarize_ftrl_run.py` añade `execution.vcs` con commit, ref y estado del worktree rastreado;
- en GitHub Actions añade `execution.ci` con repositorio, workflow, run, intento, evento, ref y SHA;
- no captura URL remota de Git, actor ni variables arbitrarias, evitando credenciales/metadatos innecesarios;
- el esquema 0.1 incorpora `execution` como extensión aditiva **opcional**, de modo que manifiestos históricos 0.1 continúan válidos;
- CI sintético comprueba compatibilidad y correspondencia `GITHUB_SHA == git HEAD`;
- el piloto real W5 de 10 páginas comprueba también la nueva procedencia.

## Criterio científico

Esto permite enlazar cada corrida con el árbol exacto de código que la produjo, incluyendo el merge ref que GitHub Actions prueba en un PR. No altera cobertura, resultados OCR ni interpretación historiográfica.