### PR TITLE
FTRL: exigir alcance exhaustivo de los 542 libros U1

### DIFF
--- a/.github/workflows/validate-ftrl-u1-exhaustive-scope.yml
+++ b/.github/workflows/validate-ftrl-u1-exhaustive-scope.yml
@@ -1,0 +1,83 @@
+name: Validate exhaustive FTRL-U1 scope
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'docs/FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md'
+      - 'docs/FTRL_U1_SCALING_ROADMAP_0_1.md'
+      - 'data/research/ltmd_u1_exhaustive_scope_contract.json'
+      - 'data/catalog/ltmd_u1_coverage.csv'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - 'scripts/validate_ftrl_u1_exhaustive_scope.py'
+      - '.github/workflows/validate-ftrl-u1-exhaustive-scope.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  exhaustive-scope:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate exhaustive 542-identity denominator
+        run: |
+          python scripts/validate_ftrl_u1_exhaustive_scope.py \
+            --output local/ftrl/ltmd_u1_exhaustive_scope_validation.json
+
+      - name: Assert current exhaustive disposition and open blockers
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          p = Path('local/ftrl/ltmd_u1_exhaustive_scope_validation.json')
+          d = json.loads(p.read_text(encoding='utf-8'))
+          assert d['schema_version'] == 'LTMD_FTRL_U1_EXHAUSTIVE_SCOPE_0.2'
+          assert d['status'] == 'scope_validated'
+          assert d['universe_identities'] == 542
+          assert d['identity_dispositions'] == {
+              'required_ftrl_processing': 524,
+              'active_retention': 13,
+              'final_exception': 5,
+          }
+          assert sum(d['wave_denominators'].values()) == 542
+          assert d['all_identities_have_disposition'] is True
+          assert d['global_closure_ready'] is False
+          assert d['global_closure_blockers']['active_retentions'] == 13
+          raw = p.read_text(encoding='utf-8').lower()
+          for forbidden in ('ocr_text_raw', 'search_text', 'snippet'):
+              assert forbidden not in raw
+          print('Exhaustive FTRL-U1 scope validated: 542/542 identities remain in denominator')
+          PY
+
+      - name: Prove global closure fails while active retentions remain
+        run: |
+          set +e
+          python scripts/validate_ftrl_u1_exhaustive_scope.py \
+            --require-global-closure > /tmp/exhaustive-closure.log 2>&1
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
+            echo 'ERROR: global exhaustive closure passed with active retentions' >&2
+            exit 1
+          fi
+          grep -q 'not globally exhaustive yet: 13 active retention' /tmp/exhaustive-closure.log
+          echo 'Fail-closed global completion gate behaved as expected'
+
+      - name: Upload text-free scope evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-exhaustive-scope-text-free
+          path: local/ftrl/ltmd_u1_exhaustive_scope_validation.json
+          if-no-files-found: error
+          retention-days: 30

--- a/data/research/ltmd_u1_exhaustive_scope_contract.json
+++ b/data/research/ltmd_u1_exhaustive_scope_contract.json
@@ -6,6 +6,20 @@
   "retained_source_register": "data/catalog/ltmd_u1_retained_source_register.csv",
   "governing_protocol": "docs/FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md",
   "identity_key": "viewer_key",
+  "wave_assignment_basis": "operational_domain",
+  "domain_to_wave": {
+    "ciencias_naturales": "W1",
+    "matematicas": "W2",
+    "espanol_lengua": "W3",
+    "ciencias_sociales": "W4",
+    "historia": "W5",
+    "geografia_atlas": "W6",
+    "civica_etica": "W7",
+    "artes": "W8",
+    "educacion_fisica": "W9",
+    "integrados_multiarea": "W10",
+    "otros_no_clasificados": "W11"
+  },
   "expected_universe_identities": 542,
   "expected_effective_technical_coverage": 524,
   "expected_active_retentions": 13,
@@ -41,6 +55,7 @@
   "aliases_remain_distinct_historical_identities": true,
   "canonical_processing_may_deduplicate_demonstrated_identical_bytes": true,
   "source_admitted_cohort_may_not_replace_project_denominator": true,
