### PR TITLE
FTRL: añadir cola reproducible de control de calidad OCR

### DIFF
--- a/.github/workflows/validate-ftrl-qc-queue.yml
+++ b/.github/workflows/validate-ftrl-qc-queue.yml
@@ -1,0 +1,89 @@
+name: Validate FTRL OCR QC queue
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/build_ftrl_qc_queue.py'
+      - '.github/workflows/validate-ftrl-qc-queue.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  qc-queue:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build synthetic restricted corpus
+        run: |
+          mkdir -p local/ftrl
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          def h(text):
+              return hashlib.sha256(text.encode()).hexdigest()
+
+          rows = [
+              dict(page_id='A:src0000', viewer_key='A', canonical_viewer_key='A', wave='W5', catalog_generation=1993, grade_code=4, page_index=0, viewer_page=1, source_sha256=h('s0'), ocr_sha256=h('o0'), ocr_confidence_mean=None, ocr_char_count=0, ocr_word_count=0, ocr_text_raw='', search_text=''),
+              dict(page_id='A:src0001', viewer_key='A', canonical_viewer_key='A', wave='W5', catalog_generation=1993, grade_code=4, page_index=1, viewer_page=2, source_sha256=h('s1'), ocr_sha256=h('o1'), ocr_confidence_mean=65.0, ocr_char_count=40, ocr_word_count=8, ocr_text_raw='RESTRICTED LOW CONFIDENCE SAMPLE', search_text='restricted low confidence sample'),
+              dict(page_id='A:src0002', viewer_key='A', canonical_viewer_key='A', wave='W5', catalog_generation=1993, grade_code=4, page_index=2, viewer_page=3, source_sha256=h('s2'), ocr_sha256=h('o2'), ocr_confidence_mean=75.0, ocr_char_count=500, ocr_word_count=90, ocr_text_raw='RESTRICTED REVIEW SAMPLE', search_text='restricted review sample'),
+              dict(page_id='B:src0001', viewer_key='B', canonical_viewer_key='B', wave='W5', catalog_generation=2019, grade_code=5, page_index=1, viewer_page=2, source_sha256=h('s3'), ocr_sha256=h('o3'), ocr_confidence_mean=92.0, ocr_char_count=900, ocr_word_count=160, ocr_text_raw='RESTRICTED GOOD SAMPLE', search_text='restricted good sample'),
+              dict(page_id='B:src0002', viewer_key='B', canonical_viewer_key='B', wave='W5', catalog_generation=2019, grade_code=5, page_index=2, viewer_page=3, source_sha256=h('s4'), ocr_sha256=h('o4'), ocr_confidence_mean=88.0, ocr_char_count=80, ocr_word_count=14, ocr_text_raw='RESTRICTED SHORT SAMPLE', search_text='restricted short sample'),
+          ]
+          path = Path('local/ftrl/synthetic_page_ocr.jsonl')
+          path.write_text(''.join(json.dumps(row) + '\n' for row in rows), encoding='utf-8')
+          PY
+
+      - name: Generate QC queue and summary
+        run: |
+          python scripts/build_ftrl_qc_queue.py \
+            --input local/ftrl/synthetic_page_ocr.jsonl \
+            --queue-output local/ftrl/qc_queue.json \
+            --summary-output local/ftrl/qc_summary.json
+
+      - name: Assert diagnostics and text exclusion
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          queue = json.loads(Path('local/ftrl/qc_queue.json').read_text())
+          summary = json.loads(Path('local/ftrl/qc_summary.json').read_text())
+
+          assert queue['schema_version'] == 'LTMD_FTRL_QC_0.1'
+          assert summary['schema_version'] == 'LTMD_FTRL_QC_0.1'
+          assert summary['page_records'] == 5
+          assert summary['pages_flagged'] == 4
+          assert summary['pages_unflagged'] == 1
+          assert summary['flag_counts']['zero_search_text'] == 1
+          assert summary['flag_counts']['missing_confidence'] == 1
+          assert summary['flag_counts']['low_confidence_critical'] == 1
+          assert summary['flag_counts']['low_confidence_review'] == 1
+          assert summary['flag_counts']['very_short_text'] == 2
+          assert summary['flag_counts']['zero_ocr_chars'] == 1
+          assert summary['flag_counts']['zero_ocr_words'] == 1
+          assert queue['pages'][0]['page_id'] == 'A:src0000'
+
+          serialized = json.dumps({'queue': queue, 'summary': summary})
+          for forbidden in ('ocr_text_raw', 'search_text', 'RESTRICTED'):
+              assert forbidden not in serialized, forbidden
+          print(json.dumps(summary['flag_counts'], sort_keys=True))
+          PY
+
+      - name: Confirm outputs stay under ignored local path
+        run: |
+          git check-ignore -q local/ftrl/qc_queue.json
+          git check-ignore -q local/ftrl/qc_summary.json
+          git check-ignore -q local/ftrl/synthetic_page_ocr.jsonl

