### PR TITLE
FTRL: hacer autoobservable la corrida integral W5

### DIFF
--- a/.github/workflows/validate-ftrl-w5-full.yml
+++ b/.github/workflows/validate-ftrl-w5-full.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ftrl-w5-full
@@ -26,6 +27,12 @@ jobs:
     steps:
       - name: Checkout exact revision
         uses: actions/checkout@v4
+
+      - name: Announce observable W5 run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 integral — corrida ${GITHUB_RUN_ID} iniciada sobre commit ${GITHUB_SHA}. Alcance preregistrado: 15 objetos canónicos, 18 identidades históricas y 2,443 páginas fuente admitidas. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -149,3 +156,39 @@ jobs:
             local/ftrl/ltmd_u1_w5_query_summary.json
           if-no-files-found: error
           retention-days: 30
+
+      - name: Report validated W5 result to issue 15
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(Path('local/ftrl/ltmd_u1_w5_full_run_manifest.json').read_text(encoding='utf-8'))
+          summary = json.loads(Path('local/ftrl/ltmd_u1_w5_query_summary.json').read_text(encoding='utf-8'))
+          c = manifest['corpus']
+          d = manifest['database']
+          run_id = os.environ['GITHUB_RUN_ID']
+          repo = os.environ['GITHUB_REPOSITORY']
+          body = (
+              f"FTRL W5 integral — corrida {run_id} VALIDADA. "
+              f"Páginas: {c['page_records']}/2443; objetos canónicos: {c['canonical_viewers']}/15; "
+              f"identidades históricas: {d['historical_identities']}/18; SQLite: {d['sqlite_integrity']}; "
+              f"páginas con search_text vacío: {c['zero_search_text_pages']}; "
+              f"consultas preregistradas ejecutadas: {len(summary['queries'])}. "
+              f"Los artefactos públicos contienen sólo evidencia agregada sin OCR ni snippets. "
+              f"Run: https://github.com/{repo}/actions/runs/{run_id}"
+          )
+          Path('local/ftrl/issue15-success.txt').write_text(body, encoding='utf-8')
+          PY
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body-file local/ftrl/issue15-success.txt
+
+      - name: Report failed W5 result to issue 15
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 integral — corrida ${GITHUB_RUN_ID} FALLÓ antes de validar el corpus completo. No se declara W5 completo. Revisar logs y conservar el estado como diagnóstico técnico. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/validate-ftrl-w5-full.yml
+++ b/.github/workflows/validate-ftrl-w5-full.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 integral — corrida ${GITHUB_RUN_ID} iniciada sobre commit ${GITHUB_SHA}. Alcance preregistrado: 15 objetos canónicos, 18 identidades históricas y 2,443 páginas fuente admitidas. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 integral — corrida ${GITHUB_RUN_ID} iniciada sobre commit ${GITHUB_SHA}. Alcance preregistrado corregido antes de OCR completo: 15 objetos canónicos, 18 identidades históricas y 2,653 páginas fuente admitidas. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -59,7 +59,7 @@ jobs:
           expected_pages = sum(int(r['direct_source_jpegs']) for r in canonical)
           assert len(canonical) == 15, len(canonical)
           assert len(historical) == 18, len(historical)
