### PR TITLE
FTRL: retirar control previo de ejecuciones futuras

### DIFF
--- a/data/research/ltmd_ftrl_w5_active_queries.csv
+++ b/data/research/ltmd_ftrl_w5_active_queries.csv
@@ -1,0 +1,3 @@
+query_id,expression,regex,variant_group,primary_term,control_term,interpretive_scope,verification_rule,absence_rule
+W5-MASONERIA,masoneria,,,masoneria,,retrieval,"Every candidate page must be checked against the source image before use as evidence.","Zero OCR/FTS hits are not evidence of historical absence; inspect coverage, OCR quality, variants, and source pages before making an absence claim."
+W5-MASONERIA-VARIANTS,"mason|masoneria|masonica|masonico|francmason",1,masoneria,masoneria,,retrieval_control,"Use only to diagnose OCR/orthographic sensitivity around the preregistered primary term. Inspect all candidates against source images.","Variant hits may expand manual review but do not replace the primary query or justify an absence claim."

--- a/docs/FTRL_QUERY_PROTOCOL_REVISION_2026-08-24.md
+++ b/docs/FTRL_QUERY_PROTOCOL_REVISION_2026-08-24.md
@@ -1,0 +1,28 @@
+# Revisión del protocolo de consultas FTRL — 24 de agosto de 2026
+
+## Alcance
+
+Esta nota registra una revisión prospectiva del conjunto de consultas FTRL después de la primera corrida integral validada de W5 Historia (`run 32743689286`). La revisión afecta únicamente las ejecuciones futuras y no modifica retrospectivamente la preregistración, los manifiestos ni la evidencia producida por aquella corrida.
+
+## Separación entre registro histórico y protocolo activo
+
+El archivo `data/research/ltmd_ftrl_w5_preregistered_queries.csv` se conserva sin cambios como parte del registro reproducible de la corrida integral ya ejecutada. No debe interpretarse como el conjunto activo para nuevos análisis.
+
+A partir de esta revisión, el conjunto activo de W5 es `data/research/ltmd_ftrl_w5_active_queries.csv`. El control positivo utilizado en la corrida histórica queda retirado de nuevas ejecuciones, comparaciones e interpretación. Su presencia en artefactos o registros anteriores constituye únicamente procedencia de una ejecución ya realizada.
+
+## Reglas de uso vigentes
+
+1. Las consultas activas producen candidatos de recuperación, no afirmaciones históricas.
+2. Todo candidato que vaya a utilizarse como evidencia debe verificarse contra la imagen fuente correspondiente.
+3. La sensibilidad a variantes ortográficas u OCR se utiliza como control de recuperación y no sustituye la consulta primaria.
+4. `zero_hits != demonstrated_absence`: una ausencia de coincidencias OCR/FTS exige revisar cobertura, calidad OCR, variantes y páginas fuente antes de cualquier inferencia.
+5. El texto OCR íntegro, los snippets y la base SQLite continúan como productos locales reconstruibles y no se publican por defecto.
+
+## Trazabilidad
+
+Esta revisión no invalida la corrida integral W5 ni su registro permanente. Mantiene explícitamente dos objetos distintos:
+
+- **preregistración histórica**: describe exactamente lo que se ejecutó y debe permanecer inmutable;
+- **protocolo activo**: describe lo que podrá ejecutarse en trabajos posteriores.
+
+La separación evita reescribir la historia del experimento y, al mismo tiempo, impide que un control retirado siga propagándose a análisis futuros.


### PR DESCRIPTION
Separa explícitamente el registro histórico de la corrida W5 del protocolo activo. Conserva inmutable la preregistración original y añade un conjunto activo para futuras ejecuciones sin el control positivo retirado. No reescribe resultados ni procedencia de la corrida 32743689286. Refs #15.