--- a/.github/workflows/validate-ftrl-qc-queue.yml
+++ b/.github/workflows/validate-ftrl-qc-queue.yml
@@ -76,9 +76,20 @@ jobs:
           assert summary['flag_counts']['zero_ocr_words'] == 1
           assert queue['pages'][0]['page_id'] == 'A:src0000'
 
+          forbidden_keys = {'ocr_text_raw', 'search_text'}
+          def walk(value):
+              if isinstance(value, dict):
+                  assert not (forbidden_keys & set(value)), forbidden_keys & set(value)
+                  for child in value.values():
+                      walk(child)
+              elif isinstance(value, list):
+                  for child in value:
+                      walk(child)
+
+          walk(queue)
+          walk(summary)
           serialized = json.dumps({'queue': queue, 'summary': summary})
-          for forbidden in ('ocr_text_raw', 'search_text', 'RESTRICTED'):
-              assert forbidden not in serialized, forbidden
+          assert 'RESTRICTED' not in serialized
           print(json.dumps(summary['flag_counts'], sort_keys=True))
           PY
 

--- a/docs/FTRL_OCR_QC_PROTOCOL.md
+++ b/docs/FTRL_OCR_QC_PROTOCOL.md
@@ -1,0 +1,52 @@
+# Protocolo de control de calidad OCR para FTRL
+
+Versión operativa: 0.1
+
+## Propósito
+
+Este protocolo define cómo identificar, ordenar y auditar páginas problemáticas de la Full-Text Research Layer (FTRL) sin publicar el texto OCR reconstruido. La cola de control de calidad es diagnóstica: una bandera de baja confianza no prueba que el texto sea incorrecto, y una página sin banderas no equivale a transcripción verificada.
+
+## Implementación
+
+La referencia ejecutable es `scripts/build_ftrl_qc_queue.py`. Recibe un corpus JSONL FTRL local y genera dos productos sin texto:
+
+- una cola de páginas con identificadores, hashes, métricas, banderas y prioridad;
+- un resumen agregado con conteos de banderas y distribución de confianza por generación, grado y objeto canónico.
+
+Los outputs deben permanecer bajo `local/` por defecto, aun cuando estén diseñados para no contener `ocr_text_raw` ni `search_text`.
+
+## Umbrales preregistrados iniciales
+
+Los valores por defecto son deliberadamente conservadores y deben registrarse si se modifican:
+
+- confianza crítica: `< 70`;
+- confianza de revisión: `>= 70` y `< 80`;
+- texto muy corto: más de cero y menos de 100 caracteres;
+- texto de búsqueda vacío: revisión prioritaria;
+- confianza ausente: revisión prioritaria;
+- cero caracteres o cero palabras OCR: revisión prioritaria.
+
+Estos umbrales sirven para triage técnico y no constituyen una métrica universal de exactitud OCR.
+
+## Priorización
+
+La cola asigna mayor prioridad a páginas sin texto recuperable, seguidas por ausencia de confianza, confianza crítica, confianza de revisión y textos excepcionalmente cortos. La puntuación sólo determina orden de inspección; no debe interpretarse como probabilidad de error.
+
+## Reglas de auditoría
+
+Toda página utilizada para sostener una afirmación historiográfica debe verificarse contra el activo fuente independientemente de su confianza OCR. Las páginas marcadas como `zero_search_text`, `zero_ocr_chars`, `zero_ocr_words` o `missing_confidence` deben revisarse antes de interpretar ausencias léxicas. Las páginas con baja confianza deben considerarse candidatas a re-OCR, cambio de segmentación o inspección visual.
+
+## Separación entre texto y evidencia pública
+
+La cola y el resumen excluyen deliberadamente:
+
+- `ocr_text_raw`;
+- `search_text`;
+- snippets;
+- imágenes fuente.
+
+Conservan hashes SHA-256, identificadores de página y métricas suficientes para vincular cada diagnóstico con la corrida exacta sin redistribuir el contenido textual.
+
+## Criterio para W5 Historia
+
+Después de una corrida integral válida de W5, la cola QC debe generarse sobre el corpus completo y revisarse antes de presentar resultados de las consultas preregistradas. El piloto de diez páginas ya demostró dos casos de interés: una página sin texto recuperado y una página con confianza marcadamente inferior al resto; la corrida completa permitirá determinar si son excepciones aisladas o parte de patrones sistemáticos.