+  "queue_labels_are_not_wave_identity": true,
   "interpretive_limits": [
     "corpus_ready != semantic_ready",
     "ocr_available != text_verified",

--- a/data/research/ltmd_u1_exhaustive_scope_contract.json
+++ b/data/research/ltmd_u1_exhaustive_scope_contract.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "LTMD_FTRL_U1_EXHAUSTIVE_SCOPE_0.2",
+  "snapshot": "LTMD-U1",
+  "snapshot_date": "2026-08-24",
+  "master_inventory": "data/catalog/ltmd_u1_coverage.csv",
+  "retained_source_register": "data/catalog/ltmd_u1_retained_source_register.csv",
+  "governing_protocol": "docs/FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md",
+  "identity_key": "viewer_key",
+  "expected_universe_identities": 542,
+  "expected_effective_technical_coverage": 524,
+  "expected_active_retentions": 13,
+  "expected_final_exceptions": 5,
+  "expected_residual_identities": 18,
+  "expected_wave_denominators": {
+    "W1": 40,
+    "W2": 64,
+    "W3": 130,
+    "W4": 14,
+    "W5": 18,
+    "W6": 42,
+    "W7": 30,
+    "W8": 20,
+    "W9": 4,
+    "W10": 69,
+    "W11": 111
+  },
+  "expected_retained_by_wave": {
+    "W2": 4,
+    "W7": 5,
+    "W8": 4,
+    "W10": 1,
+    "W11": 4
+  },
+  "allowed_identity_dispositions": [
+    "required_ftrl_processing",
+    "active_retention",
+    "final_exception"
+  ],
+  "global_closure_requires_active_retentions": 0,
+  "final_exceptions_remain_in_denominator": true,
+  "aliases_remain_distinct_historical_identities": true,
+  "canonical_processing_may_deduplicate_demonstrated_identical_bytes": true,
+  "source_admitted_cohort_may_not_replace_project_denominator": true,
+  "interpretive_limits": [
+    "corpus_ready != semantic_ready",
+    "ocr_available != text_verified",
+    "search_hit != historical_claim",
+    "zero_hits != demonstrated_absence",
+    "final_exception != source_resolved"
+  ]
+}

