### PR TITLE
FTRL: formalizar matriz de preparación U1 por cohorte

### DIFF
--- a/.github/workflows/validate-ftrl-u1-readiness.yml
+++ b/.github/workflows/validate-ftrl-u1-readiness.yml
@@ -1,0 +1,60 @@
+name: Validate FTRL U1 readiness
+
+on:
+  pull_request:
+    paths:
+      - 'data/derived/ltmd_u1_ftrl_readiness.csv'
+      - 'data/catalog/ltmd_u1_coverage.md'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - 'scripts/validate_ftrl_u1_readiness.py'
+      - 'docs/FTRL_U1_READINESS_MATRIX.md'
+      - '.github/workflows/validate-ftrl-u1-readiness.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/derived/ltmd_u1_ftrl_readiness.csv'
+      - 'data/catalog/ltmd_u1_coverage.md'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - 'scripts/validate_ftrl_u1_readiness.py'
+      - 'docs/FTRL_U1_READINESS_MATRIX.md'
+      - '.github/workflows/validate-ftrl-u1-readiness.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate readiness against canonical U1 state
+        run: python scripts/validate_ftrl_u1_readiness.py
+
+      - name: Confirm readiness artifacts are text-free metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          test ! -e local
+          python - <<'PY'
+          from pathlib import Path
+
+          targets = [
+              Path('data/derived/ltmd_u1_ftrl_readiness.csv'),
+              Path('docs/FTRL_U1_READINESS_MATRIX.md'),
+          ]
+          forbidden = ('ocr_text', 'raw_text', 'normalized_text', 'snippet')
+          for path in targets:
+              text = path.read_text(encoding='utf-8').lower()
+              found = [key for key in forbidden if key in text]
+              if found:
+                  raise SystemExit(f'{path}: forbidden restricted-text field names: {found}')
+          print('FTRL readiness artifacts: text-free metadata only')
+          PY

--- a/data/derived/ltmd_u1_ftrl_readiness.csv
+++ b/data/derived/ltmd_u1_ftrl_readiness.csv
@@ -1,0 +1,12 @@
+schema_version,wave,domain,plan_identities,effective_coverage,canonical_objects,residual_active,residual_final,ftrl_status,allowed_scope,next_gate
+LTMD_FTRL_U1_READINESS_0.1,W1,Ciencias Naturales,40,40,36,0,0,PREFLIGHT_REQUIRED,36 canonical objects,freeze manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W2,Matemáticas,64,60,57,4,0,PREFLIGHT_REQUIRED_WITH_EXCLUSIONS,57 canonical objects; exclude 4 active retentions,freeze admitted cohort manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W3,Español / Lengua,130,130,114,0,0,PREFLIGHT_REQUIRED,114 canonical objects,freeze manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W4,Ciencias Sociales,14,14,14,0,0,PREFLIGHT_REQUIRED,14 canonical objects,freeze manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W5,Historia,18,18,15,0,0,REFERENCE_FULL_VALIDATION,15 canonical objects / 18 historical identities,close full W5 validation and human OCR/source audit
+LTMD_FTRL_U1_READINESS_0.1,W6,Geografía / Atlas,42,42,37,0,0,PREFLIGHT_REQUIRED,37 canonical objects,freeze manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W7,Formación Cívica y Ética,30,25,25,5,0,PREFLIGHT_REQUIRED_WITH_EXCLUSIONS,25 canonical objects; exclude 5 active retentions,freeze admitted cohort manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W8,Artes,20,16,16,4,0,PREFLIGHT_REQUIRED_WITH_EXCLUSIONS,16 canonical objects; exclude 4 active retentions,freeze admitted cohort manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W9,Educación Física,4,4,4,0,0,PREFLIGHT_REQUIRED,4 canonical objects,freeze manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W10,Integrados / Multiarea,69,68,68,0,1,PREFLIGHT_REQUIRED_WITH_EXCLUSIONS,68 canonical objects; exclude 1 final exception,freeze admitted cohort manifests and exact page cardinality
+LTMD_FTRL_U1_READINESS_0.1,W11,Otros / No clasificados,111,107,106,0,4,PREFLIGHT_REQUIRED_WITH_EXCLUSIONS,106 canonical objects; preserve identity/canonical distinction; exclude 4 final exceptions,freeze admitted cohort manifests and exact page cardinality

