### PR TITLE
FTRL: preparar ejecución integral W1 Ciencias Naturales

### DIFF
--- a/.github/workflows/validate-ftrl-w1-full.yml
+++ b/.github/workflows/validate-ftrl-w1-full.yml
@@ -1,0 +1,137 @@
+name: Validate FTRL W1 full corpus
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ftrl-w1-full
+  cancel-in-progress: false
+
+jobs:
+  full-w1:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --version | head -n 1
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Execute complete source-admitted W1 FTRL
+        run: |
+          python scripts/run_ftrl_w1.py \
+            --full \
+            --workers 2 \
+            --output-dir local/ftrl
+
+      - name: Assert complete W1 corpus and index
+        run: |
+          python - <<'PY'
+          import csv
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path('local/ftrl/ltmd_u1_w1_full_run_manifest.json').read_text(encoding='utf-8'))
+          qc = json.loads(Path('local/ftrl/ltmd_u1_w1_full_qc_summary.json').read_text(encoding='utf-8'))
+          preflight = json.loads(Path('local/ftrl/ltmd_u1_w1_preflight.json').read_text(encoding='utf-8'))
+          with Path('local/ftrl/ltmd_u1_w1_processing_inventory.csv').open(encoding='utf-8', newline='') as fh:
+              processing = list(csv.DictReader(fh))
+
+          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.2'
+          assert preflight['status'] == 'ready'
+          assert preflight['historical_identities'] == 37
+          assert preflight['canonical_processing_objects'] == 33
+          assert preflight['byte_identical_aliases'] == 4
+          assert preflight['source_admitted_jpegs'] == 5926
+          assert preflight['internal_unserved_positions'] == 3
+
+          canonical = [r for r in processing if r['is_canonical_processing_object'] == '1']
+          historical = [r for r in processing if r['technical_identity_covered'] == '1']
+          assert len(processing) == 37
+          assert len(historical) == 37
+          assert len(canonical) == 33
+          assert sum(int(r['direct_source_jpegs']) for r in canonical) == 5926
+          assert sum(int(r['persistent_unresolved_source_gaps']) for r in canonical) == 3
+
+          assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
+          assert manifest['status'] == 'validated'
+          assert manifest['corpus']['page_records'] == 5926
+          assert manifest['database']['page_rows'] == 5926
+          assert manifest['database']['fts_rows'] == 5926
+          assert manifest['database']['sqlite_integrity'] == 'ok'
+          assert manifest['corpus']['waves'] == ['W1']
+          assert manifest['corpus']['canonical_viewers'] == 33
+          assert manifest['database']['historical_identities'] == 37
+          assert manifest['corpus']['source_byte_size_missing_pages'] == 0
+
+          vcs = manifest['execution']['vcs']
+          ci = manifest['execution']['ci']
+          assert vcs['system'] == 'git'
+          assert len(vcs['commit']) == 40
+          assert vcs['dirty_tracked_worktree'] is False
+          assert ci['provider'] == 'github-actions'
+          assert ci['repository'] == 'fersandovalgtz/libro-texto-mexicano-digital'
+          assert ci['run_id']
+          assert ci['sha'] == vcs['commit']
+
+          assert qc['schema_version'] == 'LTMD_FTRL_QC_0.1'
+          assert qc['page_records'] == 5926
+          assert qc['rights_note'].startswith('Text-free OCR quality-control summary')
+
+          forbidden = {'ocr_text_raw', 'search_text', 'snippet'}
+          def walk(value):
+              if isinstance(value, dict):
+                  assert not (forbidden & set(value)), forbidden & set(value)
+                  for child in value.values():
+                      walk(child)
+              elif isinstance(value, list):
+                  for child in value:
+                      walk(child)
+          walk(manifest)
+          walk(qc)
+          walk(preflight)
+          print('Complete W1 FTRL corpus validated with text-free public evidence')
+          PY
+
+      - name: Prove restricted outputs remain non-publishable
+        run: |
+          test -f local/ftrl/ltmd_u1_w1_full_page_ocr.jsonl
+          test -f local/ftrl/ltmd_u1_w1_full_ocr_search.sqlite
+          test -f local/ftrl/ltmd_u1_w1_full_qc_queue.json
+          test -f local/ftrl/ltmd_u1_w1_full_run_manifest.json
+          test -f local/ftrl/ltmd_u1_w1_full_qc_summary.json
+          git status --short --untracked-files=all | tee local/git-status-w1.txt
+          for path in \
+            local/ftrl/ltmd_u1_w1_full_page_ocr.jsonl \
+            local/ftrl/ltmd_u1_w1_full_ocr_search.sqlite \
+            local/ftrl/ltmd_u1_w1_full_qc_queue.json; do
+            if ! git check-ignore -q "$path"; then
+              echo "Restricted output is not ignored: $path" >&2
+              exit 1
+            fi
+          done
+          echo 'Restricted W1 OCR, SQLite, and QC queue remain ignored: OK'
+
+      - name: Upload text-free evidence only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w1-full-text-free-evidence
+          path: |
+            local/ftrl/ltmd_u1_w1_preflight.json
+            local/ftrl/ltmd_u1_w1_full_run_manifest.json
+            local/ftrl/ltmd_u1_w1_full_qc_summary.json
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/validate-ftrl-w1-runtime.yml
+++ b/.github/workflows/validate-ftrl-w1-runtime.yml
@@ -1,0 +1,134 @@
+name: Validate FTRL W1 runtime pilot
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/build_ftrl_w1_inputs.py'
+      - 'scripts/run_ftrl_w1.py'
+      - 'scripts/preflight_ftrl_w1.py'
+      - 'scripts/build_page_ocr_corpus.py'
+      - 'scripts/build_search_index.py'
+      - 'scripts/validate_ocr_corpus.py'
+      - 'scripts/summarize_ftrl_run.py'
+      - 'scripts/build_ftrl_qc_queue.py'
+      - 'data/catalog/ciencias_naturales_family_asset_readiness.csv'
+      - 'data/catalog/ciencias_naturales_pending_page_manifest.csv'
+      - 'data/expansion/cn46_page_manifest.csv'
+      - 'data/catalog/cn5_pilot_sha/**'
+      - '.github/workflows/validate-ftrl-w1-runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ftrl-w1-runtime-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-pilot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --version | head -n 1
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Execute real-source W1 pilot
+        run: |
+          python scripts/run_ftrl_w1.py \
+            --pages 12 \
+            --workers 1 \
+            --output-dir local/ftrl
+
+      - name: Assert exact pilot provenance
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path('local/ftrl/ltmd_u1_w1_pilot_12_run_manifest.json').read_text(encoding='utf-8'))
+          qc = json.loads(Path('local/ftrl/ltmd_u1_w1_pilot_12_qc_summary.json').read_text(encoding='utf-8'))
+          preflight = json.loads(Path('local/ftrl/ltmd_u1_w1_preflight.json').read_text(encoding='utf-8'))
+
+          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.2'
+          assert preflight['status'] == 'ready'
+          assert preflight['historical_identities'] == 37
+          assert preflight['canonical_processing_objects'] == 33
+          assert preflight['source_admitted_jpegs'] == 5926
+
+          assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
+          assert manifest['status'] == 'validated'
+          assert manifest['corpus']['page_records'] == 12
+          assert manifest['database']['page_rows'] == 12
+          assert manifest['database']['fts_rows'] == 12
+          assert manifest['database']['sqlite_integrity'] == 'ok'
+          assert manifest['corpus']['waves'] == ['W1']
+          assert manifest['corpus']['canonical_viewers'] == 1
+          assert manifest['database']['historical_identities'] == 1
+          assert manifest['corpus']['source_byte_size_missing_pages'] == 0
+
+          vcs = manifest['execution']['vcs']
+          ci = manifest['execution']['ci']
+          assert vcs['system'] == 'git'
+          assert len(vcs['commit']) == 40
+          assert vcs['dirty_tracked_worktree'] is False
+          assert ci['provider'] == 'github-actions'
+          assert ci['repository'] == 'fersandovalgtz/libro-texto-mexicano-digital'
+          assert ci['run_id']
+          assert ci['sha'] == vcs['commit']
+
+          assert qc['schema_version'] == 'LTMD_FTRL_QC_0.1'
+          assert qc['page_records'] == 12
+          assert qc['rights_note'].startswith('Text-free OCR quality-control summary')
+
+          forbidden = {'ocr_text_raw', 'search_text', 'snippet'}
+          def walk(value):
+              if isinstance(value, dict):
+                  assert not (forbidden & set(value)), forbidden & set(value)
+                  for child in value.values():
+                      walk(child)
+              elif isinstance(value, list):
+                  for child in value:
+                      walk(child)
+          walk(manifest)
+          walk(qc)
+          walk(preflight)
+          print('W1 real-source pilot validated with text-free public evidence')
+          PY
+
+      - name: Prove restricted outputs remain local
+        run: |
+          test -f local/ftrl/ltmd_u1_w1_pilot_12_page_ocr.jsonl
+          test -f local/ftrl/ltmd_u1_w1_pilot_12_ocr_search.sqlite
+          test -f local/ftrl/ltmd_u1_w1_pilot_12_qc_queue.json
+          for path in \
+            local/ftrl/ltmd_u1_w1_pilot_12_page_ocr.jsonl \
+            local/ftrl/ltmd_u1_w1_pilot_12_ocr_search.sqlite \
+            local/ftrl/ltmd_u1_w1_pilot_12_qc_queue.json; do
+            git check-ignore -q "$path"
+          done
+          echo 'Restricted W1 pilot outputs remain ignored: OK'
+
+      - name: Upload text-free pilot evidence only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w1-runtime-pilot-text-free
+          path: |
+            local/ftrl/ltmd_u1_w1_preflight.json
+            local/ftrl/ltmd_u1_w1_pilot_12_run_manifest.json
+            local/ftrl/ltmd_u1_w1_pilot_12_qc_summary.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_1.md
+++ b/docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_1.md
@@ -1,0 +1,120 @@
+# Protocolo de ejecución integral FTRL W1 Ciencias Naturales
+
+Versión operativa: 0.1  
+Estado: preregistrado antes de la primera corrida integral W1  
+Alcance: LTMD-U1, W1 Ciencias Naturales
+
+## Propósito
+
+Este protocolo fija las condiciones de la primera ejecución integral de la Full-Text Research Layer (FTRL) sobre la cohorte fuente-admitida de W1 Ciencias Naturales. Su función es impedir que la cohorte, las cardinalidades, los criterios de completitud o las reglas de publicación se modifiquen después de observar el OCR completo.
+
+La corrida integral es una validación técnica del corpus reconstruible y del índice de búsqueda. No constituye verificación del texto OCR, validación semántica ni evidencia suficiente para sostener afirmaciones históricas, curriculares o discursivas.
+
+## Cohorte congelada
+
+La reconciliación documental vigente fija:
+
+- 37 identidades históricas técnicamente cubiertas;
+- 33 objetos canónicos de procesamiento;
+- 4 identidades 2018 representadas mediante aliases byte-a-byte verificados hacia sus pares 2019;
+- 5,926 JPEG fuente admitidos para procesamiento;
+- 3 posiciones internas declaradas pero persistentemente no servidas: una en `LTMD-CN3-G2008` y dos en `LTMD-CN4-G2008`;
+- 759 páginas de los cuatro objetos CN5 del piloto con anclaje SHA-256 versionado.
+
+Las cuatro relaciones 2018 → 2019 son relaciones técnicas de reutilización de bytes. No establecen por sí mismas identidad bibliográfica, igualdad editorial, equivalencia curricular ni continuidad semántica.
+
+La cifra de 5,926 páginas describe exclusivamente los activos fuente admitidos y no debe reinterpretarse como equivalencia con todas las posiciones nominales declaradas por los visores.
+
+## Normalización de procedencia
+
+W1 no parte de un único manifiesto histórico. Su procedencia está distribuida entre tres capas versionadas:
+
+1. `data/catalog/ciencias_naturales_pending_page_manifest.csv`, para activos auditados directamente y casos con huecos persistentes documentados;
+2. `data/expansion/cn46_page_manifest.csv`, para objetos CN4/CN6 ya auditados en la expansión técnica;
+3. `data/catalog/cn5_pilot_sha/`, para los cuatro objetos CN5 cuyo piloto quedó posteriormente anclado criptográficamente.
+
+`scripts/build_ftrl_w1_inputs.py` reconcilia esas capas en dos archivos derivados bajo `local/ftrl/`: un manifiesto de activos compatible con FTRL y un inventario de procesamiento compatible con el índice. La normalización es determinista, sin acceso de red y sin texto OCR. No sustituye a las capas documentales originales ni modifica su autoridad metodológica.
+
+## Ejecución
+
+La referencia ejecutable integral es:
+
+```bash
+python scripts/run_ftrl_w1.py \
+  --full \
+  --workers 2 \
+  --output-dir local/ftrl
+```
+
+El workflow `.github/workflows/validate-ftrl-w1-full.yml` reproduce esta ejecución en GitHub Actions con Python 3.12, Tesseract y el modelo español `spa`, y SQLite con FTS5.
+
+La paralelización en dos shards altera únicamente la planificación del procesamiento. No modifica la cohorte, los hashes esperados, la identidad de página, el orden de concatenación final ni las reglas de aceptación. Cada descarga sigue verificándose contra el SHA-256 versionado antes de OCR.
+
+## Gate previo obligatorio
+
+Antes de iniciar OCR, `scripts/preflight_ftrl_w1.py --require-cryptographic-ready` debe devolver un estado `ready` bajo `LTMD_FTRL_W1_PREFLIGHT_0.2` y confirmar, como mínimo:
+
+- 37 identidades históricas;
+- 33 objetos canónicos;
+- 4 aliases byte-a-byte;
+- 5,926 JPEG fuente admitidos;
+- 3 posiciones internas no servidas documentadas;
+- 4 objetos CN5 anclados;
+- 759 páginas CN5 con correspondencia de bytes respecto de la evidencia técnica previa;
+- cero objetos canónicos sin capa de procedencia criptográfica aceptada.
+
+Cualquier deriva bloquea la ejecución integral.
+
+## Gates de completitud
+
+Una corrida integral sólo podrá clasificarse como técnicamente validada si cumple simultáneamente:
+
+1. 5,926 registros de página FTRL;
+2. 5,926 filas en la tabla `pages` de SQLite;
+3. 5,926 filas en el índice FTS5;
+4. `PRAGMA integrity_check = ok`;
+5. 33 objetos canónicos con páginas OCR;
+6. 37 identidades históricas técnicamente representadas en la tabla de identidades;
+7. cero páginas procesadas con tamaño de fuente desconocido;
+8. commit Git exacto y contexto de GitHub Actions registrados en el manifiesto de corrida;
+9. manifiesto FTRL con estado `validated` y ola única `W1`;
+10. salida QC sin texto con cardinalidad de 5,926 páginas;
+11. OCR por página, SQLite y cola detallada de QC mantenidos fuera de publicación y cubiertos por `.gitignore`;
+12. artefactos públicos limitados a evidencia text-free: preflight, manifiesto agregado de corrida y resumen agregado de control de calidad.
+
+Una falla en cualquier gate mantiene la corrida en estado diagnóstico y prohíbe declarar W1 cerrado en FTRL.
+
+## Control de calidad OCR
+
+Después de construir el corpus, `scripts/build_ftrl_qc_queue.py` genera una cola diagnóstica local y un resumen agregado sin texto. Se conservan los umbrales preregistrados de FTRL 0.1 para páginas sin texto recuperable, confianza ausente, baja confianza y texto excepcionalmente corto.
+
+La cola sirve para priorizar revisión humana. Una página sin bandera no equivale a transcripción validada y una página con baja confianza no prueba, por sí sola, que el contenido OCR sea incorrecto.
+
+## Consultas e interpretación
+
+Esta primera corrida integral W1 no ejecuta consultas historiográficas preregistradas. El objetivo es demostrar reconstrucción técnica integral de la cohorte fuente-admitida y producir un mapa reproducible de calidad OCR antes de definir constructos analíticos.
+
+Se mantienen como reglas obligatorias:
+
+- `source_ready != text_verified`;
+- `ocr_available != text_verified`;
+- `corpus_ready != semantic_ready`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- un alias técnico no equivale a identidad bibliográfica;
+- una posición no servida no puede reinterpretarse como ausencia de contenido curricular;
+- toda página utilizada como evidencia sustantiva debe verificarse contra el activo fuente.
+
+## Evidencia pública esperada
+
+Una ejecución integral válida podrá publicar exclusivamente:
+
+- `ltmd_u1_w1_preflight.json`;
+- `ltmd_u1_w1_full_run_manifest.json`;
+- `ltmd_u1_w1_full_qc_summary.json`.
+
+Estos artefactos contienen cardinalidades, hashes, métricas agregadas y contexto de ejecución, pero excluyen el texto OCR, las imágenes fuente, snippets y el índice SQLite.
+
+## Criterio de avance
+
+Sólo después de una corrida integral válida se actualizará la hoja de ruta para pasar W1 de `cryptographic-ready` a `corpus_ready`/`ocr_available`. La etiqueta `semantic_ready` requerirá trabajo humano adicional y no puede inferirse de una ejecución técnica exitosa.