--- a/scripts/build_ftrl_qc_queue.py
+++ b/scripts/build_ftrl_qc_queue.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Build a text-free OCR quality-control queue from an LTMD FTRL page corpus.
+
+The input JSONL may contain restricted OCR text. Outputs intentionally exclude OCR
+text and search text, retaining only page identifiers, hashes, diagnostic metrics,
+and flags needed for reproducible quality-control review.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+VERSION = "LTMD_FTRL_QC_0.1"
+
+
+def load_records(path: Path) -> list[dict]:
+    records: list[dict] = []
+    with path.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise SystemExit(f"invalid JSONL at line {line_number}: {exc}") from exc
+            required = {
+                "page_id",
+                "viewer_key",
+                "canonical_viewer_key",
+                "wave",
+                "catalog_generation",
+                "grade_code",
+                "page_index",
+                "source_sha256",
+                "ocr_sha256",
+                "ocr_char_count",
+                "ocr_word_count",
+            }
+            missing = required - set(row)
+            if missing:
+                raise SystemExit(
+                    f"record at line {line_number} lacks required keys: {sorted(missing)}"
+                )
+            records.append(row)
+    if not records:
+        raise SystemExit("input corpus is empty")
+    return records
+
+
+def classify(
+    row: dict,
+    review_confidence: float,
+    critical_confidence: float,
+    short_chars: int,
+) -> tuple[list[str], int]:
+    flags: list[str] = []
+    confidence = row.get("ocr_confidence_mean")
+    char_count = int(row.get("ocr_char_count") or 0)
+    word_count = int(row.get("ocr_word_count") or 0)
+    search_text = row.get("search_text")
+
+    if not search_text:
+        flags.append("zero_search_text")
+    if confidence is None:
+        flags.append("missing_confidence")
+    else:
+        confidence = float(confidence)
+        if confidence < critical_confidence:
+            flags.append("low_confidence_critical")
+        elif confidence < review_confidence:
+            flags.append("low_confidence_review")
+    if 0 < char_count < short_chars:
+        flags.append("very_short_text")
+    if char_count == 0:
+        flags.append("zero_ocr_chars")
+    if word_count == 0:
+        flags.append("zero_ocr_words")
+
+    weights = {
+        "zero_search_text": 100,
+        "zero_ocr_chars": 100,
+        "zero_ocr_words": 80,
+        "missing_confidence": 70,
+        "low_confidence_critical": 60,
+        "low_confidence_review": 30,
+        "very_short_text": 20,
+    }
+    priority = sum(weights[flag] for flag in set(flags))
+    return flags, priority
+
+
+def safe_number(value):
+    if value is None:
+        return None
+    number = float(value)
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def summarize(records: list[dict], queue: list[dict], thresholds: dict) -> dict:
+    flags = Counter()
+    by_generation = defaultdict(Counter)
+    by_grade = defaultdict(Counter)
+    by_viewer = defaultdict(Counter)
+    confidences: list[float] = []
+
+    for source, diagnostic in zip(records, queue):
+        confidence = safe_number(source.get("ocr_confidence_mean"))
+        if confidence is not None:
+            confidences.append(confidence)
+        for flag in diagnostic["flags"]:
+            flags[flag] += 1
+            by_generation[str(source["catalog_generation"])][flag] += 1
+            by_grade[str(source["grade_code"])][flag] += 1
+            by_viewer[str(source["canonical_viewer_key"])][flag] += 1
+
+    confidence_summary = {
+        "observed_pages": len(confidences),
+        "missing_pages": len(records) - len(confidences),
+        "minimum": min(confidences) if confidences else None,
+        "median": statistics.median(confidences) if confidences else None,
+        "mean": statistics.fmean(confidences) if confidences else None,
+        "maximum": max(confidences) if confidences else None,
+    }
+    return {
+        "schema_version": VERSION,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "rights_note": "Text-free OCR quality-control summary; contains no OCR or search text.",
+        "thresholds": thresholds,
+        "page_records": len(records),
+        "pages_flagged": sum(1 for item in queue if item["flags"]),
+        "pages_unflagged": sum(1 for item in queue if not item["flags"]),
+        "flag_counts": dict(sorted(flags.items())),
+        "confidence": confidence_summary,
+        "flag_counts_by_generation": {
+            key: dict(sorted(value.items())) for key, value in sorted(by_generation.items())
+        },
+        "flag_counts_by_grade": {
+            key: dict(sorted(value.items(), key=lambda item: item[0]))
+            for key, value in sorted(by_grade.items(), key=lambda item: int(item[0]))
+        },
+        "flag_counts_by_canonical_viewer": {
+            key: dict(sorted(value.items())) for key, value in sorted(by_viewer.items())
+        },
+    }
+
+
+def write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp = path.with_name(path.name + ".tmp")
+    temp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temp.replace(path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, required=True)
+    parser.add_argument("--queue-output", type=Path, required=True)
+    parser.add_argument("--summary-output", type=Path, required=True)
+    parser.add_argument("--review-confidence", type=float, default=80.0)
+    parser.add_argument("--critical-confidence", type=float, default=70.0)
+    parser.add_argument("--short-chars", type=int, default=100)
+    args = parser.parse_args()
+
+    if not 0 <= args.critical_confidence <= args.review_confidence <= 100:
+        raise SystemExit("confidence thresholds must satisfy 0 <= critical <= review <= 100")
+    if args.short_chars < 1:
+        raise SystemExit("--short-chars must be >= 1")
+
+    records = load_records(args.input)
+    queue: list[dict] = []
+    for row in records:
+        flags, priority = classify(
+            row,
+            args.review_confidence,
+            args.critical_confidence,
+            args.short_chars,
+        )
+        queue.append(
+            {
+                "page_id": row["page_id"],
+                "viewer_key": row["viewer_key"],
+                "canonical_viewer_key": row["canonical_viewer_key"],
+                "wave": row["wave"],
+                "catalog_generation": row["catalog_generation"],
+                "grade_code": row["grade_code"],
+                "page_index": row["page_index"],
+                "viewer_page": row.get("viewer_page"),
+                "source_sha256": row["source_sha256"],
+                "ocr_sha256": row["ocr_sha256"],
+                "ocr_confidence_mean": safe_number(row.get("ocr_confidence_mean")),
+                "ocr_char_count": int(row.get("ocr_char_count") or 0),
+                "ocr_word_count": int(row.get("ocr_word_count") or 0),
+                "flags": sorted(flags),
+                "priority_score": priority,
+            }
+        )
+
+    queue.sort(
+        key=lambda item: (
+            -item["priority_score"],
+            item["catalog_generation"],
+            item["grade_code"],
+            item["canonical_viewer_key"],
+            item["page_index"],
+        )
+    )
+    thresholds = {
+        "review_confidence_below": args.review_confidence,
+        "critical_confidence_below": args.critical_confidence,
+        "very_short_text_below_chars": args.short_chars,
+    }
+    summary = summarize(records, queue, thresholds)
+
+    queue_payload = {
+        "schema_version": VERSION,
+        "generated_at": summary["generated_at"],
+        "rights_note": "Text-free page-level OCR QC queue; contains no OCR or search text.",
+        "thresholds": thresholds,
+        "pages": queue,
+    }
+    write_json(args.queue_output, queue_payload)
+    write_json(args.summary_output, summary)
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "page_records": summary["page_records"],
+                "pages_flagged": summary["pages_flagged"],
+                "flag_counts": summary["flag_counts"],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/build_ftrl_qc_queue.py
+++ b/scripts/build_ftrl_qc_queue.py
@@ -103,26 +103,26 @@ def safe_number(value):
     return number
 
 