--- a/docs/FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md
+++ b/docs/FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md
@@ -1,0 +1,156 @@
+# Protocolo exhaustivo FTRL LTMD-U1 — 0.2
+
+**Fecha:** 24 de agosto de 2026  
+**Estado:** normativo para el escalamiento FTRL de LTMD-U1  
+**Universo congelado:** 542 identidades documentales (`viewer_key`) censadas en `data/catalog/ltmd_u1_coverage.csv`  
+**Sustituye:** el criterio de cierre por cohorte fuente-admitida de `FTRL_U1_SCALING_ROADMAP_0_1.md`
+
+## 1. Regla rectora
+
+FTRL-U1 se ejecutará de manera exhaustiva sobre el universo completo de LTMD-U1. La unidad de exhaustividad es la **identidad documental histórica**, no solamente el objeto canónico con fuente disponible ni la ola que resulte más sencilla de procesar.
+
+> **Las 542 identidades deben permanecer en el denominador, recibir una disposición técnica explícita y auditable y ser recorridas por el protocolo. Ninguna identidad puede desaparecer por ausencia de fuente, alias, retención, excepción, materia, año, calidad OCR o conveniencia operativa.**
+
+El procesamiento puede evitar duplicación de bytes cuando existe una relación criptográfica/documental demostrada, pero nunca puede borrar la identidad histórica que representa esos bytes.
+
+## 2. Dos sentidos de “procesar todos los libros”
+
+El mandato exhaustivo tiene dos capas simultáneas:
+
+1. **Exhaustividad documental 542/542.** Cada `viewer_key` del universo maestro debe terminar con un estado FTRL explícito.
+2. **Exhaustividad computacional de fuente.** Toda identidad con representación fuente admisible debe quedar cubierta por un objeto canónico procesado; todas sus páginas fuente admitidas deben atravesar verificación SHA-256, OCR, validación de corpus, indexación FTS5, procedencia y control de calidad.
+
+Cuando dos o más identidades sean byte-exactas o estén cubiertas por una relación técnica demostrada, el OCR puede ejecutarse una sola vez sobre el objeto canónico. Las identidades relacionadas deben conservarse en el índice de identidades y en los conteos históricos. **No re-OCRizar bytes idénticos no constituye omisión.**
+
+Cuando una identidad carezca de fuente reproduciblemente admisible, no se fabricará OCR ni se sustituirá por una fuente heurística. Esa identidad continúa dentro de 542 y debe permanecer como retención activa o excepción técnica final según evidencia documentada.
+
+## 3. Universo y estado de partida
+
+El corte vigente contiene:
+
+- 542 identidades documentales en el universo LTMD-U1;
+- 524 identidades con cobertura técnica efectiva cerrada o resuelta;
+- 18 identidades fuera de cobertura efectiva;
+- de esas 18, 13 son `active_retention` y 5 son `final_exception`;
+- 492 objetos canónicos de procesamiento en el corte técnico general, cifra distinta del número de identidades porque las relaciones demostradas evitan duplicación.
+
+Estas cifras describen el estado inicial del protocolo 0.2; no son metas suficientes de cierre FTRL.
+
+## 4. Estados exhaustivos por identidad
+
+Cada una de las 542 identidades debe pertenecer exactamente a una de estas disposiciones de alcance global:
+
+- `required_ftrl_processing`: tiene fuente o representación técnicamente admisible y, por tanto, debe quedar cubierta por FTRL;
+- `active_retention`: la fuente todavía no está resuelta de manera reproducible y la investigación técnica sigue abierta;
+- `final_exception`: una investigación acotada y reproducible terminó sin fuente admisible; la imposibilidad documentada es el resultado técnico de esa identidad.
+
+No se admite un cuarto estado implícito como “omitido”, “fuera de alcance”, “pendiente no registrado”, “no prioritario” o equivalente.
+
+Una identidad sólo puede pasar de `active_retention` a:
+
+- `required_ftrl_processing`, si aparece evidencia suficiente para admitir una representación y procesarla; o
+- `final_exception`, si se completa una investigación acotada, reproducible y documentada que justifique el cierre negativo.
+
+## 5. Obligación de procesamiento computacional
+
+Para toda fuente admitida, el objeto canónico correspondiente debe satisfacer como mínimo:
+
+1. identidad y relación con las identidades históricas explícitas;
+2. manifiesto de activos reproducible;
+3. SHA-256 de cada página fuente admitida;
+4. tamaño de fuente conocido;
+5. OCR reconstruible bajo `local/`;
+6. registro de página FTRL por cada JPEG admitido;
+7. SQLite `pages` con cardinalidad idéntica al corpus OCR;
+8. SQLite FTS5 con cardinalidad idéntica a `pages`;
+9. `PRAGMA integrity_check = ok`;
+10. manifiesto de ejecución text-free ligado al commit y a la corrida CI;
+11. cola y resumen de QC text-free;
+12. preservación explícita de `zero_search_text`, confianza baja, confianza ausente y otras anomalías;
+13. no publicación por defecto de OCR íntegro, SQLite, snippets o imágenes fuente cuando los derechos no lo permitan.
+
+La falta de calidad OCR no autoriza excluir una página. La página se procesa, se marca para QC y permanece trazable.
+
+## 6. Retenciones y excepciones: no son exclusiones
+
+El registro `data/catalog/ltmd_u1_retained_source_register.csv` forma parte del universo FTRL, no de un universo externo.
+
+Las `active_retention` son **trabajo pendiente obligatorio** para el cierre global. Una ola puede avanzar computacionalmente sobre sus fuentes disponibles, pero no puede declararse exhaustivamente cerrada mientras conserve retenciones activas.
+
+Las `final_exception` permanecen en el denominador 542/542 y deben conservar evidencia de la búsqueda, límite metodológico y razón por la que no existe una representación fuente admisible. No reciben OCR ficticio y no aumentan el numerador de fuente procesada.
+
+## 7. Olas: sólo mecanismo logístico
+
+W1–W11 sirven para particionar el trabajo y controlar recursos. **Ninguna ola constituye el universo final del proyecto.**
+
+El orden de ejecución puede optimizarse por costo y riesgo, pero no puede modificar el conjunto obligatorio. Completar W1, W3 o cualquier otra ola no autoriza detener FTRL-U1. Después de cada cierre intermedio se continúa con la siguiente deuda técnica hasta que las 542 identidades tengan disposición final y toda fuente admitida haya pasado por FTRL.
+
+La expresión `cohorte fuente-admitida cerrada` sólo describe la parte computacional disponible de una ola; no equivale a `ola exhaustivamente cerrada` si existe cualquier `active_retention`.
+
+## 8. Criterios de cierre
+
+### 8.1 Cierre de una identidad
+
+Una identidad está técnicamente dispuesta cuando se cumple exactamente una de estas condiciones:
+
+- está cubierta por un objeto canónico FTRL integralmente validado;
+- está cubierta por una relación técnica demostrada hacia un objeto canónico FTRL integralmente validado;
+- tiene una `final_exception` documentada.
+
+Una `active_retention` nunca cuenta como cierre.
+
+### 8.2 Cierre de una ola
+
+Una ola sólo puede llamarse **exhaustivamente cerrada** si todas sus identidades nominales cumplen 8.1 y no conserva `active_retention`.
+
+### 8.3 Cierre global FTRL-U1
+
+FTRL-U1 sólo puede declararse técnicamente exhaustivo cuando simultáneamente:
+
+- el universo maestro contiene exactamente 542 identidades únicas;
+- las 542 tienen disposición explícita;
+- no existe ninguna `active_retention`;
+- toda representación fuente admitida está cubierta por FTRL y sus cardinalidades de página son reproducibles;
+- todas las relaciones de alias/reutilización usadas para evitar procesamiento redundante están demostradas y preservan las identidades históricas;
+- las excepciones finales permanecen visibles como resultados negativos y no se contabilizan como fuente procesada;
+- la evidencia pública de ejecución es text-free y auditable.
+
+Por tanto, **524/542 de cobertura efectiva no es cierre global**, y tampoco lo es terminar todos los objetos actualmente admitidos mientras permanezca una retención activa.
+
+## 9. Contrato legible por máquina
+
+`data/research/ltmd_u1_exhaustive_scope_contract.json` congela el denominador y los invariantes del corte. `scripts/validate_ftrl_u1_exhaustive_scope.py` comprueba que:
+
+- existen exactamente 542 `viewer_key` únicos en el tablero maestro;
+- todas las identidades pertenecen a una ola W1–W11;
+- el registro residual es subconjunto exacto del universo;
+- las disposiciones `required_ftrl_processing`, `active_retention` y `final_exception` son mutuamente excluyentes y cubren 542/542;
+- el corte vigente conserva 524 + 13 + 5 = 542;
+- ninguna retención activa puede interpretarse como cierre global.
+
+El validador es un gate de alcance, no una prueba de que las 524 identidades ya hayan completado FTRL. El progreso FTRL debe medirse por separado y nunca alterar el denominador.
+
+## 10. Separación epistemológica
+
+El mandato exhaustivo es técnico y documental. No modifica estas desigualdades:
+
+- `corpus_ready != semantic_ready`;
+- `ocr_available != text_verified`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- `final_exception != source_resolved`.
+
+Procesar todos los libros disponibles no equivale a validar semánticamente todos sus textos. La validación humana seguirá siendo una capa distinta y deberá declarar su propio denominador y diseño muestral o exhaustivo.
+
+## 11. Política de avance
+
+A partir de esta versión:
+
+- no se detiene el escalamiento después de W1;
+- no se omite una identidad por dificultad técnica;
+- no se reduce el denominador para mejorar porcentajes;
+- no se declara “completo” un subconjunto como si fuera LTMD-U1;
+- cada nueva ola FTRL debe heredar este contrato;
+- cualquier cambio futuro del universo requiere una versión U2 o una revisión explícita del snapshot, nunca una modificación silenciosa de U1.
+
+Este protocolo es la autoridad para interpretar el alcance exhaustivo de FTRL-U1.

