### PR TITLE
FTRL: preparar validación integral W5 Historia

### DIFF
--- a/.github/workflows/validate-ftrl-w5-full.yml
+++ b/.github/workflows/validate-ftrl-w5-full.yml
@@ -1,0 +1,142 @@
+name: Validate FTRL W5 full corpus
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ftrl-w5-full
+  cancel-in-progress: false
+
+jobs:
+  full-w5:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --version | head -n 1
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Preflight W5 canonical cardinality
+        run: |
+          python - <<'PY'
+          import csv
+          from pathlib import Path
+
+          path = Path('data/catalog/ltmd_u1_w5_history_processing_inventory.csv')
+          rows = list(csv.DictReader(path.open(encoding='utf-8', newline='')))
+          canonical = [r for r in rows if r['is_canonical_processing_object'] == '1']
+          historical = [r for r in rows if r['technical_identity_covered'] == '1']
+          expected_pages = sum(int(r['direct_source_jpegs']) for r in canonical)
+          assert len(canonical) == 15, len(canonical)
+          assert len(historical) == 18, len(historical)
+          assert expected_pages == 2443, expected_pages
+          print({
+              'canonical_processing_objects': len(canonical),
+              'historical_identities': len(historical),
+              'expected_source_pages': expected_pages,
+          })
+          PY
+
+      - name: Run complete W5 FTRL and preregistered queries
+        run: |
+          python scripts/run_ftrl_w5_pilot.py \
+            --full \
+            --run-preregistered-queries \
+            --output-dir local/ftrl
+
+      - name: Assert complete text-free provenance result
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest_path = Path('local/ftrl/ltmd_u1_w5_full_run_manifest.json')
+          summary_path = Path('local/ftrl/ltmd_u1_w5_query_summary.json')
+          manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+          summary = json.loads(summary_path.read_text(encoding='utf-8'))
+
+          assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
+          assert manifest['status'] == 'validated'
+          assert manifest['corpus']['page_records'] == 2443
+          assert manifest['database']['page_rows'] == 2443
+          assert manifest['database']['fts_rows'] == 2443
+          assert manifest['database']['sqlite_integrity'] == 'ok'
+          assert manifest['corpus']['waves'] == ['W5']
+          assert manifest['corpus']['canonical_viewers'] == 15
+          assert manifest['database']['historical_identities'] == 18
+          assert manifest['corpus']['source_byte_size_missing_pages'] == 0
+
+          vcs = manifest['execution']['vcs']
+          ci = manifest['execution']['ci']
+          assert vcs['system'] == 'git'
+          assert len(vcs['commit']) == 40
+          assert vcs['dirty_tracked_worktree'] is False
+          assert ci['provider'] == 'github-actions'
+          assert ci['repository'] == 'fersandovalgtz/libro-texto-mexicano-digital'
+          assert ci['run_id']
+          assert ci['sha'] == vcs['commit']
+
+          assert summary['schema_version'] == 'LTMD_FTRL_QUERY_PROTOCOL_0.1'
+          assert summary['rights_note'].startswith('Text-free aggregate query summary')
+          assert summary['queries']
+          for query in summary['queries']:
+              assert 'query_expression' not in query
+              assert 'snippet' not in query
+              assert 'query_expression_sha256' in query
+
+          print(json.dumps({
+              'status': manifest['status'],
+              'page_records': manifest['corpus']['page_records'],
+              'canonical_viewers': manifest['corpus']['canonical_viewers'],
+              'historical_identities': manifest['database']['historical_identities'],
+              'zero_search_text_pages': manifest['corpus']['zero_search_text_pages'],
+              'sqlite_integrity': manifest['database']['sqlite_integrity'],
+              'preregistered_queries': len(summary['queries']),
+              'git_commit': vcs['commit'],
+              'ci_run_id': ci['run_id'],
+          }, ensure_ascii=False, sort_keys=True))
+          PY
+
+      - name: Prove restricted outputs remain non-publishable
+        run: |
+          test -f local/ftrl/ltmd_u1_w5_full_page_ocr.jsonl
+          test -f local/ftrl/ltmd_u1_w5_full_ocr_search.sqlite
+          test -f local/ftrl/ltmd_u1_w5_query_candidates.json
+          test -f local/ftrl/ltmd_u1_w5_full_run_manifest.json
+          test -f local/ftrl/ltmd_u1_w5_query_summary.json
+
+          git status --short --untracked-files=all | tee local/git-status.txt
+          for path in \
+            local/ftrl/ltmd_u1_w5_full_page_ocr.jsonl \
+            local/ftrl/ltmd_u1_w5_full_ocr_search.sqlite \
+            local/ftrl/ltmd_u1_w5_query_candidates.json; do
+            if ! git check-ignore -q "$path"; then
+              echo "Restricted output is not ignored: $path" >&2
+              exit 1
+            fi
+          done
+          echo 'Restricted OCR, SQLite, and candidate snippets remain ignored: OK'
+
+      - name: Upload text-free evidence only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w5-full-text-free-evidence
+          path: |
+            local/ftrl/ltmd_u1_w5_full_run_manifest.json
+            local/ftrl/ltmd_u1_w5_query_summary.json
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/FTRL_W5_FULL_EXECUTION_PROTOCOL.md
+++ b/docs/FTRL_W5_FULL_EXECUTION_PROTOCOL.md
@@ -1,0 +1,93 @@
+# Protocolo de ejecución integral FTRL W5 Historia
+
+Versión operativa: 0.1  
+Estado: preregistrado antes de la primera corrida integral W5  
+Alcance: LTMD-U1, ola W5 Historia
+
+## Propósito
+
+Este protocolo fija las condiciones de la primera ejecución integral de la Full-Text Research Layer (FTRL) sobre W5 Historia. Su función es evitar que la definición de completitud, las verificaciones de integridad o el tratamiento de los resultados se modifiquen después de observar el corpus completo.
+
+La corrida integral no constituye por sí misma validación semántica ni demuestra afirmaciones historiográficas. Produce una infraestructura de recuperación trazable que deberá someter cada candidato relevante a verificación contra la página fuente.
+
+## Cohorte congelada
+
+La topología de procesamiento vigente contiene:
+
+- 18 identidades históricas técnicamente cubiertas;
+- 15 objetos canónicos de procesamiento;
+- 2,443 JPEG fuente admitidos para OCR;
+- tres identidades 2018 representadas técnicamente mediante relaciones de alias de ruta demostradas hacia 2019, sin borrar su identidad histórica.
+
+La cardinalidad esperada se deriva de `data/catalog/ltmd_u1_w5_history_processing_inventory.csv` y no debe ajustarse para hacer coincidir una corrida incompleta.
+
+## Ejecución
+
+La referencia ejecutable es:
+
+```bash
+python scripts/run_ftrl_w5_pilot.py \
+  --full \
+  --run-preregistered-queries \
+  --output-dir local/ftrl
+```
+
+El workflow `.github/workflows/validate-ftrl-w5-full.yml` reproduce este procedimiento en un runner limpio de GitHub Actions y exige Tesseract con datos `spa`, SQLite FTS5 y Python 3.12.
+
+## Gates de completitud
+
+Una corrida integral sólo puede clasificarse como validada si cumple simultáneamente:
+
+1. 2,443 registros de página FTRL;
+2. 2,443 filas en la tabla `pages` de SQLite;
+3. 2,443 filas FTS5;
+4. `PRAGMA integrity_check = ok`;
+5. 15 visores canónicos de procesamiento;
+6. 18 identidades históricas representadas en el índice;
+7. cero páginas con tamaño de fuente ausente en el manifiesto de procedencia;
+8. commit Git exacto y contexto de CI registrados en el manifiesto de corrida;
+9. outputs restringidos —OCR por página, SQLite y candidatos con snippets— fuera de publicación y cubiertos por `.gitignore`;
+10. artefactos públicos limitados al manifiesto de corrida sin texto y al resumen agregado de consultas sin snippets.
+
+Cualquier discrepancia mantiene la corrida en estado diagnóstico y no autoriza declarar W5 completo.
+
+## Consultas preregistradas
+
+La corrida integral ejecutará el protocolo congelado en `data/research/ltmd_ftrl_w5_preregistered_queries.csv` únicamente después de validar el corpus y el índice.
+
+El archivo local de candidatos puede contener snippets OCR y no debe versionarse ni redistribuirse sin revisión separada de derechos. El resumen público sólo podrá contener conteos, distribuciones, hashes de expresiones de consulta, reglas de verificación y metadatos no sustitutivos.
+
+## Interpretación
+
+Se mantienen como reglas obligatorias:
+
+- `ocr_available != text_verified`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- un alias técnico no implica identidad bibliográfica;
+- una coincidencia de búsqueda debe verificarse contra el activo fuente antes de utilizarse como evidencia histórica;
+- una ausencia de hits debe evaluarse a la luz de cobertura, calidad OCR y variantes de recuperación.
+
+## Auditoría posterior obligatoria
+
+Después de una corrida integral válida deberán revisarse manualmente, como mínimo:
+
+- páginas con `search_text` vacío;
+- páginas del extremo inferior de confianza OCR;
+- todas las páginas candidatas utilizadas en una afirmación historiográfica;
+- controles de errores OCR previsibles para las consultas preregistradas.
+
+La página `H1993P4HI198:src0000`, que produjo cero caracteres en el piloto de 10 páginas, y `H1993P4HI198:src0010`, que registró la confianza mínima de ese piloto, permanecen casos prioritarios de auditoría técnica.
+
+## Evidencia pública esperada
+
+La primera corrida integral válida debe producir, como mínimo:
+
+- un manifiesto `LTMD_FTRL_RUN_0.1` sin texto fuente;
+- un resumen `LTMD_FTRL_QUERY_PROTOCOL_0.1` sin expresiones en claro ni snippets;
+- identificación del commit exacto y del run de GitHub Actions;
+- cardinalidades finales y distribución de confianza OCR;
+- registro explícito de páginas sin texto recuperable;
+- acta metodológica posterior que distinga diagnóstico técnico de resultados históricos.
+
+Este protocolo no anticipa resultados de las consultas ni autoriza publicar el OCR íntegro.


### PR DESCRIPTION
## Propósito

Prepara la primera corrida integral de la Full-Text Research Layer sobre W5 Historia sin publicar OCR, SQLite ni snippets de candidatos.

## Cambios

- añade un workflow manual `validate-ftrl-w5-full.yml` para procesar los 15 objetos canónicos y 2,443 páginas fuente admitidas;
- congela gates de cardinalidad, SQLite/FTS5, procedencia Git/CI y protección de outputs restringidos;
- ejecuta el protocolo de consultas preregistradas únicamente después de validar el corpus completo;
- publica como artefactos sólo el manifiesto de corrida y el resumen agregado sin texto;
- añade `docs/FTRL_W5_FULL_EXECUTION_PROTOCOL.md` para preregistrar las condiciones de la primera corrida completa.

## Integridad científica

No se anticipan resultados historiográficos. Se mantienen `ocr_available != text_verified`, `search_hit != historical_claim` y `zero_hits != demonstrated_absence`.

Refs #15