--- a/docs/FTRL_U1_READINESS_MATRIX.md
+++ b/docs/FTRL_U1_READINESS_MATRIX.md
@@ -1,0 +1,70 @@
+# FTRL U1 — matriz de preparación por cohorte
+
+Versión: `LTMD_FTRL_U1_READINESS_0.1`  
+Fecha: 2026-08-24  
+Universo de referencia: LTMD-U1, 542 identidades documentales.
+
+## Propósito
+
+Esta matriz define el orden de escalamiento de la Full-Text Research Layer (FTRL) desde W5 hacia LTMD-U1 sin convertir el cierre técnico de una ola en una afirmación de preparación OCR, validación textual o validez semántica.
+
+La unidad operativa de preparación es la **cohorte fuente-admitida**, no la ola completa. Las identidades retenidas o cerradas como excepción técnica permanecen fuera del procesamiento FTRL mientras no exista evidencia nueva que modifique su estado.
+
+## Estados
+
+- `REFERENCE_FULL_VALIDATION`: cohorte de referencia con corrida FTRL integral en validación; no implica todavía auditoría humana de OCR ni validación historiográfica.
+- `PREFLIGHT_REQUIRED`: cohorte técnicamente cerrada, candidata a FTRL, pero todavía requiere un preflight específico que demuestre inventario canónico, resolución de activos, cardinalidad de páginas y validación SHA-256 antes de OCR masivo.
+- `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS`: igual que el estado anterior, pero el alcance FTRL debe excluir de forma explícita y contable las identidades retenidas o las excepciones finales.
+
+Ninguno de estos estados equivale a `semantic_ready`.
+
+## Matriz
+
+| Ola | Dominio | Plan | Cobertura efectiva | Canónicos | Residual fuera de cobertura | Estado FTRL | Alcance permitido antes de OCR |
+|---|---|---:|---:|---:|---:|---|---|
+| W1 | Ciencias Naturales | 40 | 40 | 36 | 0 | `PREFLIGHT_REQUIRED` | 36 canónicos; confirmar manifiestos y cardinalidad de páginas |
+| W2 | Matemáticas | 64 | 60 | 57 | 4 activas | `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS` | 57 canónicos; excluir las 4 retenciones activas |
+| W3 | Español / Lengua | 130 | 130 | 114 | 0 | `PREFLIGHT_REQUIRED` | 114 canónicos; confirmar manifiestos y cardinalidad de páginas |
+| W4 | Ciencias Sociales | 14 | 14 | 14 | 0 | `PREFLIGHT_REQUIRED` | 14 canónicos; confirmar manifiestos y cardinalidad de páginas |
+| W5 | Historia | 18 | 18 | 15 | 0 | `REFERENCE_FULL_VALIDATION` | 15 canónicos / 18 identidades; referencia metodológica |
+| W6 | Geografía / Atlas | 42 | 42 | 37 | 0 | `PREFLIGHT_REQUIRED` | 37 canónicos; confirmar manifiestos y cardinalidad de páginas |
+| W7 | Formación Cívica y Ética | 30 | 25 | 25 | 5 activas | `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS` | 25 canónicos; excluir las 5 retenciones activas |
+| W8 | Artes | 20 | 16 | 16 | 4 activas | `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS` | 16 canónicos; excluir las 4 retenciones activas |
+| W9 | Educación Física | 4 | 4 | 4 | 0 | `PREFLIGHT_REQUIRED` | 4 canónicos; confirmar manifiestos y cardinalidad de páginas |
+| W10 | Integrados / Multiarea | 69 | 68 | 68 | 1 final | `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS` | 68 canónicos; excluir la excepción técnica final |
+| W11 | Otros / No clasificados | 111 | 107 | 106 | 4 finales | `PREFLIGHT_REQUIRED_WITH_EXCLUSIONS` | 106 canónicos; conservar la diferencia identidad/canónico y excluir 4 excepciones finales |
+| **Total** |  | **542** | **524** | **492** | **18** |  |  |
+
+## Regla de promoción a FTRL ejecutable
+
+Una cohorte sólo podrá pasar de `PREFLIGHT_REQUIRED*` a una ejecución OCR masiva cuando un preflight reproducible confirme, como mínimo:
+
+1. conjunto congelado de identidades históricas y objetos canónicos;
+2. manifiesto de activos por objeto canónico;
+3. cardinalidad exacta de páginas fuente admitidas;
+4. resolución completa o excepciones internas explícitas y preservadas;
+5. SHA-256 verificable de cada activo admitido antes de OCR;
+6. relaciones de alias documentadas sin OCR redundante;
+7. salida restringida bajo `local/` y evidencia pública libre de texto fuente extenso;
+8. runner y validador capaces de fallar ante deriva de inventario o procedencia.
+
+La prueba de W5 mostró por qué este gate debe ser obligatorio: una cardinalidad preregistrada obsoleta debe producir un fallo temprano, no una corrida silenciosamente inconsistente.
+
+## Orden de escalamiento recomendado
+
+W5 permanece como implementación de referencia hasta cerrar su validación integral. Después, el orden técnico debe priorizar cohortes pequeñas y cerradas para comprobar que el runner generalizado no contiene supuestos específicos de Historia: W9 y W4 son candidatos naturales para ese smoke test. Sólo entonces conviene escalar a cohortes mayores como W1, W6 y W3. W2, W7, W8, W10 y W11 pueden procesarse por su cohorte admitida, pero sus exclusiones deben viajar en manifiestos, resúmenes y reportes de cobertura.
+
+Este orden es metodológico, no historiográfico: no expresa prioridad sustantiva entre materias.
+
+## Guardas epistemológicas
+
+- `corpus_ready != semantic_ready`
+- `ocr_available != text_verified`
+- `search_hit != historical_claim`
+- `zero_hits != demonstrated_absence`
+- cierre técnico de ola != preparación FTRL demostrada
+- excepción técnica final != fuente resuelta
+
+## Fuentes canónicas de estado
+
+La matriz debe mantenerse sincronizada con `data/catalog/ltmd_u1_coverage.md`, `docs/LTMD_U1_MASTER_PLAN_0_3.md` y `data/catalog/ltmd_u1_retained_source_register.csv`. Cuando esas fuentes cambien, esta matriz no debe actualizarse por inferencia manual: el siguiente paso es automatizar una comprobación de consistencia en CI.