--- a/docs/FTRL_U1_SCALING_ROADMAP_0_1.md
+++ b/docs/FTRL_U1_SCALING_ROADMAP_0_1.md
@@ -1,8 +1,11 @@
 # FTRL LTMD-U1 — hoja de ruta de escalamiento 0.1
 
+> [!IMPORTANT]
+> **Documento histórico, parcialmente sustituido.** Desde el 24 de agosto de 2026, el alcance y los criterios de cierre de FTRL-U1 se rigen por [`FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md`](FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md). En particular, cualquier formulación de este documento que permita un cierre `fuente-admitido` o parcial como cierre suficiente de una ola o del proyecto **queda anulada**: las 542 identidades permanecen en el denominador, las retenciones activas son trabajo obligatorio y sólo las excepciones técnicas finales documentadas pueden cerrar una identidad sin OCR.
+
 **Fecha:** 24 de agosto de 2026  
 **Base metodológica:** W5 Historia validada integralmente  
-**Objetivo:** escalar `LTMD_FTRL_0.1` desde W5 hacia LTMD-U1 sin perder trazabilidad, derechos, reproducibilidad ni separación entre procesamiento técnico e interpretación histórica.
+**Objetivo original:** escalar `LTMD_FTRL_0.1` desde W5 hacia LTMD-U1 sin perder trazabilidad, derechos, reproducibilidad ni separación entre procesamiento técnico e interpretación histórica.
 
 ## Principio rector
 
@@ -36,24 +39,24 @@ Antes de OCR integral, cada ola debe producir su inventario canónico, manifiest
 
 ### Grupo B — cohortes fuente-admitidas con identidades retenidas
 
