### PR TITLE
FTRL: ejecutar W5 completo como check observable

### DIFF
--- a/.github/workflows/validate-ftrl-w5-full.yml
+++ b/.github/workflows/validate-ftrl-w5-full.yml
@@ -6,13 +6,18 @@ on:
     branches: [main]
     paths:
       - 'data/research/validation/ltmd_u1_w5_full_run_trigger.txt'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'data/research/validation/ltmd_u1_w5_full_run_trigger.txt'
+      - '.github/workflows/validate-ftrl-w5-full.yml'
 
 permissions:
   contents: read
 
 concurrency:
   group: ftrl-w5-full
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   full-w5:

--- a/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
+++ b/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
@@ -1,9 +1,9 @@
 LTMD FTRL W5 FULL RUN TRIGGER
 
-requested_at_local=2026-08-24T09:06:00-06:00
+requested_at_local=2026-08-24T09:09:00-06:00
 scope=W5 Historia
 expected_canonical_objects=15
 expected_historical_identities=18
 expected_source_pages=2443
-purpose=First complete preregistered FTRL execution over W5
+purpose=First complete preregistered FTRL execution over W5 with connector-observable PR check
 publication_policy=text-free evidence only


### PR DESCRIPTION
## Propósito

Ejecutar la primera corrida integral W5 como check de pull request para que su estado, pasos y logs puedan auditarse desde el conector antes de fusionar.

## Cambios

- añade `pull_request` como trigger acotado al workflow y al archivo-sello W5;
- cambia la concurrencia a `cancel-in-progress: true` para evitar dos corridas completas simultáneas;
- vuelve a armar el archivo-sello con el mismo alcance preregistrado: 15 objetos canónicos, 18 identidades históricas y 2,443 páginas;
- no modifica el corpus, las consultas preregistradas ni la política de publicación sin texto.

Este PR debe producir la corrida integral observable; sólo se fusionará después de revisar su resultado.

Refs #15