### PR TITLE
FTRL: activar primera corrida integral W5

### DIFF
--- a/.github/workflows/validate-ftrl-w5-full.yml
+++ b/.github/workflows/validate-ftrl-w5-full.yml
@@ -2,6 +2,10 @@ name: Validate FTRL W5 full corpus
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/validation/ltmd_u1_w5_full_run_trigger.txt'
 
 permissions:
   contents: read

--- a/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
+++ b/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
@@ -1,0 +1,9 @@
+LTMD FTRL W5 FULL RUN TRIGGER
+
+requested_at_local=2026-08-24T09:06:00-06:00
+scope=W5 Historia
+expected_canonical_objects=15
+expected_historical_identities=18
+expected_source_pages=2443
+purpose=First complete preregistered FTRL execution over W5
+publication_policy=text-free evidence only


### PR DESCRIPTION
## Propósito

Activa de forma auditable la primera corrida integral de W5 Historia sin depender del botón manual de GitHub Actions.

## Cambios

- conserva `workflow_dispatch`;
- añade un trigger por `push` limitado exclusivamente al archivo-sello `data/research/validation/ltmd_u1_w5_full_run_trigger.txt` sobre `main`;
- registra en ese archivo el alcance congelado de la corrida: 15 objetos canónicos, 18 identidades históricas y 2,443 páginas fuente admitidas;
- mantiene intacta la política de artefactos públicos sin texto.

Al fusionarse este PR, el cambio del archivo-sello disparará exactamente una corrida integral W5.

Refs #15