-Estas olas pueden escalarse sobre su cohorte admitida, pero la evidencia debe declarar explícitamente que no representa el universo nominal completo.
+Estas olas pueden avanzar computacionalmente sobre su cohorte admitida, pero **no pueden considerarse exhaustivamente cerradas** mientras conserven una retención activa. Las retenidas permanecen en el denominador y deben resolverse o alcanzar una excepción técnica final conforme al protocolo 0.2.
 
-| Ola | Dominio | Cohorte admitida | Retenidas | Regla |
+| Ola | Dominio | Cohorte actualmente admitida | Retenidas | Regla vigente |
 |---|---|---:|---:|---|
-| W7 | Formación Cívica y Ética | 25/30 | 5 | procesar sólo cohorte admitida; no reinterpretar retenidas como ausencias |
-| W8 | Artes | 16/20 | 4 | idem |
-| W10 | Integrados / Multiarea | 68/69 | 1 | idem |
-| W11 | Otros / No clasificados | 107/111 | 4 | idem |
+| W7 | Formación Cívica y Ética | 25/30 | 5 | procesar la fuente disponible y mantener las 5 como deuda obligatoria |
+| W8 | Artes | 16/20 | 4 | procesar la fuente disponible y mantener las 4 como deuda obligatoria |
+| W10 | Integrados / Multiarea | 68/69 | 1 | la excepción final permanece en el denominador como cierre negativo documentado |
+| W11 | Otros / No clasificados | 107/111 | 4 | las excepciones finales permanecen en el denominador como cierres negativos documentados |
 
-Los manifiestos FTRL de estas olas deben incluir simultáneamente cardinalidad procesada y cardinalidad histórica nominal, con referencia al registro consolidado de fuentes retenidas.
+Los manifiestos FTRL deben incluir simultáneamente cardinalidad procesada y cardinalidad histórica nominal, con referencia al registro consolidado de fuentes retenidas.
 
 ### Grupo C — cobertura parcial no cerrada
 
-| Ola | Dominio | Estado | Regla |
+| Ola | Dominio | Estado | Regla vigente |
 |---|---|---|---|
-| W2 | Matemáticas | 60/64; 4 excepciones preservadas | no declarar cohorte integral; resolver o congelar formalmente las cuatro excepciones antes de cualquier afirmación de cobertura completa |
+| W2 | Matemáticas | 60/64; 4 retenciones activas | procesar las 60 disponibles y mantener las cuatro restantes como trabajo obligatorio; no declarar cierre exhaustivo |
 
-W2 puede utilizarse para pruebas técnicas parciales si el alcance se preregistra, pero no debe presentarse como un corpus FTRL integral de la ola mientras permanezcan las cuatro excepciones.
+W2 puede utilizarse para pruebas técnicas parciales si el alcance se preregistra, pero no debe presentarse como un corpus FTRL integral de la ola mientras permanezcan las cuatro retenciones activas.
 
 ## Gate mínimo por ola
 
@@ -72,25 +75,27 @@ Ninguna nueva corrida integral debe aceptarse sin satisfacer, como mínimo, los 
 11. registro separado de páginas con `zero_search_text`, baja confianza o anomalías OCR;
 12. prohibición explícita de convertir hits de búsqueda en afirmaciones históricas sin verificación visual.
 
+A estos gates se añade obligatoriamente el gate global de alcance 0.2: ninguna identidad puede desaparecer del denominador maestro.
+
 ## Secuencia operativa
 
-El orden recomendado para reducir riesgo es:
+El orden recomendado para reducir riesgo sigue siendo:
 
 **W1 → W3 → W6 → W4 → W9 → W7 → W8 → W10 → W11 → W2**.
 
-La secuencia privilegia primero cohortes técnicamente cerradas y suficientemente amplias para probar generalización; después incorpora olas con retenidas explícitas; W2 queda al final porque todavía conserva excepciones técnicas no resueltas.
+El orden es exclusivamente logístico. **No autoriza detener el proyecto antes de recorrer W1–W11 ni omitir las identidades retenidas.** Después de cada ola se continúa con la deuda restante hasta satisfacer el cierre global 542/542 del protocolo 0.2.
 
-No se fija aún un volumen total de páginas esperado para U1. Esa cifra deberá calcularse de manera reproducible a partir de los manifiestos canónicos de cada ola, evitando extrapolaciones o sumas manuales.
+No se fija aún un volumen total de páginas esperado para U1. Esa cifra deberá calcularse de manera reproducible a partir de los manifiestos canónicos de todas las olas, evitando extrapolaciones o sumas manuales.
 
