### PR TITLE
FTRL: ejecutar primera corrida integral W5 observada

### DIFF
--- a/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
+++ b/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
@@ -1,9 +1,10 @@
 LTMD FTRL W5 FULL RUN TRIGGER
 
-requested_at_local=2026-08-24T09:12:00-06:00
+requested_at_local=2026-08-24T09:14:00-06:00
 scope=W5 Historia
 expected_canonical_objects=15
 expected_historical_identities=18
 expected_source_pages=2443
 purpose=Observable first complete preregistered FTRL execution over W5
+trigger_event=pull_request_synchronize
 publication_policy=text-free evidence only

--- a/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
+++ b/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
@@ -1,9 +1,9 @@
 LTMD FTRL W5 FULL RUN TRIGGER
 
-requested_at_local=2026-08-24T09:09:00-06:00
+requested_at_local=2026-08-24T09:12:00-06:00
 scope=W5 Historia
 expected_canonical_objects=15
 expected_historical_identities=18
 expected_source_pages=2443
-purpose=First complete preregistered FTRL execution over W5 with connector-observable PR check
+purpose=Observable first complete preregistered FTRL execution over W5
 publication_policy=text-free evidence only


### PR DESCRIPTION
Superseded by PR #26. The observable execution path was moved into the self-reporting workflow, and the W5 source-page cardinality was corrected from 2,443 to 2,653 before full OCR after run 32743452417 failed at preflight.