--- a/scripts/validate_ftrl_u1_readiness.py
+++ b/scripts/validate_ftrl_u1_readiness.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Validate the machine-readable FTRL U1 readiness matrix.
+
+The validator is intentionally text-free and standard-library only. It compares
+readiness counts against the canonical U1 coverage dashboard and residual
+lifecycle against the retained-source register. It does not fetch source assets,
+run OCR, or promote any cohort to semantic readiness.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+READINESS = ROOT / "data/derived/ltmd_u1_ftrl_readiness.csv"
+COVERAGE = ROOT / "data/catalog/ltmd_u1_coverage.md"
+RETAINED = ROOT / "data/catalog/ltmd_u1_retained_source_register.csv"
+
+SCHEMA_VERSION = "LTMD_FTRL_U1_READINESS_0.1"
+EXPECTED_WAVES = {f"W{i}" for i in range(1, 12)}
+EXPECTED_COLUMNS = [
+    "schema_version",
+    "wave",
+    "domain",
+    "plan_identities",
+    "effective_coverage",
+    "canonical_objects",
+    "residual_active",
+    "residual_final",
+    "ftrl_status",
+    "allowed_scope",
+    "next_gate",
+]
+ALLOWED_STATUSES = {
+    "REFERENCE_FULL_VALIDATION",
+    "PREFLIGHT_REQUIRED",
+    "PREFLIGHT_REQUIRED_WITH_EXCLUSIONS",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FTRL U1 readiness validation failed: {message}")
+
+
+def load_readiness() -> list[dict[str, str]]:
+    with READINESS.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames != EXPECTED_COLUMNS:
+            fail(f"unexpected readiness columns: {reader.fieldnames!r}")
+        rows = list(reader)
+    if len(rows) != 11:
+        fail(f"expected 11 wave rows, found {len(rows)}")
+    return rows
+
+
+def parse_coverage() -> dict[str, tuple[int, int, int, int]]:
+    rows: dict[str, tuple[int, int, int, int]] = {}
+    for line in COVERAGE.read_text(encoding="utf-8").splitlines():
+        if not line.startswith("| W"):
+            continue
+        parts = [part.strip() for part in line.strip().strip("|").split("|")]
+        if len(parts) != 7:
+            fail(f"unexpected coverage row: {line}")
+        wave, _domain, plan, effective, canonical, remaining, _status = parts
+        try:
+            rows[wave] = tuple(map(int, (plan, effective, canonical, remaining)))
+        except ValueError:
+            fail(f"non-integer coverage value in {wave}")
+    if set(rows) != EXPECTED_WAVES:
+        fail(f"coverage waves mismatch: {sorted(rows)}")
+    return rows
+
+
+def retained_lifecycle() -> tuple[Counter[str], Counter[str]]:
+    wave_counts: Counter[str] = Counter()
+    lifecycle: Counter[str] = Counter()
+    with RETAINED.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            wave_counts[row["wave"]] += 1
+            lifecycle[row["status"]] += 1
+    return wave_counts, lifecycle
+
+
+def main() -> None:
+    rows = load_readiness()
+    coverage = parse_coverage()
+    retained_by_wave, lifecycle = retained_lifecycle()
+
+    waves = [row["wave"] for row in rows]
+    if len(set(waves)) != len(waves) or set(waves) != EXPECTED_WAVES:
+        fail(f"readiness waves must be unique W1-W11: {waves!r}")
+
+    versions = {row["schema_version"] for row in rows}
+    if versions != {SCHEMA_VERSION}:
+        fail(f"schema version mismatch: {sorted(versions)!r}")
+
+    totals = Counter()
+    active_total = 0
+    final_total = 0
+
+    for row in rows:
+        wave = row["wave"]
+        status = row["ftrl_status"]
+        if status not in ALLOWED_STATUSES:
+            fail(f"invalid FTRL status for {wave}: {status}")
+
+        try:
+            plan = int(row["plan_identities"])
+            effective = int(row["effective_coverage"])
+            canonical = int(row["canonical_objects"])
+            active = int(row["residual_active"])
+            final = int(row["residual_final"])
+        except ValueError:
+            fail(f"non-integer readiness count in {wave}")
+
+        expected_plan, expected_effective, expected_canonical, expected_remaining = coverage[wave]
+        if (plan, effective, canonical) != (
+            expected_plan,
+            expected_effective,
+            expected_canonical,
+        ):
+            fail(
+                f"{wave} diverges from canonical coverage: "
+                f"readiness={(plan, effective, canonical)}, "
+                f"coverage={(expected_plan, expected_effective, expected_canonical)}"
+            )
+        if active + final != expected_remaining:
+            fail(
+                f"{wave} residual mismatch: readiness={active + final}, "
+                f"coverage={expected_remaining}"
+            )
+        if retained_by_wave.get(wave, 0) != active + final:
+            fail(
+                f"{wave} retained-register mismatch: register={retained_by_wave.get(wave, 0)}, "
+                f"readiness={active + final}"
+            )
+
+        if expected_remaining == 0 and status == "PREFLIGHT_REQUIRED_WITH_EXCLUSIONS":
+            fail(f"{wave} declares exclusions but has zero residual")
+        if expected_remaining > 0 and status != "PREFLIGHT_REQUIRED_WITH_EXCLUSIONS":
+            fail(f"{wave} has residual identities but does not declare exclusions")
+
+        totals["plan"] += plan
+        totals["effective"] += effective
+        totals["canonical"] += canonical
+        active_total += active
+        final_total += final
+
+    w5 = next(row for row in rows if row["wave"] == "W5")
+    if w5["ftrl_status"] != "REFERENCE_FULL_VALIDATION":
+        fail("W5 must remain the reference full-validation cohort in schema 0.1")
+
+    if (totals["plan"], totals["effective"], totals["canonical"]) != (542, 524, 492):
+        fail(f"unexpected U1 totals: {dict(totals)}")
+    if (active_total, final_total) != (13, 5):
+        fail(f"unexpected residual lifecycle: active={active_total}, final={final_total}")
+    if lifecycle != Counter({"active_retention": 13, "final_exception": 5}):
+        fail(f"retained-source lifecycle changed: {dict(lifecycle)}")
+
+    print("LTMD FTRL U1 readiness matrix: OK")
+    print("U1: plan=542 effective=524 canonical=492 residual=18")
+    print("Residual lifecycle: active=13 final=5")
+    print("W5 remains REFERENCE_FULL_VALIDATION")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Objetivo

Formaliza una matriz de preparación FTRL para W1–W11 sin confundir cierre técnico con preparación OCR, validación textual o validez semántica.

## Cambios

- añade `docs/FTRL_U1_READINESS_MATRIX.md`;
- añade `data/derived/ltmd_u1_ftrl_readiness.csv` como capa machine-readable;
- añade `scripts/validate_ftrl_u1_readiness.py`, que cruza la matriz contra el tablero U1 y el registro de retenciones;
- añade CI específico para impedir deriva de cardinalidades y preservar artefactos text-free.

## Criterio científico

La preparación se define por **cohorte fuente-admitida**, no por ola completa. W5 permanece como cohorte metodológica de referencia mientras termina su corrida integral. Las 18 identidades fuera de cobertura efectiva permanecen explícitamente excluidas: 13 retenciones activas y 5 excepciones finales.

La matriz no promueve ninguna ola a `semantic_ready`, no publica OCR ni snippets y no altera el estado de las retenciones.

Refs #15.