-## Criterio de cierre de FTRL-U1
+## Criterio de cierre de FTRL-U1 — sustituido
 
-FTRL-U1 podrá declararse técnicamente cerrado cuando todas las olas tengan una cohorte explícitamente definida y cada cohorte haya pasado sus gates de integridad. El cierre podrá ser:
+La formulación anterior que admitía cierres `integral`, `fuente-admitido` o `parcial` como categorías terminales queda sustituida. A partir de 0.2:
 
-- **integral**, cuando una ola cubra todo su universo nominal;
-- **fuente-admitido**, cuando existan retenidas documentadas que permanezcan fuera de procesamiento;
-- **parcial**, cuando aún existan excepciones no congeladas metodológicamente.
+- una corrida sobre fuente admitida es un **avance computacional**, no cierre exhaustivo si hay retenciones activas;
+- una ola sólo cierra exhaustivamente cuando todas sus identidades tienen cobertura FTRL demostrada o una excepción técnica final;
+- FTRL-U1 sólo cierra cuando las 542 identidades tienen disposición final y no existe ninguna `active_retention`.
 
-La etiqueta de cierre deberá viajar con cualquier análisis derivado.
+Véase el criterio normativo completo en [`FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md`](FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md).
 
 ## Trabajo humano posterior
 

--- a/scripts/validate_ftrl_u1_exhaustive_scope.py
+++ b/scripts/validate_ftrl_u1_exhaustive_scope.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import re
 from collections import Counter
 from pathlib import Path
 
 DEFAULT_CONTRACT = Path("data/research/ltmd_u1_exhaustive_scope_contract.json")
-WAVE_RE = re.compile(r"^U1-(W(?:10|11|[1-9]))-")
 
 
 def read_csv(path: Path) -> list[dict[str, str]]:
@@ -22,14 +20,13 @@ def read_csv(path: Path) -> list[dict[str, str]]:
         return list(csv.DictReader(fh))
 
 
-def wave_from_coverage(row: dict[str, str]) -> str:
-    label = row.get("wave_label", "")
-    match = WAVE_RE.match(label)
-    if not match:
+def wave_from_domain(row: dict[str, str], domain_to_wave: dict[str, str]) -> str:
+    domain = row.get("operational_domain", "").strip()
+    if domain not in domain_to_wave:
         raise AssertionError(
-            f"coverage identity {row.get('viewer_key')} lacks a valid U1-W1..W11 wave_label: {label!r}"
+            f"coverage identity {row.get('viewer_key')} has unmapped operational_domain: {domain!r}"
         )
-    return match.group(1)
+    return domain_to_wave[domain]
 
 
 def main() -> None:
@@ -48,6 +45,9 @@ def main() -> None:
     retained_path = Path(contract["retained_source_register"])
     coverage = read_csv(coverage_path)
     retained = read_csv(retained_path)
+    domain_to_wave = {
+        str(domain): str(wave) for domain, wave in contract["domain_to_wave"].items()
+    }
 
     expected_universe = int(contract["expected_universe_identities"])
     expected_effective = int(contract["expected_effective_technical_coverage"])
@@ -65,7 +65,7 @@ def main() -> None:
         "every U1 identity must remain cataloged in the master denominator"
     )
 
-    wave_counts = Counter(wave_from_coverage(row) for row in coverage)
+    wave_counts = Counter(wave_from_domain(row, domain_to_wave) for row in coverage)
     expected_wave_counts = {
         str(key): int(value)
         for key, value in contract["expected_wave_denominators"].items()
@@ -87,6 +87,18 @@ def main() -> None:
     assert set(retained_keys) <= set(viewer_keys), (
         "retained-source register contains identity outside frozen U1 universe"
     )
+
+    coverage_by_key = {row["viewer_key"]: row for row in coverage}
+    for row in retained:
+        key = row["viewer_key"]
+        expected_wave = wave_from_domain(coverage_by_key[key], domain_to_wave)
+        assert row["wave"] == expected_wave, (
+            f"retained-source wave/domain mismatch for {key}: "
+            f"register={row['wave']} domain-derived={expected_wave}"
+        )
+        assert row["operational_domain"] == coverage_by_key[key]["operational_domain"], (
+            f"retained-source operational_domain drift for {key}"
+        )
 
     allowed_residual_status = {"active_retention", "final_exception"}
     observed_statuses = {row.get("status", "") for row in retained}
@@ -149,6 +161,7 @@ def main() -> None:
         "status": "scope_validated",
         "universe_identities": expected_universe,
         "identity_dispositions": disposition_counts,
+        "wave_assignment_basis": contract["wave_assignment_basis"],
         "wave_denominators": dict(sorted(wave_counts.items())),
         "retained_by_wave": dict(sorted(retained_wave_counts.items())),
         "all_identities_have_disposition": True,
@@ -159,7 +172,8 @@ def main() -> None:
         "interpretation": (
             "Scope validation does not assert that required_ftrl_processing identities "
             "have completed OCR/FTRL. Active retentions remain mandatory work and block "
-            "global exhaustive closure."
+            "global exhaustive closure. Queue labels (including historical W0 materialized "
+            "states) do not replace operational-domain wave identity."
         ),
     }
 