--- a/scripts/build_ftrl_w1_inputs.py
+++ b/scripts/build_ftrl_w1_inputs.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Build normalized, text-free FTRL inputs for LTMD-U1 W1 Ciencias Naturales.
+
+The W1 source-admitted cohort is already documented across three versioned
+provenance layers. This script reconciles those layers into the generic FTRL
+asset-manifest and processing-inventory schemas used by the OCR/FTS pipeline.
+It performs no network access and emits no OCR text.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from pathlib import Path
+
+READINESS = Path("data/catalog/ciencias_naturales_family_asset_readiness.csv")
+DIRECT_MANIFEST = Path("data/catalog/ciencias_naturales_pending_page_manifest.csv")
+CN46_MANIFEST = Path("data/expansion/cn46_page_manifest.csv")
+CN5_SHA_DIR = Path("data/catalog/cn5_pilot_sha")
+VERSION = "LTMD_U1_W1_FTRL_INPUTS_0.1"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+PILOT_BOOKS = {
+    "LTMD-CN5-G1972",
+    "LTMD-CN5-G1988",
+    "LTMD-CN5-G1993",
+    "LTMD-CN5-G2014",
+}
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def as_int(row: dict[str, str], key: str) -> int:
+    value = row.get(key, "")
+    if value == "":
+        raise AssertionError(f"missing integer field {key}: {row}")
+    return int(value)
+
+
+def source_url(viewer_key: str, source_image_index: int) -> str:
+    return (
+        "https://historico.conaliteg.gob.mx/c/"
+        f"{viewer_key}/{source_image_index:03d}.jpg"
+    )
+
+
+def normalized_asset_row(
+    *,
+    readiness: dict[str, str],
+    viewer_page: int,
+    source_image_index: int,
+    source_asset_url: str,
+    byte_size: int,
+    sha256: str,
+    source_layer: str,
+    http_status: str = "200",
+    content_type: str = "image/jpeg",
+) -> dict[str, str | int]:
+    if not SHA256_RE.fullmatch(sha256):
+        raise AssertionError(
+            f"invalid SHA-256 for {readiness['book_id']}:{source_image_index}"
+        )
+    if byte_size <= 0:
+        raise AssertionError(
+            f"non-positive byte size for {readiness['book_id']}:{source_image_index}"
+        )
+    return {
+        "audit_version": VERSION,
+        "book_id": readiness["book_id"],
+        "viewer_key": readiness["viewer_key"],
+        "catalog_generation": as_int(readiness, "catalog_generation"),
+        "grade_code": as_int(readiness, "grade"),
+        "title_core": "Ciencias Naturales",
+        "viewer_ui": "normalized_w1",
+        "ag_clave": readiness["viewer_key"],
+        "viewer_page": viewer_page,
+        "declared_positions": as_int(readiness, "viewer_positions_declared"),
+        "source_image_index": source_image_index,
+        "source_asset_url": source_asset_url,
+        "is_final_declared_position": int(
+            viewer_page == as_int(readiness, "viewer_positions_declared")
+        ),
+        "asset_status": "source_jpeg",
+        "probe_state": "versioned_sha256_provenance",
+        "http_status": http_status,
+        "content_type": content_type,
+        "byte_size": byte_size,
+        "sha256": sha256,
+        "attempts": "",
+        "error": "",
+        "source_layer": source_layer,
+    }
+
+
+def load_direct_rows(
+    readiness_by_id: dict[str, dict[str, str]], canonical: set[str]
+) -> dict[str, list[dict[str, str | int]]]:
+    selected = {
+        bid
+        for bid in canonical
+        if readiness_by_id[bid]["asset_strategy"]
+        in {"direct_sha256_manifest", "direct_manifest_plus_focused_gap_audit"}
+    }
+    out = {bid: [] for bid in selected}
+    for row in read_csv(DIRECT_MANIFEST):
+        bid = row["book_id"]
+        if bid not in selected or row["asset_status"] != "source_jpeg":
+            continue
+        r = readiness_by_id[bid]
+        out[bid].append(
+            normalized_asset_row(
+                readiness=r,
+                viewer_page=as_int(row, "viewer_page"),
+                source_image_index=as_int(row, "source_image_index"),
+                source_asset_url=row["source_asset_url"],
+                byte_size=as_int(row, "byte_size"),
+                sha256=row["sha256"],
+                source_layer="ciencias_naturales_pending_page_manifest",
+                http_status=row.get("http_status", "200"),
+                content_type=row.get("content_type", "image/jpeg"),
+            )
+        )
+    return out
+
+
+def load_cn46_rows(
+    readiness_by_id: dict[str, dict[str, str]], canonical: set[str]
+) -> dict[str, list[dict[str, str | int]]]:
+    selected = {
+        bid
+        for bid in canonical
+        if readiness_by_id[bid]["asset_strategy"] == "existing_pilot_or_cn46_manifest"
+        and bid not in PILOT_BOOKS
+    }
+    out = {bid: [] for bid in selected}
+    for row in read_csv(CN46_MANIFEST):
+        bid = row["book_id"]
+        if bid not in selected or row["asset_status"] != "source_jpeg":
+            continue
+        r = readiness_by_id[bid]
+        out[bid].append(
+            normalized_asset_row(
+                readiness=r,
+                viewer_page=as_int(row, "viewer_page"),
+                source_image_index=as_int(row, "source_image_index"),
+                source_asset_url=row["source_asset_url"],
+                byte_size=as_int(row, "byte_size"),
+                sha256=row["sha256"],
+                source_layer="cn46_page_manifest",
+                http_status=row.get("http_status", "200"),
+                content_type=row.get("content_type", "image/jpeg"),
+            )
+        )
+    return out
+
+
+def load_cn5_anchor_rows(
+    readiness_by_id: dict[str, dict[str, str]], canonical: set[str]
+) -> dict[str, list[dict[str, str | int]]]:
+    selected = PILOT_BOOKS & canonical
+    if selected != PILOT_BOOKS:
+        raise AssertionError(f"pilot canonical set drifted: {sorted(selected)}")
+    out = {bid: [] for bid in selected}
+    files = sorted(CN5_SHA_DIR.glob("*.csv"))
+    if len(files) != 9:
+        raise AssertionError(f"expected 9 compact CN5 anchor files, found {len(files)}")
+    for path in files:
+        match = re.match(r"^(LTMD-CN5-G\d{4})-part\d+\.csv$", path.name)
+        if not match:
+            raise AssertionError(f"unexpected CN5 anchor filename: {path.name}")
+        bid = match.group(1)
+        if bid not in selected:
+            raise AssertionError(f"unexpected CN5 anchor book: {bid}")
+        r = readiness_by_id[bid]
+        for row in read_csv(path):
+            index = as_int(row, "source_image_index")
+            out[bid].append(
+                normalized_asset_row(
+                    readiness=r,
+                    viewer_page=as_int(row, "viewer_page"),
+                    source_image_index=index,
+                    source_asset_url=source_url(r["viewer_key"], index),
+                    byte_size=as_int(row, "byte_size"),
+                    sha256=row["sha256"],
+                    source_layer="cn5_pilot_sha_anchor",
+                )
+            )
+    return out
+
+
+def build_processing_rows(
+    readiness: list[dict[str, str]],
+) -> list[dict[str, str | int]]:
+    by_id = {row["book_id"]: row for row in readiness}
+    rows: list[dict[str, str | int]] = []
+    for row in readiness:
+        alias_target = row["alias_to_book_id"]
+        canonical = by_id[alias_target] if alias_target else row
+        is_canonical = int(not alias_target)
+        if alias_target:
+            mode = "byte_identical_alias"
+            state = "alias_to_versioned_canonical_assets"
+        elif row["asset_readiness"] == "partial_internal_unserved":
+            mode = "source_admitted_canonical_with_documented_gaps"
+            state = "partial_declared_positions_source_admitted"
+        elif row["book_id"] in PILOT_BOOKS:
+            mode = "versioned_sha256_anchor_canonical"
+            state = "full_source_anchor"
+        else:
+            mode = "direct_canonical"
+            state = "full_direct_or_audited_source"
+        rows.append(
+            {
+                "processing_version": VERSION,
+                "book_id": row["book_id"],
+                "viewer_key": row["viewer_key"],
+                "catalog_generation": as_int(row, "catalog_generation"),
+                "grade_code": as_int(row, "grade"),
+                "title_core": "Ciencias Naturales",
+                "original_source_state": state,
+                "processing_mode": mode,
+                "canonical_processing_viewer_key": canonical["viewer_key"],
+                "technical_identity_covered": 1,
+                "is_canonical_processing_object": is_canonical,
+                "declared_positions": as_int(row, "viewer_positions_declared"),
+                "direct_source_jpegs": as_int(row, "resolved_source_assets") if is_canonical else 0,
+                "terminal_synthetic_candidates_original_route": as_int(row, "terminal_synthetic"),
+                "persistent_unresolved_source_gaps": as_int(row, "internal_unserved_positions"),
+                "evidence_basis": row["asset_strategy"],
+                "interpretive_limit": (
+                    "Operational processing topology only; source-admitted coverage, aliases, "
+                    "and unserved positions do not establish bibliographic identity, semantic "
+                    "equivalence, or verified OCR text."
+                ),
+            }
+        )
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, str | int]]) -> None:
+    if not rows:
+        raise AssertionError(f"refusing to write empty CSV: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--asset-output",
+        type=Path,
+        default=Path("local/ftrl/ltmd_u1_w1_asset_manifest.csv"),
+    )
+    parser.add_argument(
+        "--processing-output",
+        type=Path,
+        default=Path("local/ftrl/ltmd_u1_w1_processing_inventory.csv"),
+    )
+    args = parser.parse_args()
+
+    readiness = read_csv(READINESS)
+    by_id = {row["book_id"]: row for row in readiness}
+    if len(by_id) != len(readiness):
+        raise AssertionError("duplicate W1 book_id in readiness")
+    aliases = {bid: row["alias_to_book_id"] for bid, row in by_id.items() if row["alias_to_book_id"]}
+    canonical = set(by_id) - set(aliases)
+
+    assert len(readiness) == 37, len(readiness)
+    assert len(aliases) == 4, len(aliases)
+    assert len(canonical) == 33, len(canonical)
+    for alias, target in aliases.items():
+        assert target in canonical, f"invalid alias target {alias} -> {target}"
+
+    layers: dict[str, list[dict[str, str | int]]] = {}
+    for source in (
+        load_direct_rows(by_id, canonical),
+        load_cn46_rows(by_id, canonical),
+        load_cn5_anchor_rows(by_id, canonical),
+    ):
+        overlap = set(layers) & set(source)
+        if overlap:
+            raise AssertionError(f"canonical objects assigned to multiple layers: {sorted(overlap)}")
+        layers.update(source)
+
+    if set(layers) != canonical:
+        missing = sorted(canonical - set(layers))
+        extra = sorted(set(layers) - canonical)
+        raise AssertionError(f"W1 layer reconciliation mismatch missing={missing} extra={extra}")
+
+    assets: list[dict[str, str | int]] = []
+    for bid in sorted(canonical):
+        rows = layers[bid]
+        expected = as_int(by_id[bid], "resolved_source_assets")
+        if len(rows) != expected:
+            raise AssertionError(f"source page mismatch for {bid}: {len(rows)} != {expected}")
+        keys = {(str(r["viewer_key"]), int(r["source_image_index"])) for r in rows}
+        if len(keys) != len(rows):
+            raise AssertionError(f"duplicate source page identity within {bid}")
+        assets.extend(rows)
+
+    assets.sort(
+        key=lambda r: (
+            int(r["catalog_generation"]),
+            int(r["grade_code"]),
+            str(r["viewer_key"]),
+            int(r["source_image_index"]),
+        )
+    )
+    page_keys = {(str(r["viewer_key"]), int(r["source_image_index"])) for r in assets}
+    assert len(page_keys) == len(assets), "duplicate normalized W1 page identity"
+    assert len(assets) == 5926, len(assets)
+    assert all(int(r["byte_size"]) > 0 for r in assets)
+    assert all(SHA256_RE.fullmatch(str(r["sha256"])) for r in assets)
+
+    processing = build_processing_rows(readiness)
+    assert len(processing) == 37
+    assert sum(int(r["is_canonical_processing_object"]) for r in processing) == 33
+    assert sum(int(r["persistent_unresolved_source_gaps"]) for r in processing if int(r["is_canonical_processing_object"])) == 3
+    assert sum(int(r["direct_source_jpegs"]) for r in processing) == 5926
+
+    write_csv(args.asset_output, assets)
+    write_csv(args.processing_output, processing)
+
+    layer_counts: dict[str, int] = {}
+    for row in assets:
+        layer = str(row["source_layer"])
+        layer_counts[layer] = layer_counts.get(layer, 0) + 1
+    print(
+        {
+            "schema": VERSION,
+            "historical_identities": len(processing),
+            "canonical_processing_objects": 33,
+            "source_admitted_pages": len(assets),
+            "documented_internal_unserved_positions": 3,
+            "source_layers": dict(sorted(layer_counts.items())),
+            "asset_output": str(args.asset_output),
+            "processing_output": str(args.processing_output),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w1.py
+++ b/scripts/run_ftrl_w1.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Run LTMD-U1 W1 Ciencias Naturales through the FTRL pipeline."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None:
+        raise SystemExit("Tesseract is required but was not found on PATH")
+    langs = subprocess.run(
+        ["tesseract", "--list-langs"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.splitlines()
+    if "spa" not in {lang.strip() for lang in langs}:
+        raise SystemExit("Tesseract Spanish language data ('spa') is required")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    except sqlite3.OperationalError as exc:
+        raise SystemExit("SQLite FTS5 support is required") from exc
+    finally:
+        conn.close()
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_rows(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows:
+        raise SystemExit(f"cannot write empty shard: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def balanced_shards(rows: list[dict[str, str]], count: int) -> list[list[dict[str, str]]]:
+    count = max(1, min(count, len(rows)))
+    base, remainder = divmod(len(rows), count)
+    shards: list[list[dict[str, str]]] = []
+    start = 0
+    for index in range(count):
+        size = base + (1 if index < remainder else 0)
+        shards.append(rows[start : start + size])
+        start += size
+    assert sum(len(shard) for shard in shards) == len(rows)
+    return shards
+
+
+def run_ocr_shards(
+    *,
+    rows: list[dict[str, str]],
+    processing_inventory: Path,
+    output_dir: Path,
+    workers: int,
+) -> Path:
+    shard_dir = output_dir / "w1" / "shards"
+    cache_root = output_dir / "w1" / "assets"
+    shards = balanced_shards(rows, workers)
+    processes: list[tuple[int, subprocess.Popen]] = []
+    outputs: list[Path] = []
+
+    for index, shard_rows in enumerate(shards):
+        manifest = shard_dir / f"asset_manifest_{index:02d}.csv"
+        output = shard_dir / f"page_ocr_{index:02d}.jsonl"
+        cache = cache_root / f"shard_{index:02d}"
+        write_rows(manifest, shard_rows)
+        outputs.append(output)
+        command = [
+            sys.executable,
+            "scripts/build_page_ocr_corpus.py",
+            "--asset-manifest",
+            str(manifest),
+            "--processing-inventory",
+            str(processing_inventory),
+            "--wave",
+            "W1",
+            "--output",
+            str(output),
+            "--cache-dir",
+            str(cache),
+            "--resume",
+        ]
+        print("+", " ".join(command), flush=True)
+        processes.append((index, subprocess.Popen(command)))
+
+    failed: list[tuple[int, int]] = []
+    for index, process in processes:
+        code = process.wait()
+        if code:
+            failed.append((index, code))
+    if failed:
+        raise SystemExit(f"W1 OCR shard failure(s): {failed}")
+
+    combined = output_dir / "ltmd_u1_w1_full_page_ocr.jsonl"
+    temp = combined.with_name(combined.name + ".tmp")
+    page_ids: set[str] = set()
+    count = 0
+    with temp.open("w", encoding="utf-8", newline="\n") as out:
+        for path in outputs:
+            with path.open(encoding="utf-8") as fh:
+                for line in fh:
+                    if not line.strip():
+                        continue
+                    record = json.loads(line)
+                    page_id = str(record["page_id"])
+                    if page_id in page_ids:
+                        raise SystemExit(f"duplicate OCR page_id across shards: {page_id}")
+                    page_ids.add(page_id)
+                    out.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+                    count += 1
+    temp.replace(combined)
+    if count != len(rows):
+        raise SystemExit(f"combined OCR cardinality mismatch: {count} != {len(rows)}")
+    return combined
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--full", action="store_true")
+    parser.add_argument("--pages", type=int, default=12)
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--output-dir", type=Path, default=Path("local/ftrl"))
+    args = parser.parse_args()
+
+    if args.pages < 1:
+        raise SystemExit("--pages must be >= 1")
+    if args.workers < 1:
+        raise SystemExit("--workers must be >= 1")
+    require_environment()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    preflight = args.output_dir / "ltmd_u1_w1_preflight.json"
+    run(
+        [
+            sys.executable,
+            "scripts/preflight_ftrl_w1.py",
+            "--require-cryptographic-ready",
+            "--output",
+            str(preflight),
+        ]
+    )
+
+    asset_manifest = args.output_dir / "ltmd_u1_w1_asset_manifest.csv"
+    processing_inventory = args.output_dir / "ltmd_u1_w1_processing_inventory.csv"
+    run(
+        [
+            sys.executable,
+            "scripts/build_ftrl_w1_inputs.py",
+            "--asset-output",
+            str(asset_manifest),
+            "--processing-output",
+            str(processing_inventory),
+        ]
+    )
+
+    rows = read_rows(asset_manifest)
+    if len(rows) != 5926:
+        raise SystemExit(f"normalized W1 asset cardinality drifted: {len(rows)}")
+    if not args.full:
+        rows = rows[: args.pages]
+        label = f"pilot_{len(rows)}"
+        pilot_manifest = args.output_dir / f"ltmd_u1_w1_{label}_asset_manifest.csv"
+        write_rows(pilot_manifest, rows)
+        jsonl = args.output_dir / f"ltmd_u1_w1_{label}_page_ocr.jsonl"
+        run(
+            [
+                sys.executable,
+                "scripts/build_page_ocr_corpus.py",
+                "--asset-manifest",
+                str(pilot_manifest),
+                "--processing-inventory",
+                str(processing_inventory),
+                "--wave",
+                "W1",
+                "--output",
+                str(jsonl),
+                "--cache-dir",
+                str(args.output_dir / "w1" / "assets" / label),
+                "--resume",
+            ]
+        )
+    else:
+        label = "full"
+        jsonl = run_ocr_shards(
+            rows=rows,
+            processing_inventory=processing_inventory,
+            output_dir=args.output_dir,
+            workers=args.workers,
+        )
+
+    db = args.output_dir / f"ltmd_u1_w1_{label}_ocr_search.sqlite"
+    run_manifest = args.output_dir / f"ltmd_u1_w1_{label}_run_manifest.json"
+    qc_queue = args.output_dir / f"ltmd_u1_w1_{label}_qc_queue.json"
+    qc_summary = args.output_dir / f"ltmd_u1_w1_{label}_qc_summary.json"
+
+    run(
+        [
+            sys.executable,
+            "scripts/build_search_index.py",
+            "--input",
+            str(jsonl),
+            "--processing-inventory",
+            str(processing_inventory),
+            "--output",
+            str(db),
+        ]
+    )
+    run(
+        [
+            sys.executable,
+            "scripts/validate_ocr_corpus.py",
+            "--input",
+            str(jsonl),
+            "--db",
+            str(db),
+        ]
+    )
+    run(
+        [
+            sys.executable,
+            "scripts/summarize_ftrl_run.py",
+            "--input",
+            str(jsonl),
+            "--db",
+            str(db),
+            "--asset-manifest",
+            str(asset_manifest),
+            "--processing-inventory",
+            str(processing_inventory),
+            "--label",
+            label,
+            "--output",
+            str(run_manifest),
+        ]
+    )
+    run(
+        [
+            sys.executable,
+            "scripts/build_ftrl_qc_queue.py",
+            "--input",
+            str(jsonl),
+            "--queue-output",
+            str(qc_queue),
+            "--summary-output",
+            str(qc_summary),
+        ]
+    )
+
+    print(f"FTRL W1 {label} ready: {db}")
+    print(f"Run provenance manifest: {run_manifest}")
+    print(f"Text-free QC summary: {qc_summary}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w1.py
+++ b/scripts/run_ftrl_w1.py
@@ -180,6 +180,7 @@ def main() -> None:
         label = f"pilot_{len(rows)}"
         pilot_manifest = args.output_dir / f"ltmd_u1_w1_{label}_asset_manifest.csv"
         write_rows(pilot_manifest, rows)
+        provenance_asset_manifest = pilot_manifest
         jsonl = args.output_dir / f"ltmd_u1_w1_{label}_page_ocr.jsonl"
         run(
             [
@@ -200,6 +201,7 @@ def main() -> None:
         )
     else:
         label = "full"
+        provenance_asset_manifest = asset_manifest
         jsonl = run_ocr_shards(
             rows=rows,
             processing_inventory=processing_inventory,
@@ -243,7 +245,7 @@ def main() -> None:
             "--db",
             str(db),
             "--asset-manifest",
-            str(asset_manifest),
+            str(provenance_asset_manifest),
             "--processing-inventory",
             str(processing_inventory),
             "--label",


### PR DESCRIPTION
## Propósito

Prepara la primera ejecución integral FTRL de LTMD-U1 W1 Ciencias Naturales sin alterar las capas documentales fuente ni publicar OCR reconstruido.

## Cambios

- normaliza de forma determinista las tres capas versionadas de procedencia W1 a los esquemas genéricos FTRL;
- preserva 37 identidades históricas, 33 objetos canónicos, 4 aliases byte-a-byte y 5,926 JPEG fuente admitidos;
- incorpora un runner W1 con piloto real y ejecución integral paralelizada en dos shards;
- añade un gate de integración de 12 páginas fuente reales para PR;
- añade un workflow integral manual con cardinalidades fail-closed, SQLite FTS5, manifiesto de ejecución y QC text-free;
- congela el protocolo de ejecución antes de observar el OCR integral.

## Límites metodológicos

La corrida técnica no implica verificación OCR ni `semantic_ready`. Los 3 huecos internos documentados en 2008 permanecen explícitos y fuera de la cohorte de páginas fuente admitidas. Los aliases 2018→2019 son relaciones técnicas de bytes, no identidad bibliográfica.

## Publicación y derechos

El OCR por página, SQLite y la cola detallada de QC permanecen bajo `local/` y fuera de publicación. Los workflows sólo cargan evidencia text-free: preflight, manifiesto agregado y resumen agregado de QC.

Refs #15.