-def summarize(records: list[dict], queue: list[dict], thresholds: dict) -> dict:
+def summarize(queue: list[dict], thresholds: dict) -> dict:
     flags = Counter()
     by_generation = defaultdict(Counter)
     by_grade = defaultdict(Counter)
     by_viewer = defaultdict(Counter)
     confidences: list[float] = []
 
-    for source, diagnostic in zip(records, queue):
-        confidence = safe_number(source.get("ocr_confidence_mean"))
+    for diagnostic in queue:
+        confidence = safe_number(diagnostic.get("ocr_confidence_mean"))
         if confidence is not None:
             confidences.append(confidence)
         for flag in diagnostic["flags"]:
             flags[flag] += 1
-            by_generation[str(source["catalog_generation"])][flag] += 1
-            by_grade[str(source["grade_code"])][flag] += 1
-            by_viewer[str(source["canonical_viewer_key"])][flag] += 1
+            by_generation[str(diagnostic["catalog_generation"])][flag] += 1
+            by_grade[str(diagnostic["grade_code"])][flag] += 1
+            by_viewer[str(diagnostic["canonical_viewer_key"])][flag] += 1
 
     confidence_summary = {
         "observed_pages": len(confidences),
-        "missing_pages": len(records) - len(confidences),
+        "missing_pages": len(queue) - len(confidences),
         "minimum": min(confidences) if confidences else None,
         "median": statistics.median(confidences) if confidences else None,
         "mean": statistics.fmean(confidences) if confidences else None,
@@ -133,7 +133,7 @@ def summarize(records: list[dict], queue: list[dict], thresholds: dict) -> dict:
         "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
         "rights_note": "Text-free OCR quality-control summary; contains no OCR or search text.",
         "thresholds": thresholds,
-        "page_records": len(records),
+        "page_records": len(queue),
         "pages_flagged": sum(1 for item in queue if item["flags"]),
         "pages_unflagged": sum(1 for item in queue if not item["flags"]),
         "flag_counts": dict(sorted(flags.items())),
@@ -219,7 +219,7 @@ def main() -> None:
         "critical_confidence_below": args.critical_confidence,
         "very_short_text_below_chars": args.short_chars,
     }
-    summary = summarize(records, queue, thresholds)
+    summary = summarize(queue, thresholds)
 
     queue_payload = {
         "schema_version": VERSION,


### PR DESCRIPTION
## Propósito

Preparar el control de calidad inmediatamente posterior a la corrida integral W5 sin exponer OCR ni texto de búsqueda.

## Cambios

- añade `scripts/build_ftrl_qc_queue.py` para generar una cola text-free de páginas problemáticas a partir del corpus FTRL local;
- preregistra umbrales iniciales de revisión (`<80`), confianza crítica (`<70`) y texto muy corto (`<100` caracteres);
- clasifica páginas con texto de búsqueda vacío, confianza ausente, confianza baja, cero caracteres, cero palabras o longitud excepcionalmente corta;
- conserva únicamente identificadores, hashes, métricas y banderas, excluyendo `ocr_text_raw`, `search_text` y snippets;
- añade un workflow sintético que prueba cardinalidades, prioridades y ausencia de filtración textual;
- documenta el protocolo en `docs/FTRL_OCR_QC_PROTOCOL.md`.

Este PR no toca el corpus W5 ni el workflow integral en ejecución y no debe cancelar la corrida activa.

Refs #15