--- a/scripts/validate_ftrl_u1_exhaustive_scope.py
+++ b/scripts/validate_ftrl_u1_exhaustive_scope.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Validate that FTRL-U1 preserves the exhaustive 542-identity universe.
+
+This gate validates scope and disposition, not completion of OCR/FTRL processing.
+It is intentionally text-free and operates only on repository metadata.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+DEFAULT_CONTRACT = Path("data/research/ltmd_u1_exhaustive_scope_contract.json")
+WAVE_RE = re.compile(r"^U1-(W(?:10|11|[1-9]))-")
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def wave_from_coverage(row: dict[str, str]) -> str:
+    label = row.get("wave_label", "")
+    match = WAVE_RE.match(label)
+    if not match:
+        raise AssertionError(
+            f"coverage identity {row.get('viewer_key')} lacks a valid U1-W1..W11 wave_label: {label!r}"
+        )
+    return match.group(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", type=Path, default=DEFAULT_CONTRACT)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument(
+        "--require-global-closure",
+        action="store_true",
+        help="Fail unless there are zero active retentions.",
+    )
+    args = parser.parse_args()
+
+    contract = json.loads(args.contract.read_text(encoding="utf-8"))
+    coverage_path = Path(contract["master_inventory"])
+    retained_path = Path(contract["retained_source_register"])
+    coverage = read_csv(coverage_path)
+    retained = read_csv(retained_path)
+
+    expected_universe = int(contract["expected_universe_identities"])
+    expected_effective = int(contract["expected_effective_technical_coverage"])
+    expected_active = int(contract["expected_active_retentions"])
+    expected_final = int(contract["expected_final_exceptions"])
+    expected_residual = int(contract["expected_residual_identities"])
+
+    viewer_keys = [row.get("viewer_key", "").strip() for row in coverage]
+    assert all(viewer_keys), "blank viewer_key in master coverage inventory"
+    assert len(viewer_keys) == expected_universe, (
+        f"U1 denominator drift: {len(viewer_keys)} != {expected_universe}"
+    )
+    assert len(set(viewer_keys)) == expected_universe, "duplicate viewer_key in U1 universe"
+    assert all(row.get("cataloged") == "1" for row in coverage), (
+        "every U1 identity must remain cataloged in the master denominator"
+    )
+
+    wave_counts = Counter(wave_from_coverage(row) for row in coverage)
+    expected_wave_counts = {
+        str(key): int(value)
+        for key, value in contract["expected_wave_denominators"].items()
+    }
+    assert dict(sorted(wave_counts.items())) == dict(sorted(expected_wave_counts.items())), (
+        f"wave denominator drift: observed={dict(sorted(wave_counts.items()))} "
+        f"expected={dict(sorted(expected_wave_counts.items()))}"
+    )
+    assert sum(wave_counts.values()) == expected_universe
+
+    retained_keys = [row.get("viewer_key", "").strip() for row in retained]
+    assert all(retained_keys), "blank viewer_key in retained-source register"
+    assert len(retained_keys) == expected_residual, (
+        f"residual register drift: {len(retained_keys)} != {expected_residual}"
+    )
+    assert len(set(retained_keys)) == expected_residual, (
+        "duplicate viewer_key in retained-source register"
+    )
+    assert set(retained_keys) <= set(viewer_keys), (
+        "retained-source register contains identity outside frozen U1 universe"
+    )
+
+    allowed_residual_status = {"active_retention", "final_exception"}
+    observed_statuses = {row.get("status", "") for row in retained}
+    assert observed_statuses <= allowed_residual_status, (
+        f"unexpected retained-source lifecycle state(s): {sorted(observed_statuses - allowed_residual_status)}"
+    )
+
+    status_counts = Counter(row["status"] for row in retained)
+    assert status_counts["active_retention"] == expected_active, (
+        f"active-retention drift: {status_counts['active_retention']} != {expected_active}"
+    )
+    assert status_counts["final_exception"] == expected_final, (
+        f"final-exception drift: {status_counts['final_exception']} != {expected_final}"
+    )
+    assert status_counts["active_retention"] + status_counts["final_exception"] == expected_residual
+
+    retained_wave_counts = Counter(row["wave"] for row in retained)
+    expected_retained_by_wave = {
+        str(key): int(value)
+        for key, value in contract["expected_retained_by_wave"].items()
+    }
+    assert dict(sorted(retained_wave_counts.items())) == dict(
+        sorted(expected_retained_by_wave.items())
+    ), (
+        f"retained wave distribution drift: observed={dict(sorted(retained_wave_counts.items()))} "
+        f"expected={dict(sorted(expected_retained_by_wave.items()))}"
+    )
+
+    required_keys = set(viewer_keys) - set(retained_keys)
+    assert len(required_keys) == expected_effective, (
+        f"required-FTRL identity count drift: {len(required_keys)} != {expected_effective}"
+    )
+
+    active_keys = {
+        row["viewer_key"] for row in retained if row["status"] == "active_retention"
+    }
+    final_keys = {
+        row["viewer_key"] for row in retained if row["status"] == "final_exception"
+    }
+    assert required_keys.isdisjoint(active_keys)
+    assert required_keys.isdisjoint(final_keys)
+    assert active_keys.isdisjoint(final_keys)
+    assert required_keys | active_keys | final_keys == set(viewer_keys), (
+        "one or more U1 identities lack an exhaustive FTRL disposition"
+    )
+
+    disposition_counts = {
+        "required_ftrl_processing": len(required_keys),
+        "active_retention": len(active_keys),
+        "final_exception": len(final_keys),
+    }
+    assert sum(disposition_counts.values()) == expected_universe
+
+    global_closure_ready = len(active_keys) == int(
+        contract["global_closure_requires_active_retentions"]
+    )
+    result = {
+        "schema_version": contract["schema_version"],
+        "snapshot": contract["snapshot"],
+        "status": "scope_validated",
+        "universe_identities": expected_universe,
+        "identity_dispositions": disposition_counts,
+        "wave_denominators": dict(sorted(wave_counts.items())),
+        "retained_by_wave": dict(sorted(retained_wave_counts.items())),
+        "all_identities_have_disposition": True,
+        "global_closure_ready": global_closure_ready,
+        "global_closure_blockers": {
+            "active_retentions": len(active_keys),
+        },
+        "interpretation": (
+            "Scope validation does not assert that required_ftrl_processing identities "
+            "have completed OCR/FTRL. Active retentions remain mandatory work and block "
+            "global exhaustive closure."
+        ),
+    }
+
+    serialized = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(serialized, encoding="utf-8")
+    print(serialized, end="")
+
+    if args.require_global_closure and not global_closure_ready:
+        raise SystemExit(
+            f"FTRL-U1 is not globally exhaustive yet: {len(active_keys)} active retention(s) remain"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Propósito

Corrige el alcance normativo de FTRL-U1 para que el proyecto sea exhaustivo sobre las **542 identidades documentales** del universo maestro, no sólo sobre cohortes fuente-admitidas.

## Cambio de criterio

- las 542 identidades permanecen siempre en el denominador;
- las 524 con cobertura técnica efectiva quedan como `required_ftrl_processing`;
- las 13 `active_retention` son deuda obligatoria y bloquean el cierre global;
- las 5 `final_exception` permanecen en el denominador como resultados negativos auditables, sin OCR inventado;
- aliases y reutilizaciones demostradas pueden evitar OCR redundante, pero nunca borrar identidades históricas;
- una ola fuente-admitida puede avanzar computacionalmente, pero no se considera exhaustivamente cerrada mientras conserve retenciones activas.

## Implementación

- nuevo protocolo normativo `FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md`;
- contrato legible por máquina con el universo 542 y sus invariantes;
- validador fail-closed que exige disposición exhaustiva 542/542;
- CI que prueba además que el cierre global falle mientras permanezcan las 13 retenciones activas;
- hoja de ruta 0.1 marcada como parcialmente sustituida y corregida donde permitía interpretar cierres por cohorte admitida.

Este PR modifica el gobierno del alcance; no declara que las 524 identidades procesables ya hayan completado FTRL. Refs #15.