-          assert expected_pages == 2443, expected_pages
+          assert expected_pages == 2653, expected_pages
           print({
               'canonical_processing_objects': len(canonical),
               'historical_identities': len(historical),
@@ -87,9 +87,9 @@ jobs:
 
           assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
           assert manifest['status'] == 'validated'
-          assert manifest['corpus']['page_records'] == 2443
-          assert manifest['database']['page_rows'] == 2443
-          assert manifest['database']['fts_rows'] == 2443
+          assert manifest['corpus']['page_records'] == 2653
+          assert manifest['database']['page_rows'] == 2653
+          assert manifest['database']['fts_rows'] == 2653
           assert manifest['database']['sqlite_integrity'] == 'ok'
           assert manifest['corpus']['waves'] == ['W5']
           assert manifest['corpus']['canonical_viewers'] == 15
@@ -175,7 +175,7 @@ jobs:
           repo = os.environ['GITHUB_REPOSITORY']
           body = (
               f"FTRL W5 integral — corrida {run_id} VALIDADA. "
-              f"Páginas: {c['page_records']}/2443; objetos canónicos: {c['canonical_viewers']}/15; "
+              f"Páginas: {c['page_records']}/2653; objetos canónicos: {c['canonical_viewers']}/15; "
               f"identidades históricas: {d['historical_identities']}/18; SQLite: {d['sqlite_integrity']}; "
               f"páginas con search_text vacío: {c['zero_search_text_pages']}; "
               f"consultas preregistradas ejecutadas: {len(summary['queries'])}. "

--- a/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
+++ b/data/research/validation/ltmd_u1_w5_full_run_trigger.txt
@@ -1,9 +1,10 @@
 LTMD FTRL W5 FULL RUN TRIGGER
 
-requested_at_local=2026-08-24T09:09:00-06:00
+requested_at_local=2026-08-24T09:16:00-06:00
 scope=W5 Historia
 expected_canonical_objects=15
 expected_historical_identities=18
-expected_source_pages=2443
-purpose=First complete preregistered FTRL execution over W5 with connector-observable PR check
+expected_source_pages=2653
+cardinality_correction_basis=run_32743452417_preflight_sum_direct_source_jpegs
+purpose=First complete preregistered FTRL execution over W5 with self-reporting
 publication_policy=text-free evidence only

--- a/docs/FTRL_W5_FULL_EXECUTION_PROTOCOL.md
+++ b/docs/FTRL_W5_FULL_EXECUTION_PROTOCOL.md
@@ -1,7 +1,7 @@
 # Protocolo de ejecución integral FTRL W5 Historia
 
-Versión operativa: 0.1  
-Estado: preregistrado antes de la primera corrida integral W5  
+Versión operativa: 0.2  
+Estado: preregistrado y corregido antes de la primera corrida OCR integral W5  
 Alcance: LTMD-U1, ola W5 Historia
 
 ## Propósito
@@ -10,13 +10,19 @@ Este protocolo fija las condiciones de la primera ejecución integral de la Full
 
 La corrida integral no constituye por sí misma validación semántica ni demuestra afirmaciones historiográficas. Produce una infraestructura de recuperación trazable que deberá someter cada candidato relevante a verificación contra la página fuente.
 
+## Corrección preregistrada de cardinalidad — 24 de agosto de 2026
+
+La primera activación integral, GitHub Actions run `32743452417`, se detuvo deliberadamente en el preflight **antes de ejecutar OCR**. El gate calculó directamente desde `data/catalog/ltmd_u1_w5_history_processing_inventory.csv` la suma de `direct_source_jpegs` para los 15 objetos marcados como `is_canonical_processing_object=1` y obtuvo **2,653 páginas**.
+
+La expectativa previa de 2,443 páginas era un error aritmético de la preparación del workflow. No provenía del inventario y no se modifica para acomodar un resultado observado: la corrección se realiza precisamente porque el gate reproducible rechazó esa cifra antes de procesar el corpus completo. Por tanto, la cardinalidad preregistrada vigente es **2,653**.
+
 ## Cohorte congelada
 
 La topología de procesamiento vigente contiene:
 
 - 18 identidades históricas técnicamente cubiertas;
 - 15 objetos canónicos de procesamiento;
-- 2,443 JPEG fuente admitidos para OCR;
+- 2,653 JPEG fuente admitidos para OCR;
 - tres identidades 2018 representadas técnicamente mediante relaciones de alias de ruta demostradas hacia 2019, sin borrar su identidad histórica.
 
 La cardinalidad esperada se deriva de `data/catalog/ltmd_u1_w5_history_processing_inventory.csv` y no debe ajustarse para hacer coincidir una corrida incompleta.
@@ -38,9 +44,9 @@ El workflow `.github/workflows/validate-ftrl-w5-full.yml` reproduce este procedi
 
 Una corrida integral sólo puede clasificarse como validada si cumple simultáneamente:
 
-1. 2,443 registros de página FTRL;
-2. 2,443 filas en la tabla `pages` de SQLite;
-3. 2,443 filas FTS5;
+1. 2,653 registros de página FTRL;
+2. 2,653 filas en la tabla `pages` de SQLite;
+3. 2,653 filas FTS5;
 4. `PRAGMA integrity_check = ok`;
 5. 15 visores canónicos de procesamiento;
 6. 18 identidades históricas representadas en el índice;


### PR DESCRIPTION
Instrumenta el workflow integral W5 para reportar inicio, validación o fallo directamente en el issue #15, incluyendo sólo cardinalidades y metadatos técnicos sin OCR ni snippets. El propio cambio del workflow debe ejecutar el check integral como `pull_request`. Refs #15