### PR TITLE
FTRL: activar primera corrida integral W1

### DIFF
--- a/.github/workflows/validate-ftrl-w1-full.yml
+++ b/.github/workflows/validate-ftrl-w1-full.yml
@@ -2,6 +2,10 @@ name: Validate FTRL W1 full corpus
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w1_full_run_stamp.json'
 
 permissions:
   contents: read

--- a/data/research/ltmd_u1_w1_full_run_stamp.json
+++ b/data/research/ltmd_u1_w1_full_run_stamp.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": "LTMD_FTRL_W1_FULL_ACTIVATION_0.1",
+  "wave": "W1",
+  "domain": "Ciencias Naturales",
+  "activation_date": "2026-08-24",
+  "protocol": "docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_1.md",
+  "prepared_by_commit": "90fb4a96ba3a8972a5b9838e27c8f182694c79bb",
+  "execution_scope": "source-admitted canonical cohort",
+  "expected_historical_identities": 37,
+  "expected_canonical_processing_objects": 33,
+  "expected_byte_identical_aliases": 4,
+  "expected_source_admitted_pages": 5926,
+  "documented_internal_unserved_positions": 3,
+  "workers": 2,
+  "publication_policy": "text-free evidence only",
+  "interpretive_limit": "Technical activation only; does not establish OCR verification or semantic readiness."
+}


### PR DESCRIPTION
## Propósito

Activa una sola ejecución integral auditada de W1 Ciencias Naturales después de que el PR #34 y su piloto real de 12 páginas pasaron los gates científicos y FTRL.

## Mecanismo

El workflow integral conserva `workflow_dispatch` y añade un disparador acotado exclusivamente al cambio de `data/research/ltmd_u1_w1_full_run_stamp.json` sobre `main`. El sello fija la cohorte esperada: 37 identidades históricas, 33 objetos canónicos, 4 aliases, 5,926 páginas fuente admitidas y 3 posiciones internas no servidas documentadas.

La ejecución sigue publicando únicamente evidencia text-free; OCR, SQLite y cola detallada de QC permanecen bajo `local/`.

Refs #15 y #34.