### PR TITLE
FTRL W1: reconciliar denominador exhaustivo 40/40

### DIFF
--- a/.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml
+++ b/.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml
@@ -1,0 +1,31 @@
+name: Audit exhaustive FTRL W1 denominator
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/audit_ftrl_w1_exhaustive_denominator.py'
+      - 'data/catalog/ltmd_u1_coverage.csv'
+      - 'data/catalog/ciencias_naturales_family_asset_readiness.csv'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - '.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit-w1-denominator:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Compare W1 master denominator with FTRL readiness
+        run: python scripts/audit_ftrl_w1_exhaustive_denominator.py

--- a/.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml
+++ b/.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml
@@ -7,6 +7,8 @@ on:
       - 'scripts/audit_ftrl_w1_exhaustive_denominator.py'
       - 'data/catalog/ltmd_u1_coverage.csv'
       - 'data/catalog/ciencias_naturales_family_asset_readiness.csv'
+      - 'data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv'
+      - 'data/expansion/cn46_page_manifest_summary.csv'
       - 'data/catalog/ltmd_u1_retained_source_register.csv'
       - '.github/workflows/audit-ftrl-w1-exhaustive-denominator.yml'
   workflow_dispatch:
@@ -27,5 +29,5 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Compare W1 master denominator with FTRL readiness
+      - name: Compare W1 master denominator with explicit FTRL dispositions
         run: python scripts/audit_ftrl_w1_exhaustive_denominator.py

--- a/.github/workflows/validate-ftrl-w1-full.yml
+++ b/.github/workflows/validate-ftrl-w1-full.yml
@@ -1,17 +1,17 @@
-name: Validate FTRL W1 full corpus
+name: Validate exhaustive FTRL W1 full corpus
 
 on:
   workflow_dispatch:
   push:
     branches: [main]
     paths:
-      - 'data/research/ltmd_u1_w1_full_run_stamp.json'
+      - 'data/research/ltmd_u1_w1_exhaustive_full_run_stamp.json'
 
 permissions:
   contents: read
 
 concurrency:
-  group: ftrl-w1-full
+  group: ftrl-w1-exhaustive-full
   cancel-in-progress: false
 
 jobs:
@@ -34,14 +34,14 @@ jobs:
           tesseract --version | head -n 1
           tesseract --list-langs | grep -Fx spa
 
-      - name: Execute complete source-admitted W1 FTRL
+      - name: Execute complete exhaustive source-admitted W1 FTRL
         run: |
           python scripts/run_ftrl_w1.py \
             --full \
             --workers 2 \
             --output-dir local/ftrl
 
-      - name: Assert complete W1 corpus and index
+      - name: Assert complete exhaustive W1 corpus and index
         run: |
           python - <<'PY'
           import csv
@@ -54,31 +54,35 @@ jobs:
           with Path('local/ftrl/ltmd_u1_w1_processing_inventory.csv').open(encoding='utf-8', newline='') as fh:
               processing = list(csv.DictReader(fh))
 
-          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.2'
+          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.3'
           assert preflight['status'] == 'ready'
-          assert preflight['historical_identities'] == 37
-          assert preflight['canonical_processing_objects'] == 33
+          assert preflight['historical_identities'] == 40
+          assert preflight['canonical_processing_objects'] == 36
           assert preflight['byte_identical_aliases'] == 4
-          assert preflight['source_admitted_jpegs'] == 5926
+          assert preflight['source_admitted_jpegs'] == 6516
           assert preflight['internal_unserved_positions'] == 3
+          assert preflight['terminal_synthetic_positions'] == 34
+          assert preflight['legacy_family_readiness_identities'] == 37
+          assert preflight['supplemental_historical_identities'] == 3
+          assert preflight['cn46_objects_outside_w1_readiness'] == []
 
           canonical = [r for r in processing if r['is_canonical_processing_object'] == '1']
           historical = [r for r in processing if r['technical_identity_covered'] == '1']
-          assert len(processing) == 37
-          assert len(historical) == 37
-          assert len(canonical) == 33
-          assert sum(int(r['direct_source_jpegs']) for r in canonical) == 5926
+          assert len(processing) == 40
+          assert len(historical) == 40
+          assert len(canonical) == 36
+          assert sum(int(r['direct_source_jpegs']) for r in canonical) == 6516
           assert sum(int(r['persistent_unresolved_source_gaps']) for r in canonical) == 3
 
           assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
           assert manifest['status'] == 'validated'
-          assert manifest['corpus']['page_records'] == 5926
-          assert manifest['database']['page_rows'] == 5926
-          assert manifest['database']['fts_rows'] == 5926
+          assert manifest['corpus']['page_records'] == 6516
+          assert manifest['database']['page_rows'] == 6516
+          assert manifest['database']['fts_rows'] == 6516
           assert manifest['database']['sqlite_integrity'] == 'ok'
           assert manifest['corpus']['waves'] == ['W1']
-          assert manifest['corpus']['canonical_viewers'] == 33
-          assert manifest['database']['historical_identities'] == 37
+          assert manifest['corpus']['canonical_viewers'] == 36
+          assert manifest['database']['historical_identities'] == 40
           assert manifest['corpus']['source_byte_size_missing_pages'] == 0
 
           vcs = manifest['execution']['vcs']
@@ -92,7 +96,7 @@ jobs:
           assert ci['sha'] == vcs['commit']
 
           assert qc['schema_version'] == 'LTMD_FTRL_QC_0.1'
-          assert qc['page_records'] == 5926
+          assert qc['page_records'] == 6516
           assert qc['rights_note'].startswith('Text-free OCR quality-control summary')
 
           forbidden = {'ocr_text_raw', 'search_text', 'snippet'}
@@ -107,7 +111,7 @@ jobs:
           walk(manifest)
           walk(qc)
           walk(preflight)
-          print('Complete W1 FTRL corpus validated with text-free public evidence')
+          print('Complete exhaustive W1 FTRL corpus validated with text-free public evidence')
           PY
 
       - name: Prove restricted outputs remain non-publishable
@@ -132,7 +136,7 @@ jobs:
       - name: Upload text-free evidence only
         uses: actions/upload-artifact@v4
         with:
-          name: ltmd-u1-w1-full-text-free-evidence
+          name: ltmd-u1-w1-exhaustive-full-text-free-evidence
           path: |
             local/ftrl/ltmd_u1_w1_preflight.json
             local/ftrl/ltmd_u1_w1_full_run_manifest.json

--- a/.github/workflows/validate-ftrl-w1-preflight.yml
+++ b/.github/workflows/validate-ftrl-w1-preflight.yml
@@ -1,11 +1,14 @@
-name: Validate FTRL W1 preflight
+name: Validate exhaustive FTRL W1 preflight
 
 on:
   pull_request:
     paths:
+      - 'scripts/build_ftrl_w1_inputs.py'
       - 'scripts/preflight_ftrl_w1.py'
+      - 'data/catalog/ltmd_u1_coverage.csv'
       - 'data/catalog/ciencias_naturales_family_asset_readiness.csv'
       - 'data/catalog/ciencias_naturales_pending_page_manifest_summary.csv'
+      - 'data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv'
       - 'data/expansion/cn46_page_manifest_summary.csv'
       - 'data/book_inventory.csv'
       - 'data/derived/ocr_page_metrics.csv'
@@ -31,24 +34,28 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Reconcile W1 documentary layers
+      - name: Reconcile exhaustive W1 documentary layers
         run: |
           python scripts/preflight_ftrl_w1.py --output local/ftrl/ltmd_u1_w1_preflight.json
 
-      - name: Assert text-free ready state and exact cardinalities
+      - name: Assert text-free ready state and exact exhaustive cardinalities
         run: |
           python - <<'PY'
           import json
           from pathlib import Path
           p = Path('local/ftrl/ltmd_u1_w1_preflight.json')
           d = json.loads(p.read_text(encoding='utf-8'))
-          assert d['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.2'
+          assert d['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.3'
           assert d['wave'] == 'W1'
-          assert d['historical_identities'] == 37
-          assert d['canonical_processing_objects'] == 33
+          assert d['historical_identities'] == 40
+          assert d['canonical_processing_objects'] == 36
           assert d['byte_identical_aliases'] == 4
-          assert d['source_admitted_jpegs'] == 5926
+          assert d['source_admitted_jpegs'] == 6516
           assert d['internal_unserved_positions'] == 3
+          assert d['terminal_synthetic_positions'] == 34
+          assert d['legacy_family_readiness_identities'] == 37
+          assert d['supplemental_historical_identities'] == 3
+          assert d['cn46_objects_outside_w1_readiness'] == []
           assert d['status'] == 'ready'
           assert d['pilot_sha256_objects'] == 4
           assert d['pilot_sha256_pages'] == 759
@@ -59,10 +66,10 @@ jobs:
           raw = p.read_text(encoding='utf-8').lower()
           for forbidden in ('ocr_text_raw', 'search_text', 'snippet'):
               assert forbidden not in raw
-          print('W1 cryptographic readiness validated')
+          print('Exhaustive W1 cryptographic readiness validated')
           PY
 
-      - name: Prove positive cryptographic-ready gate
+      - name: Prove positive exhaustive cryptographic-ready gate
         run: |
           python scripts/preflight_ftrl_w1.py --require-cryptographic-ready \
             --output local/ftrl/ltmd_u1_w1_gate.json
@@ -93,7 +100,7 @@ jobs:
       - name: Upload text-free preflight evidence
         uses: actions/upload-artifact@v4
         with:
-          name: ltmd-u1-w1-preflight-text-free
+          name: ltmd-u1-w1-exhaustive-preflight-text-free
           path: |
             local/ftrl/ltmd_u1_w1_preflight.json
             local/ftrl/ltmd_u1_w1_gate.json

--- a/.github/workflows/validate-ftrl-w1-runtime.yml
+++ b/.github/workflows/validate-ftrl-w1-runtime.yml
@@ -12,9 +12,13 @@ on:
       - 'scripts/validate_ocr_corpus.py'
       - 'scripts/summarize_ftrl_run.py'
       - 'scripts/build_ftrl_qc_queue.py'
+      - 'data/catalog/ltmd_u1_coverage.csv'
       - 'data/catalog/ciencias_naturales_family_asset_readiness.csv'
       - 'data/catalog/ciencias_naturales_pending_page_manifest.csv'
+      - 'data/catalog/ltmd_u1_w1_1966_page_manifest.csv'
+      - 'data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv'
       - 'data/expansion/cn46_page_manifest.csv'
+      - 'data/expansion/cn46_page_manifest_summary.csv'
       - 'data/catalog/cn5_pilot_sha/**'
       - '.github/workflows/validate-ftrl-w1-runtime.yml'
   workflow_dispatch:
@@ -46,14 +50,14 @@ jobs:
           tesseract --version | head -n 1
           tesseract --list-langs | grep -Fx spa
 
-      - name: Execute real-source W1 pilot
+      - name: Execute real-source exhaustive W1 pilot
         run: |
           python scripts/run_ftrl_w1.py \
             --pages 12 \
             --workers 1 \
             --output-dir local/ftrl
 
-      - name: Assert exact pilot provenance
+      - name: Assert exact exhaustive pilot provenance
         run: |
           python - <<'PY'
           import json
@@ -63,11 +67,17 @@ jobs:
           qc = json.loads(Path('local/ftrl/ltmd_u1_w1_pilot_12_qc_summary.json').read_text(encoding='utf-8'))
           preflight = json.loads(Path('local/ftrl/ltmd_u1_w1_preflight.json').read_text(encoding='utf-8'))
 
-          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.2'
+          assert preflight['schema'] == 'LTMD_FTRL_W1_PREFLIGHT_0.3'
           assert preflight['status'] == 'ready'
-          assert preflight['historical_identities'] == 37
-          assert preflight['canonical_processing_objects'] == 33
-          assert preflight['source_admitted_jpegs'] == 5926
+          assert preflight['historical_identities'] == 40
+          assert preflight['canonical_processing_objects'] == 36
+          assert preflight['byte_identical_aliases'] == 4
+          assert preflight['source_admitted_jpegs'] == 6516
+          assert preflight['internal_unserved_positions'] == 3
+          assert preflight['terminal_synthetic_positions'] == 34
+          assert preflight['legacy_family_readiness_identities'] == 37
+          assert preflight['supplemental_historical_identities'] == 3
+          assert preflight['cn46_objects_outside_w1_readiness'] == []
 
           assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
           assert manifest['status'] == 'validated'
@@ -106,7 +116,7 @@ jobs:
           walk(manifest)
           walk(qc)
           walk(preflight)
-          print('W1 real-source pilot validated with text-free public evidence')
+          print('Exhaustive W1 real-source pilot validated with text-free public evidence')
           PY
 
       - name: Prove restricted outputs remain local
@@ -125,7 +135,7 @@ jobs:
       - name: Upload text-free pilot evidence only
         uses: actions/upload-artifact@v4
         with:
-          name: ltmd-u1-w1-runtime-pilot-text-free
+          name: ltmd-u1-w1-exhaustive-runtime-pilot-text-free
           path: |
             local/ftrl/ltmd_u1_w1_preflight.json
             local/ftrl/ltmd_u1_w1_pilot_12_run_manifest.json

--- a/docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_2.md
+++ b/docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_2.md
@@ -1,0 +1,165 @@
+# Protocolo de ejecución integral exhaustiva FTRL W1 Ciencias Naturales
+
+Versión operativa: 0.2  
+Estado: preregistrado antes de la primera corrida integral exhaustiva W1  
+Alcance: LTMD-U1, W1 Ciencias Naturales
+
+## Nota de supersesión
+
+Esta versión 0.2 **supersede operativamente** a `FTRL_W1_FULL_EXECUTION_PROTOCOL_0_1.md` para cualquier afirmación de completitud exhaustiva de W1.
+
+La versión 0.1 congeló correctamente una cohorte técnica entonces reconciliada de 37 identidades, 33 objetos canónicos y 5,926 JPEG fuente. Una auditoría posterior contra el denominador maestro `data/catalog/ltmd_u1_coverage.csv` demostró que el dominio `ciencias_naturales` contiene 40 identidades históricas. Las tres identidades ausentes de aquella cohorte no eran retenciones ni fuentes no resueltas: ya estaban materializadas y contaban con manifiestos versionados. En consecuencia, la corrida 37/37 conserva valor diagnóstico y de desarrollo, pero no puede usarse como evidencia de exhaustividad W1.
+
+La corrección se realiza sin reescribir la capa histórica de 37 identidades. La FTRL exhaustiva une explícitamente esa capa con los manifiestos ya existentes para `H1966P6CI374`, `H1966P6CI375` y `H1993P6CI209`.
+
+## Propósito
+
+Este protocolo fija las condiciones de la primera ejecución integral **exhaustiva** de la Full-Text Research Layer (FTRL) sobre W1 Ciencias Naturales. Su función es impedir que el denominador, la topología de procesamiento, las cardinalidades, los criterios de completitud o las reglas de publicación se modifiquen después de observar el OCR completo.
+
+La corrida integral es una validación técnica del corpus reconstruible y del índice de búsqueda. No constituye verificación del texto OCR, validación semántica ni evidencia suficiente para sostener afirmaciones históricas, curriculares o discursivas.
+
+## Denominador maestro y cohorte congelada
+
+El denominador maestro vigente fija 40 identidades históricas cuyo `operational_domain` es `ciencias_naturales`.
+
+La reconciliación exhaustiva congela:
+
+- **40 identidades históricas** técnicamente cubiertas;
+- **36 objetos canónicos de procesamiento**;
+- **4 identidades 2018** representadas mediante aliases byte-a-byte verificados hacia sus pares 2019;
+- **6,516 JPEG fuente** admitidos para procesamiento;
+- **3 posiciones internas** declaradas pero persistentemente no servidas: una en `LTMD-CN3-G2008` y dos en `LTMD-CN4-G2008`;
+- **34 posiciones terminales sintéticas** documentadas en los objetos canónicos;
+- **759 páginas** de los cuatro objetos CN5 del piloto con anclaje SHA-256 versionado.
+
+Las cuatro relaciones 2018 → 2019 son relaciones técnicas de reutilización de bytes. No establecen por sí mismas identidad bibliográfica, igualdad editorial, equivalencia curricular ni continuidad semántica.
+
+La cifra de 6,516 páginas describe exclusivamente activos fuente admitidos; no debe reinterpretarse como equivalencia con todas las posiciones nominales declaradas por los visores.
+
+## Corrección exhaustiva 37 → 40
+
+Las tres identidades incorporadas son:
+
+1. `H1966P6CI374` — `U1-H1966P6CI374`, **MI CUADERNO DE TRABAJO DE ESTUDIO DE LA NATURALEZA**: 179 posiciones de visor, 178 JPEG fuente, una posición terminal sintética, cero huecos internos;
+2. `H1966P6CI375` — `U1-H1966P6CI375`, **MI LIBRO DE ESTUDIO DE LA NATURALEZA**: 163 posiciones de visor, 162 JPEG fuente, una posición terminal sintética, cero huecos internos;
+3. `H1993P6CI209` — `LTMD-CN6-G1993-DH`, **Ciencias Naturales y desarrollo humano**: 251 posiciones de visor, 250 JPEG fuente, una posición terminal sintética.
+
+Los dos objetos de 1966 están documentados en `data/catalog/ltmd_u1_w1_1966_page_manifest.csv` y su resumen. El objeto 1993-DH está documentado en `data/expansion/cn46_page_manifest.csv` y su resumen. En los tres casos el número de hashes SHA-256 únicos coincide con el número de JPEG fuente admitidos.
+
+La suma correctiva es 340 + 250 = 590 páginas fuente adicionales. Por tanto: 5,926 + 590 = **6,516**.
+
+## Normalización de procedencia
+
+W1 no parte de un único manifiesto histórico. Su procedencia exhaustiva está distribuida entre cuatro capas versionadas:
+
+1. `data/catalog/ciencias_naturales_pending_page_manifest.csv`, para activos auditados directamente y casos con huecos persistentes documentados;
+2. `data/catalog/ltmd_u1_w1_1966_page_manifest.csv`, para los dos objetos de 1966;
+3. `data/expansion/cn46_page_manifest.csv`, para objetos CN4/CN6 ya auditados, incluido `LTMD-CN6-G1993-DH`;
+4. `data/catalog/cn5_pilot_sha/`, para los cuatro objetos CN5 cuyo piloto quedó posteriormente anclado criptográficamente.
+
+`data/catalog/ciencias_naturales_family_asset_readiness.csv` se conserva sin modificación como registro histórico de 37 identidades. `scripts/build_ftrl_w1_inputs.py` versión lógica 0.2 reconcilia ese registro con el denominador maestro y las tres disposiciones suplementarias, y produce bajo `local/ftrl/` un manifiesto exhaustivo de activos y un inventario exhaustivo de procesamiento.
+
+La normalización es determinista, sin acceso de red y sin texto OCR. No sustituye a las capas documentales originales ni modifica su autoridad metodológica.
+
+## Gate de exhaustividad previo
+
+Antes del preflight criptográfico, `scripts/audit_ftrl_w1_exhaustive_denominator.py` debe confirmar:
+
+- denominador maestro W1 = 40;
+- registro histórico familiar = 37;
+- disposiciones FTRL suplementarias = 3;
+- disposiciones FTRL explícitas = 40;
+- cero identidades W1 sin disposición;
+- cero identidades extra fuera del denominador.
+
+La ausencia de cualquiera de las 40 identidades bloquea la clasificación de exhaustividad.
+
+## Gate criptográfico obligatorio
+
+Antes de iniciar OCR, `scripts/preflight_ftrl_w1.py --require-cryptographic-ready` debe devolver `status=ready` bajo `LTMD_FTRL_W1_PREFLIGHT_0.3` y confirmar, como mínimo:
+
+- 40 identidades históricas;
+- 36 objetos canónicos;
+- 4 aliases byte-a-byte;
+- 6,516 JPEG fuente admitidos;
+- 3 posiciones internas no servidas documentadas;
+- 34 posiciones terminales sintéticas;
+- 4 objetos CN5 anclados;
+- 759 páginas CN5 con correspondencia de bytes respecto de la evidencia técnica previa;
+- dos objetos 1966 con manifiesto SHA-256 versionado;
+- `LTMD-CN6-G1993-DH` incorporado desde CN46;
+- cero objetos CN46 fuera del denominador exhaustivo W1;
+- cero objetos canónicos sin capa de procedencia criptográfica aceptada.
+
+Cualquier deriva bloquea la ejecución integral.
+
+## Ejecución
+
+La referencia ejecutable integral es:
+
+```bash
+python scripts/run_ftrl_w1.py \
+  --full \
+  --workers 2 \
+  --output-dir local/ftrl
+```
+
+El workflow `.github/workflows/validate-ftrl-w1-full.yml` reproduce esta ejecución en GitHub Actions con Python 3.12, Tesseract y el modelo español `spa`, y SQLite con FTS5.
+
+La paralelización en dos shards altera únicamente la planificación del procesamiento. No modifica la cohorte, los hashes esperados, la identidad de página, el orden de concatenación final ni las reglas de aceptación. Cada descarga se verifica contra el SHA-256 versionado antes del OCR.
+
+El antiguo sello `data/research/ltmd_u1_w1_full_run_stamp.json` queda asociado al protocolo 0.1 y no debe reactivar una corrida considerada exhaustiva. La versión 0.2 utiliza exclusivamente un nuevo sello `data/research/ltmd_u1_w1_exhaustive_full_run_stamp.json`, creado sólo después de que los gates del PR de corrección hayan pasado.
+
+## Gates de completitud
+
+Una corrida integral exhaustiva sólo podrá clasificarse como técnicamente validada si cumple simultáneamente:
+
+1. 6,516 registros de página FTRL;
+2. 6,516 filas en la tabla `pages` de SQLite;
+3. 6,516 filas en el índice FTS5;
+4. `PRAGMA integrity_check = ok`;
+5. 36 objetos canónicos con páginas OCR;
+6. 40 identidades históricas técnicamente representadas en la tabla de identidades;
+7. cero páginas procesadas con tamaño de fuente desconocido;
+8. commit Git exacto y contexto de GitHub Actions registrados en el manifiesto de corrida;
+9. manifiesto FTRL con estado `validated` y ola única `W1`;
+10. salida QC sin texto con cardinalidad de 6,516 páginas;
+11. OCR por página, SQLite y cola detallada de QC mantenidos fuera de publicación y cubiertos por `.gitignore`;
+12. artefactos públicos limitados a evidencia text-free: preflight, manifiesto agregado de corrida y resumen agregado de control de calidad.
+
+Una falla en cualquier gate mantiene la corrida en estado diagnóstico y prohíbe declarar W1 cerrado en FTRL.
+
+## Control de calidad OCR
+
+Después de construir el corpus, `scripts/build_ftrl_qc_queue.py` genera una cola diagnóstica local y un resumen agregado sin texto. Se conservan los umbrales preregistrados de FTRL 0.1 para páginas sin texto recuperable, confianza ausente, baja confianza y texto excepcionalmente corto.
+
+La cola sirve para priorizar revisión humana. Una página sin bandera no equivale a transcripción validada y una página con baja confianza no prueba, por sí sola, que el contenido OCR sea incorrecto.
+
+## Consultas e interpretación
+
+Esta primera corrida integral exhaustiva W1 no ejecuta consultas historiográficas preregistradas. El objetivo es demostrar reconstrucción técnica integral de la cohorte fuente-admitida y producir un mapa reproducible de calidad OCR antes de definir constructos analíticos.
+
+Se mantienen como reglas obligatorias:
+
+- `source_ready != text_verified`;
+- `ocr_available != text_verified`;
+- `corpus_ready != semantic_ready`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- un alias técnico no equivale a identidad bibliográfica;
+- una posición no servida no puede reinterpretarse como ausencia de contenido curricular;
+- toda página utilizada como evidencia sustantiva debe verificarse contra el activo fuente.
+
+## Evidencia pública esperada
+
+Una ejecución integral válida podrá publicar exclusivamente:
+
+- `ltmd_u1_w1_preflight.json`;
+- `ltmd_u1_w1_full_run_manifest.json`;
+- `ltmd_u1_w1_full_qc_summary.json`.
+
+Estos artefactos contienen cardinalidades, hashes, métricas agregadas y contexto de ejecución, pero excluyen el texto OCR, las imágenes fuente, snippets y el índice SQLite.
+
+## Criterio de avance
+
+Sólo después de una corrida integral exhaustiva válida se actualizará la hoja de ruta para pasar W1 de `cryptographic-ready` a `corpus_ready`/`ocr_available`. La etiqueta `semantic_ready` requerirá trabajo humano adicional y no puede inferirse de una ejecución técnica exitosa.

--- a/scripts/audit_ftrl_w1_exhaustive_denominator.py
+++ b/scripts/audit_ftrl_w1_exhaustive_denominator.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Audit the exhaustive LTMD-U1 W1 denominator against current FTRL inputs.
+
+This is a metadata-only gate. It never downloads assets or emits OCR text.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+COVERAGE = Path("data/catalog/ltmd_u1_coverage.csv")
+READINESS = Path("data/catalog/ciencias_naturales_family_asset_readiness.csv")
+RETAINED = Path("data/catalog/ltmd_u1_retained_source_register.csv")
+EXPECTED_W1 = 40
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def main() -> None:
+    coverage = read_csv(COVERAGE)
+    readiness = read_csv(READINESS)
+    retained = read_csv(RETAINED)
+
+    w1 = [r for r in coverage if r.get("operational_domain") == "ciencias_naturales"]
+    if len(w1) != EXPECTED_W1:
+        raise AssertionError(f"W1 denominator drift: {len(w1)} != {EXPECTED_W1}")
+
+    w1_keys = {r["viewer_key"] for r in w1}
+    readiness_keys = {r["viewer_key"] for r in readiness}
+    if len(readiness_keys) != len(readiness):
+        raise AssertionError("duplicate viewer_key in W1 readiness")
+    if not readiness_keys <= w1_keys:
+        raise AssertionError(
+            f"readiness contains non-W1 identities: {sorted(readiness_keys - w1_keys)}"
+        )
+
+    retained_w1 = [r for r in retained if r.get("viewer_key") in w1_keys]
+    missing = [r for r in w1 if r["viewer_key"] not in readiness_keys]
+
+    result = {
+        "schema_version": "LTMD_FTRL_W1_EXHAUSTIVE_AUDIT_0.1",
+        "w1_denominator": len(w1),
+        "current_ftrl_readiness_identities": len(readiness),
+        "retained_w1_identities": len(retained_w1),
+        "identities_not_in_current_ftrl_readiness": len(missing),
+        "missing": [
+            {
+                "viewer_key": r["viewer_key"],
+                "catalog_generation": r["catalog_generation"],
+                "grade_code": r["grade_code"],
+                "tail_code": r["tail_code"],
+                "book_id": r.get("book_id", ""),
+                "asset_status": r.get("asset_status", ""),
+                "asset_resolved_full": r.get("asset_resolved_full", ""),
+                "asset_resolved_partial": r.get("asset_resolved_partial", ""),
+                "page_manifest_ready": r.get("page_manifest_ready", ""),
+                "ocr_ready": r.get("ocr_ready", ""),
+                "coverage_inherited_from_viewer": r.get("coverage_inherited_from_viewer", ""),
+                "wave_label": r.get("wave_label", ""),
+                "queue_status": r.get("queue_status", ""),
+            }
+            for r in missing
+        ],
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+
+    # Under the exhaustive protocol, W1 cannot be called complete until every one
+    # of its 40 historical identities has an explicit FTRL disposition.
+    if missing:
+        raise SystemExit(
+            f"W1 FTRL denominator is not exhaustive: {len(missing)} of {EXPECTED_W1} "
+            "historical identities are absent from the current FTRL readiness cohort"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_ftrl_w1_exhaustive_denominator.py
+++ b/scripts/audit_ftrl_w1_exhaustive_denominator.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
-"""Audit the exhaustive LTMD-U1 W1 denominator against current FTRL inputs.
+"""Audit the exhaustive LTMD-U1 W1 denominator against explicit FTRL inputs.
 
-This is a metadata-only gate. It never downloads assets or emits OCR text.
+This metadata-only gate preserves the historical 37-identity family-readiness
+register and verifies that the three additional master-denominator identities
+have explicit, versioned FTRL source dispositions. It never downloads assets or
+emits OCR text.
 """
 from __future__ import annotations
 
@@ -11,8 +14,12 @@ from pathlib import Path
 
 COVERAGE = Path("data/catalog/ltmd_u1_coverage.csv")
 READINESS = Path("data/catalog/ciencias_naturales_family_asset_readiness.csv")
+W1966_SUMMARY = Path("data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv")
+CN46_SUMMARY = Path("data/expansion/cn46_page_manifest_summary.csv")
 RETAINED = Path("data/catalog/ltmd_u1_retained_source_register.csv")
 EXPECTED_W1 = 40
+EXPECTED_LEGACY = 37
+EXPECTED_SUPPLEMENTAL = {"H1966P6CI374", "H1966P6CI375", "H1993P6CI209"}
 
 
 def read_csv(path: Path) -> list[dict[str, str]]:
@@ -23,6 +30,8 @@ def read_csv(path: Path) -> list[dict[str, str]]:
 def main() -> None:
     coverage = read_csv(COVERAGE)
     readiness = read_csv(READINESS)
+    w1966 = read_csv(W1966_SUMMARY)
+    cn46 = read_csv(CN46_SUMMARY)
     retained = read_csv(RETAINED)
 
     w1 = [r for r in coverage if r.get("operational_domain") == "ciencias_naturales"]
@@ -31,6 +40,10 @@ def main() -> None:
 
     w1_keys = {r["viewer_key"] for r in w1}
     readiness_keys = {r["viewer_key"] for r in readiness}
+    if len(readiness) != EXPECTED_LEGACY:
+        raise AssertionError(
+            f"legacy W1 readiness drift: {len(readiness)} != {EXPECTED_LEGACY}"
+        )
     if len(readiness_keys) != len(readiness):
         raise AssertionError("duplicate viewer_key in W1 readiness")
     if not readiness_keys <= w1_keys:
@@ -38,42 +51,55 @@ def main() -> None:
             f"readiness contains non-W1 identities: {sorted(readiness_keys - w1_keys)}"
         )
 
-    retained_w1 = [r for r in retained if r.get("viewer_key") in w1_keys]
-    missing = [r for r in w1 if r["viewer_key"] not in readiness_keys]
+    missing_from_legacy = w1_keys - readiness_keys
+    if missing_from_legacy != EXPECTED_SUPPLEMENTAL:
+        raise AssertionError(
+            "unexpected master/readiness difference: "
+            f"{sorted(missing_from_legacy)}"
+        )
 
+    w1966_keys = {r["viewer_key"] for r in w1966}
+    if w1966_keys != {"H1966P6CI374", "H1966P6CI375"}:
+        raise AssertionError(f"unexpected W1-1966 summary set: {sorted(w1966_keys)}")
+    for row in w1966:
+        if int(row["asset_layer_ready"]) != 1:
+            raise AssertionError(f"W1-1966 asset layer not ready: {row['viewer_key']}")
+        if int(row["source_jpegs"]) != int(row["unique_source_hashes"]):
+            raise AssertionError(f"W1-1966 SHA coverage mismatch: {row['viewer_key']}")
+
+    dh_rows = [r for r in cn46 if r["viewer_key"] == "H1993P6CI209"]
+    if len(dh_rows) != 1:
+        raise AssertionError("expected one CN46 disposition for H1993P6CI209")
+    dh = dh_rows[0]
+    if dh["book_id"] != "LTMD-CN6-G1993-DH":
+        raise AssertionError("H1993P6CI209 book_id drift")
+    if int(dh["source_jpegs"]) != int(dh["unique_source_hashes"]):
+        raise AssertionError("H1993P6CI209 SHA coverage mismatch")
+
+    supplemental_keys = w1966_keys | {dh["viewer_key"]}
+    explicit_ftrl_keys = readiness_keys | supplemental_keys
+    missing = sorted(w1_keys - explicit_ftrl_keys)
+    extra = sorted(explicit_ftrl_keys - w1_keys)
+
+    retained_w1 = [r for r in retained if r.get("viewer_key") in w1_keys]
     result = {
-        "schema_version": "LTMD_FTRL_W1_EXHAUSTIVE_AUDIT_0.1",
+        "schema_version": "LTMD_FTRL_W1_EXHAUSTIVE_AUDIT_0.2",
         "w1_denominator": len(w1),
-        "current_ftrl_readiness_identities": len(readiness),
+        "legacy_family_readiness_identities": len(readiness),
+        "supplemental_ftrl_identities": len(supplemental_keys),
+        "explicit_ftrl_dispositions": len(explicit_ftrl_keys),
         "retained_w1_identities": len(retained_w1),
-        "identities_not_in_current_ftrl_readiness": len(missing),
-        "missing": [
-            {
-                "viewer_key": r["viewer_key"],
-                "catalog_generation": r["catalog_generation"],
-                "grade_code": r["grade_code"],
-                "tail_code": r["tail_code"],
-                "book_id": r.get("book_id", ""),
-                "asset_status": r.get("asset_status", ""),
-                "asset_resolved_full": r.get("asset_resolved_full", ""),
-                "asset_resolved_partial": r.get("asset_resolved_partial", ""),
-                "page_manifest_ready": r.get("page_manifest_ready", ""),
-                "ocr_ready": r.get("ocr_ready", ""),
-                "coverage_inherited_from_viewer": r.get("coverage_inherited_from_viewer", ""),
-                "wave_label": r.get("wave_label", ""),
-                "queue_status": r.get("queue_status", ""),
-            }
-            for r in missing
-        ],
+        "identities_without_ftrl_disposition": len(missing),
+        "missing": missing,
+        "extra": extra,
+        "supplemental": sorted(supplemental_keys),
     }
     print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
 
-    # Under the exhaustive protocol, W1 cannot be called complete until every one
-    # of its 40 historical identities has an explicit FTRL disposition.
-    if missing:
+    if missing or extra or len(explicit_ftrl_keys) != EXPECTED_W1:
         raise SystemExit(
-            f"W1 FTRL denominator is not exhaustive: {len(missing)} of {EXPECTED_W1} "
-            "historical identities are absent from the current FTRL readiness cohort"
+            "W1 FTRL denominator is not exhaustive: every one of the 40 historical "
+            "identities must have one explicit FTRL disposition"
         )
 
 

--- a/scripts/build_ftrl_w1_inputs.py
+++ b/scripts/build_ftrl_w1_inputs.py
@@ -1,10 +1,17 @@
 #!/usr/bin/env python3
-"""Build normalized, text-free FTRL inputs for LTMD-U1 W1 Ciencias Naturales.
+"""Build normalized, text-free FTRL inputs for exhaustive LTMD-U1 W1.
 
-The W1 source-admitted cohort is already documented across three versioned
-provenance layers. This script reconciles those layers into the generic FTRL
-asset-manifest and processing-inventory schemas used by the OCR/FTS pipeline.
-It performs no network access and emits no OCR text.
+W1 Ciencias Naturales has 40 historical identities in the master LTMD-U1
+coverage denominator. The original family-readiness register documents 37 of
+those identities. This normalizer preserves that register as historical evidence
+and explicitly supplements it with three already-materialized, versioned source
+layers:
+
+* H1966P6CI374 and H1966P6CI375 from the W1-1966 SHA-256 page manifest;
+* H1993P6CI209 / LTMD-CN6-G1993-DH from the audited CN46 manifest.
+
+The resulting FTRL cohort is exhaustive for the current W1 denominator. The
+script performs no network access and emits no OCR text.
 """
 from __future__ import annotations
 
@@ -14,11 +21,21 @@ import re
 from pathlib import Path
 
 READINESS = Path("data/catalog/ciencias_naturales_family_asset_readiness.csv")
+COVERAGE = Path("data/catalog/ltmd_u1_coverage.csv")
 DIRECT_MANIFEST = Path("data/catalog/ciencias_naturales_pending_page_manifest.csv")
+W1966_MANIFEST = Path("data/catalog/ltmd_u1_w1_1966_page_manifest.csv")
+W1966_SUMMARY = Path("data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv")
 CN46_MANIFEST = Path("data/expansion/cn46_page_manifest.csv")
+CN46_SUMMARY = Path("data/expansion/cn46_page_manifest_summary.csv")
 CN5_SHA_DIR = Path("data/catalog/cn5_pilot_sha")
-VERSION = "LTMD_U1_W1_FTRL_INPUTS_0.1"
+VERSION = "LTMD_U1_W1_FTRL_INPUTS_0.2"
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+EXPECTED_HISTORICAL = 40
+EXPECTED_ALIASES = 4
+EXPECTED_CANONICAL = 36
+EXPECTED_SOURCE_PAGES = 6516
+EXPECTED_INTERNAL_GAPS = 3
+SUPPLEMENTAL_VIEWERS = {"H1966P6CI374", "H1966P6CI375", "H1993P6CI209"}
 PILOT_BOOKS = {
     "LTMD-CN5-G1972",
     "LTMD-CN5-G1988",
@@ -44,6 +61,96 @@ def source_url(viewer_key: str, source_image_index: int) -> str:
         "https://historico.conaliteg.gob.mx/c/"
         f"{viewer_key}/{source_image_index:03d}.jpg"
     )
+
+
+def exhaustive_readiness() -> list[dict[str, str]]:
+    """Return the 40-identity W1 processing cohort without rewriting legacy data."""
+    legacy = read_csv(READINESS)
+    coverage = [
+        row for row in read_csv(COVERAGE)
+        if row.get("operational_domain") == "ciencias_naturales"
+    ]
+    if len(coverage) != EXPECTED_HISTORICAL:
+        raise AssertionError(
+            f"W1 master denominator drift: {len(coverage)} != {EXPECTED_HISTORICAL}"
+        )
+
+    by_viewer = {row["viewer_key"]: row for row in legacy}
+    if len(by_viewer) != len(legacy):
+        raise AssertionError("duplicate viewer_key in legacy W1 readiness")
+    coverage_by_viewer = {row["viewer_key"]: row for row in coverage}
+    if len(coverage_by_viewer) != len(coverage):
+        raise AssertionError("duplicate viewer_key in W1 master denominator")
+    if not set(by_viewer) <= set(coverage_by_viewer):
+        raise AssertionError(
+            f"legacy readiness contains non-W1 identities: "
+            f"{sorted(set(by_viewer) - set(coverage_by_viewer))}"
+        )
+
+    missing = set(coverage_by_viewer) - set(by_viewer)
+    if missing != SUPPLEMENTAL_VIEWERS:
+        raise AssertionError(
+            f"unexpected W1 supplemental identity set: {sorted(missing)}"
+        )
+
+    w1966 = {row["viewer_key"]: row for row in read_csv(W1966_SUMMARY)}
+    cn46 = {row["viewer_key"]: row for row in read_csv(CN46_SUMMARY)}
+
+    for viewer_key in sorted(missing):
+        cov = coverage_by_viewer[viewer_key]
+        if cov.get("asset_resolved_full") != "1" or cov.get("page_manifest_ready") != "1":
+            raise AssertionError(f"supplemental W1 source is not materialized: {viewer_key}")
+        if cov.get("ocr_ready") != "1":
+            raise AssertionError(f"supplemental W1 source is not OCR-ready: {viewer_key}")
+
+        if viewer_key in w1966:
+            src = w1966[viewer_key]
+            strategy = "w1_1966_sha256_manifest"
+            internal_unserved = as_int(src, "internal_unserved")
+            grade = src["grade_code"]
+        elif viewer_key == "H1993P6CI209" and viewer_key in cn46:
+            src = cn46[viewer_key]
+            strategy = "existing_pilot_or_cn46_manifest"
+            internal_unserved = 0
+            grade = src["grade"]
+        else:
+            raise AssertionError(f"no versioned supplemental source for {viewer_key}")
+
+        if src["book_id"] != cov["book_id"]:
+            raise AssertionError(
+                f"book_id mismatch for {viewer_key}: {src['book_id']} != {cov['book_id']}"
+            )
+        if src["catalog_generation"] != cov["catalog_generation"]:
+            raise AssertionError(f"generation mismatch for {viewer_key}")
+        if grade != cov["grade_code"]:
+            raise AssertionError(f"grade mismatch for {viewer_key}")
+        if as_int(src, "unique_source_hashes") != as_int(src, "source_jpegs"):
+            raise AssertionError(f"non-unique supplemental SHA-256 set: {viewer_key}")
+
+        row = {
+            "book_id": cov["book_id"],
+            "viewer_key": viewer_key,
+            "catalog_generation": cov["catalog_generation"],
+            "grade": cov["grade_code"],
+            "viewer_positions_declared": src["viewer_positions"],
+            "resolved_source_assets": src["source_jpegs"],
+            "terminal_synthetic": src["terminal_synthetic"],
+            "internal_unserved_positions": str(internal_unserved),
+            "asset_strategy": strategy,
+            "asset_readiness": "full_versioned_sha256_source",
+            "alias_to_book_id": "",
+            "exhaustive_source_basis": (
+                "ltmd_u1_w1_1966_page_manifest"
+                if viewer_key in w1966
+                else "cn46_page_manifest"
+            ),
+        }
+        legacy.append(row)
+
+    exhaustive_viewers = {row["viewer_key"] for row in legacy}
+    if exhaustive_viewers != set(coverage_by_viewer):
+        raise AssertionError("exhaustive W1 identity reconciliation failed")
+    return legacy
 
 
 def normalized_asset_row(
@@ -73,7 +180,7 @@ def normalized_asset_row(
         "catalog_generation": as_int(readiness, "catalog_generation"),
         "grade_code": as_int(readiness, "grade"),
         "title_core": "Ciencias Naturales",
-        "viewer_ui": "normalized_w1",
+        "viewer_ui": "normalized_w1_exhaustive",
         "ag_clave": readiness["viewer_key"],
         "viewer_page": viewer_page,
         "declared_positions": as_int(readiness, "viewer_positions_declared"),
@@ -118,6 +225,36 @@ def load_direct_rows(
                 byte_size=as_int(row, "byte_size"),
                 sha256=row["sha256"],
                 source_layer="ciencias_naturales_pending_page_manifest",
+                http_status=row.get("http_status", "200"),
+                content_type=row.get("content_type", "image/jpeg"),
+            )
+        )
+    return out
+
+
+def load_1966_rows(
+    readiness_by_id: dict[str, dict[str, str]], canonical: set[str]
+) -> dict[str, list[dict[str, str | int]]]:
+    selected = {
+        bid
+        for bid in canonical
+        if readiness_by_id[bid]["asset_strategy"] == "w1_1966_sha256_manifest"
+    }
+    out = {bid: [] for bid in selected}
+    for row in read_csv(W1966_MANIFEST):
+        bid = row["book_id"]
+        if bid not in selected or row["asset_status"] != "source_jpeg":
+            continue
+        r = readiness_by_id[bid]
+        out[bid].append(
+            normalized_asset_row(
+                readiness=r,
+                viewer_page=as_int(row, "viewer_page"),
+                source_image_index=as_int(row, "source_image_index"),
+                source_asset_url=row["source_asset_url"],
+                byte_size=as_int(row, "byte_size"),
+                sha256=row["sha256"],
+                source_layer="ltmd_u1_w1_1966_page_manifest",
                 http_status=row.get("http_status", "200"),
                 content_type=row.get("content_type", "image/jpeg"),
             )
@@ -208,6 +345,9 @@ def build_processing_rows(
         elif row["book_id"] in PILOT_BOOKS:
             mode = "versioned_sha256_anchor_canonical"
             state = "full_source_anchor"
+        elif row["asset_strategy"] == "w1_1966_sha256_manifest":
+            mode = "versioned_sha256_manifest_canonical"
+            state = "full_materialized_w1_1966_source"
         else:
             mode = "direct_canonical"
             state = "full_direct_or_audited_source"
@@ -263,42 +403,56 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    readiness = read_csv(READINESS)
+    readiness = exhaustive_readiness()
     by_id = {row["book_id"]: row for row in readiness}
     if len(by_id) != len(readiness):
-        raise AssertionError("duplicate W1 book_id in readiness")
-    aliases = {bid: row["alias_to_book_id"] for bid, row in by_id.items() if row["alias_to_book_id"]}
+        raise AssertionError("duplicate W1 book_id in exhaustive readiness")
+    aliases = {
+        bid: row["alias_to_book_id"]
+        for bid, row in by_id.items()
+        if row["alias_to_book_id"]
+    }
     canonical = set(by_id) - set(aliases)
 
-    assert len(readiness) == 37, len(readiness)
-    assert len(aliases) == 4, len(aliases)
-    assert len(canonical) == 33, len(canonical)
+    assert len(readiness) == EXPECTED_HISTORICAL, len(readiness)
+    assert len(aliases) == EXPECTED_ALIASES, len(aliases)
+    assert len(canonical) == EXPECTED_CANONICAL, len(canonical)
     for alias, target in aliases.items():
         assert target in canonical, f"invalid alias target {alias} -> {target}"
 
     layers: dict[str, list[dict[str, str | int]]] = {}
     for source in (
         load_direct_rows(by_id, canonical),
+        load_1966_rows(by_id, canonical),
         load_cn46_rows(by_id, canonical),
         load_cn5_anchor_rows(by_id, canonical),
     ):
         overlap = set(layers) & set(source)
         if overlap:
-            raise AssertionError(f"canonical objects assigned to multiple layers: {sorted(overlap)}")
+            raise AssertionError(
+                f"canonical objects assigned to multiple layers: {sorted(overlap)}"
+            )
         layers.update(source)
 
     if set(layers) != canonical:
         missing = sorted(canonical - set(layers))
         extra = sorted(set(layers) - canonical)
-        raise AssertionError(f"W1 layer reconciliation mismatch missing={missing} extra={extra}")
+        raise AssertionError(
+            f"W1 layer reconciliation mismatch missing={missing} extra={extra}"
+        )
 
     assets: list[dict[str, str | int]] = []
     for bid in sorted(canonical):
         rows = layers[bid]
         expected = as_int(by_id[bid], "resolved_source_assets")
         if len(rows) != expected:
-            raise AssertionError(f"source page mismatch for {bid}: {len(rows)} != {expected}")
-        keys = {(str(r["viewer_key"]), int(r["source_image_index"])) for r in rows}
+            raise AssertionError(
+                f"source page mismatch for {bid}: {len(rows)} != {expected}"
+            )
+        keys = {
+            (str(r["viewer_key"]), int(r["source_image_index"]))
+            for r in rows
+        }
         if len(keys) != len(rows):
             raise AssertionError(f"duplicate source page identity within {bid}")
         assets.extend(rows)
@@ -311,17 +465,26 @@ def main() -> None:
             int(r["source_image_index"]),
         )
     )
-    page_keys = {(str(r["viewer_key"]), int(r["source_image_index"])) for r in assets}
+    page_keys = {
+        (str(r["viewer_key"]), int(r["source_image_index"]))
+        for r in assets
+    }
     assert len(page_keys) == len(assets), "duplicate normalized W1 page identity"
-    assert len(assets) == 5926, len(assets)
+    assert len(assets) == EXPECTED_SOURCE_PAGES, len(assets)
     assert all(int(r["byte_size"]) > 0 for r in assets)
     assert all(SHA256_RE.fullmatch(str(r["sha256"])) for r in assets)
 
     processing = build_processing_rows(readiness)
-    assert len(processing) == 37
-    assert sum(int(r["is_canonical_processing_object"]) for r in processing) == 33
-    assert sum(int(r["persistent_unresolved_source_gaps"]) for r in processing if int(r["is_canonical_processing_object"])) == 3
-    assert sum(int(r["direct_source_jpegs"]) for r in processing) == 5926
+    assert len(processing) == EXPECTED_HISTORICAL
+    assert sum(
+        int(r["is_canonical_processing_object"]) for r in processing
+    ) == EXPECTED_CANONICAL
+    assert sum(
+        int(r["persistent_unresolved_source_gaps"])
+        for r in processing
+        if int(r["is_canonical_processing_object"])
+    ) == EXPECTED_INTERNAL_GAPS
+    assert sum(int(r["direct_source_jpegs"]) for r in processing) == EXPECTED_SOURCE_PAGES
 
     write_csv(args.asset_output, assets)
     write_csv(args.processing_output, processing)
@@ -334,9 +497,10 @@ def main() -> None:
         {
             "schema": VERSION,
             "historical_identities": len(processing),
-            "canonical_processing_objects": 33,
+            "canonical_processing_objects": EXPECTED_CANONICAL,
+            "byte_identical_aliases": EXPECTED_ALIASES,
             "source_admitted_pages": len(assets),
-            "documented_internal_unserved_positions": 3,
+            "documented_internal_unserved_positions": EXPECTED_INTERNAL_GAPS,
             "source_layers": dict(sorted(layer_counts.items())),
             "asset_output": str(args.asset_output),
             "processing_output": str(args.processing_output),

--- a/scripts/preflight_ftrl_w1.py
+++ b/scripts/preflight_ftrl_w1.py
@@ -1,16 +1,19 @@
 #!/usr/bin/env python3
-"""Fail-closed preflight for LTMD-U1 W1 Ciencias Naturales FTRL.
+"""Fail-closed preflight for exhaustive LTMD-U1 W1 Ciencias Naturales FTRL.
 
-The gate reconciles four documentary layers without downloading source assets or
-reading OCR text:
-1) the W1 family readiness register;
+The gate reconciles the 40-identity master W1 denominator against five
+versioned documentary layers without downloading source assets or reading OCR
+text:
+
+1) the legacy 37-identity W1 family readiness register;
 2) the direct SHA-256 manifest summary;
-3) the audited CN4/CN6 expansion manifest;
-4) the versioned CN5 pilot SHA-256 page manifests, cross-checked against prior
+3) the W1-1966 SHA-256 manifest summary (two supplemental identities);
+4) the audited CN4/CN6 expansion manifest, including H1993P6CI209;
+5) the versioned CN5 pilot SHA-256 page manifests, cross-checked against prior
    OCR source-byte metrics and the preserved CI provenance record.
 
-The output is text-free. A technically audited OCR does not substitute for a
-page-level cryptographic source anchor.
+The output is text-free. Cryptographic readiness validates source identity and
+routing; it does not make OCR text verified or the wave semantic-ready.
 """
 from __future__ import annotations
 
@@ -21,7 +24,17 @@ import json
 from collections import defaultdict
 from pathlib import Path
 
-SCHEMA = "LTMD_FTRL_W1_PREFLIGHT_0.2"
+from build_ftrl_w1_inputs import (
+    EXPECTED_ALIASES,
+    EXPECTED_CANONICAL,
+    EXPECTED_HISTORICAL,
+    EXPECTED_INTERNAL_GAPS,
+    EXPECTED_SOURCE_PAGES,
+    exhaustive_readiness,
+)
+
+SCHEMA = "LTMD_FTRL_W1_PREFLIGHT_0.3"
+EXPECTED_TERMINAL_SYNTHETIC = 34
 PILOT_BOOKS = {
     "LTMD-CN5-G1972",
     "LTMD-CN5-G1988",
@@ -43,7 +56,12 @@ def as_int(row: dict[str, str], key: str) -> int:
 
 
 def canonical_json_sha256(value: object) -> str:
-    payload = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
 
 
@@ -51,7 +69,9 @@ def canonical_csv_sha256(rows: list[dict[str, str]]) -> str:
     return canonical_json_sha256(rows)
 
 
-def load_pilot_anchor(anchor_dir: Path) -> tuple[list[dict[str, str]], dict[str, str]]:
+def load_pilot_anchor(
+    anchor_dir: Path,
+) -> tuple[list[dict[str, str]], dict[str, str]]:
     if not anchor_dir.exists():
         return [], {}
     rows: list[dict[str, str]] = []
@@ -65,7 +85,9 @@ def load_pilot_anchor(anchor_dir: Path) -> tuple[list[dict[str, str]], dict[str,
         loaded = read_csv(path)
         file_hashes[path.name] = canonical_csv_sha256(loaded)
         if loaded:
-            assert set(loaded[0]) == expected_fields, f"pilot compact schema drift: {path.name}"
+            assert set(loaded[0]) == expected_fields, (
+                f"pilot compact schema drift: {path.name}"
+            )
         for row in loaded:
             viewer_page = int(row["viewer_page"])
             enriched = dict(row)
@@ -78,43 +100,77 @@ def load_pilot_anchor(anchor_dir: Path) -> tuple[list[dict[str, str]], dict[str,
 
 def main() -> None:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--readiness", default="data/catalog/ciencias_naturales_family_asset_readiness.csv")
-    ap.add_argument("--direct-summary", default="data/catalog/ciencias_naturales_pending_page_manifest_summary.csv")
-    ap.add_argument("--cn46-summary", default="data/expansion/cn46_page_manifest_summary.csv")
+    ap.add_argument(
+        "--direct-summary",
+        default="data/catalog/ciencias_naturales_pending_page_manifest_summary.csv",
+    )
+    ap.add_argument(
+        "--w1966-summary",
+        default="data/catalog/ltmd_u1_w1_1966_page_manifest_summary.csv",
+    )
+    ap.add_argument(
+        "--cn46-summary",
+        default="data/expansion/cn46_page_manifest_summary.csv",
+    )
     ap.add_argument("--pilot-inventory", default="data/book_inventory.csv")
     ap.add_argument("--pilot-sha-dir", default="data/catalog/cn5_pilot_sha")
-    ap.add_argument("--pilot-sha-summary", default="data/catalog/cn5_pilot_sha_manifest_summary.json")
-    ap.add_argument("--pilot-sha-provenance", default="data/catalog/cn5_pilot_sha_provenance.json")
-    ap.add_argument("--pilot-ocr-metrics", default="data/derived/ocr_page_metrics.csv")
-    ap.add_argument("--output", default="local/ftrl/ltmd_u1_w1_preflight.json")
+    ap.add_argument(
+        "--pilot-sha-summary",
+        default="data/catalog/cn5_pilot_sha_manifest_summary.json",
+    )
+    ap.add_argument(
+        "--pilot-sha-provenance",
+        default="data/catalog/cn5_pilot_sha_provenance.json",
+    )
+    ap.add_argument(
+        "--pilot-ocr-metrics",
+        default="data/derived/ocr_page_metrics.csv",
+    )
+    ap.add_argument(
+        "--output",
+        default="local/ftrl/ltmd_u1_w1_preflight.json",
+    )
     ap.add_argument("--require-cryptographic-ready", action="store_true")
     args = ap.parse_args()
 
-    readiness = read_csv(Path(args.readiness))
+    readiness = exhaustive_readiness()
     direct = read_csv(Path(args.direct_summary))
+    w1966 = read_csv(Path(args.w1966_summary))
     cn46 = read_csv(Path(args.cn46_summary))
     pilot_inventory = read_csv(Path(args.pilot_inventory))
     pilot_rows, pilot_file_hashes = load_pilot_anchor(Path(args.pilot_sha_dir))
 
     r_by_id = {r["book_id"]: r for r in readiness}
-    assert len(r_by_id) == len(readiness), "duplicate book_id in readiness"
+    assert len(r_by_id) == len(readiness), "duplicate book_id in exhaustive readiness"
 
     historical = set(r_by_id)
-    aliases = {bid: r["alias_to_book_id"] for bid, r in r_by_id.items() if r["alias_to_book_id"]}
+    aliases = {
+        bid: r["alias_to_book_id"]
+        for bid, r in r_by_id.items()
+        if r["alias_to_book_id"]
+    }
     canonical = historical - set(aliases)
 
     for alias, target in aliases.items():
         assert target in historical, f"alias target absent: {alias} -> {target}"
-        assert not r_by_id[target]["alias_to_book_id"], f"alias target is itself alias: {target}"
+        assert not r_by_id[target]["alias_to_book_id"], (
+            f"alias target is itself alias: {target}"
+        )
         assert r_by_id[alias]["asset_readiness"] == "full_alias_same_bytes", alias
-        assert as_int(r_by_id[alias], "resolved_source_assets") == as_int(r_by_id[target], "resolved_source_assets"), alias
+        assert as_int(r_by_id[alias], "resolved_source_assets") == as_int(
+            r_by_id[target], "resolved_source_assets"
+        ), alias
 
     direct_by_id = {r["book_id"]: r for r in direct}
     assert len(direct_by_id) == len(direct), "duplicate book_id in direct summary"
+    w1966_by_id = {r["book_id"]: r for r in w1966}
+    assert len(w1966_by_id) == 2, "W1-1966 supplemental summary must contain two books"
     cn46_by_id = {r["book_id"]: r for r in cn46}
     assert len(cn46_by_id) == len(cn46), "duplicate book_id in CN46 summary"
     pilot_inventory_by_id = {r["book_id"]: r for r in pilot_inventory}
-    assert len(pilot_inventory_by_id) == len(pilot_inventory), "duplicate book_id in pilot inventory"
+    assert len(pilot_inventory_by_id) == len(pilot_inventory), (
+        "duplicate book_id in pilot inventory"
+    )
 
     pilot_by_id: dict[str, list[dict[str, str]]] = defaultdict(list)
     pilot_byte_matches = 0
@@ -122,21 +178,38 @@ def main() -> None:
     pilot_anchor_summary_validated = False
 
     if pilot_rows:
-        assert {r["book_id"] for r in pilot_rows} == PILOT_BOOKS, "pilot SHA manifest book set drift"
+        assert {r["book_id"] for r in pilot_rows} == PILOT_BOOKS, (
+            "pilot SHA manifest book set drift"
+        )
         assert len(pilot_rows) == 759, len(pilot_rows)
-        assert len({r["page_id"] for r in pilot_rows}) == 759, "duplicate pilot page_id"
-        assert all(r["asset_status"] == "source_jpeg" for r in pilot_rows), "non-JPEG pilot row"
-        assert all(len(r["sha256"]) == 64 and set(r["sha256"]) <= set("0123456789abcdef") for r in pilot_rows), "invalid pilot SHA-256"
+        assert len({r["page_id"] for r in pilot_rows}) == 759, (
+            "duplicate pilot page_id"
+        )
+        assert all(r["asset_status"] == "source_jpeg" for r in pilot_rows), (
+            "non-JPEG pilot row"
+        )
+        assert all(
+            len(r["sha256"]) == 64
+            and set(r["sha256"]) <= set("0123456789abcdef")
+            for r in pilot_rows
+        ), "invalid pilot SHA-256"
         for row in pilot_rows:
             pilot_by_id[row["book_id"]].append(row)
 
         expected_files = {
-            "LTMD-CN5-G1972-part01.csv", "LTMD-CN5-G1972-part02.csv", "LTMD-CN5-G1972-part03.csv",
-            "LTMD-CN5-G1988-part01.csv", "LTMD-CN5-G1988-part02.csv",
-            "LTMD-CN5-G1993-part01.csv", "LTMD-CN5-G1993-part02.csv",
-            "LTMD-CN5-G2014-part01.csv", "LTMD-CN5-G2014-part02.csv",
+            "LTMD-CN5-G1972-part01.csv",
+            "LTMD-CN5-G1972-part02.csv",
+            "LTMD-CN5-G1972-part03.csv",
+            "LTMD-CN5-G1988-part01.csv",
+            "LTMD-CN5-G1988-part02.csv",
+            "LTMD-CN5-G1993-part01.csv",
+            "LTMD-CN5-G1993-part02.csv",
+            "LTMD-CN5-G2014-part01.csv",
+            "LTMD-CN5-G2014-part02.csv",
         }
-        assert set(pilot_file_hashes) == expected_files, f"pilot anchor file set drift: {sorted(pilot_file_hashes)}"
+        assert set(pilot_file_hashes) == expected_files, (
+            f"pilot anchor file set drift: {sorted(pilot_file_hashes)}"
+        )
 
         summary_path = Path(args.pilot_sha_summary)
         provenance_path = Path(args.pilot_sha_provenance)
@@ -151,9 +224,15 @@ def main() -> None:
         assert summary["prior_ocr_metric_byte_matches"] == 759
         assert summary["source_byte_drift"] == 0
         assert provenance["schema"] == "LTMD_CN5_PILOT_SHA_PROVENANCE_0.1"
-        assert provenance["publication_scope"] == "metadata_and_hashes_only_no_source_bytes_no_ocr_text"
-        assert provenance["summary_canonical_sha256"] == canonical_json_sha256(summary), "pilot summary canonical hash drift"
-        assert provenance["compact_manifest_canonical_sha256"] == pilot_file_hashes, "pilot compact-manifest canonical hash drift"
+        assert provenance["publication_scope"] == (
+            "metadata_and_hashes_only_no_source_bytes_no_ocr_text"
+        )
+        assert provenance["summary_canonical_sha256"] == canonical_json_sha256(
+            summary
+        ), "pilot summary canonical hash drift"
+        assert provenance["compact_manifest_canonical_sha256"] == pilot_file_hashes, (
+            "pilot compact-manifest canonical hash drift"
+        )
         pilot_anchor_files_validated = len(pilot_file_hashes)
         pilot_anchor_summary_validated = True
 
@@ -166,8 +245,12 @@ def main() -> None:
         assert len(metric_bytes) == 759, len(metric_bytes)
         for row in pilot_rows:
             pid = row["page_id"]
-            assert pid in metric_bytes, f"pilot page absent from prior OCR metrics: {pid}"
-            assert int(row["byte_size"]) == metric_bytes[pid], f"pilot source-byte drift: {pid}"
+            assert pid in metric_bytes, (
+                f"pilot page absent from prior OCR metrics: {pid}"
+            )
+            assert int(row["byte_size"]) == metric_bytes[pid], (
+                f"pilot source-byte drift: {pid}"
+            )
             pilot_byte_matches += 1
 
     coverage: dict[str, str] = {}
@@ -179,6 +262,8 @@ def main() -> None:
         candidates: list[str] = []
         if bid in direct_by_id and as_int(direct_by_id[bid], "source_jpegs") > 0:
             candidates.append("direct_sha256_manifest")
+        if bid in w1966_by_id and as_int(w1966_by_id[bid], "source_jpegs") > 0:
+            candidates.append("w1_1966_sha256_manifest")
         if bid in cn46_by_id:
             candidates.append("cn46_sha256_manifest")
         if bid in PILOT_BOOKS:
@@ -196,26 +281,59 @@ def main() -> None:
         coverage[bid] = candidates[0]
 
         resolved = as_int(r_by_id[bid], "resolved_source_assets")
-        if candidates[0] == "direct_sha256_manifest":
+        layer = candidates[0]
+        if layer == "direct_sha256_manifest":
             row = direct_by_id[bid]
-            assert as_int(row, "source_jpegs") == resolved, f"direct page mismatch: {bid}"
-            assert as_int(row, "unique_source_hashes") == resolved, f"direct hash mismatch: {bid}"
-        elif candidates[0] == "cn46_sha256_manifest":
+            assert as_int(row, "source_jpegs") == resolved, (
+                f"direct page mismatch: {bid}"
+            )
+            assert as_int(row, "unique_source_hashes") == resolved, (
+                f"direct hash mismatch: {bid}"
+            )
+        elif layer == "w1_1966_sha256_manifest":
+            row = w1966_by_id[bid]
+            assert as_int(row, "source_jpegs") == resolved, (
+                f"W1-1966 page mismatch: {bid}"
+            )
+            assert as_int(row, "unique_source_hashes") == resolved, (
+                f"W1-1966 hash mismatch: {bid}"
+            )
+            assert as_int(row, "internal_unserved") == 0, (
+                f"unexpected W1-1966 internal gap: {bid}"
+            )
+        elif layer == "cn46_sha256_manifest":
             row = cn46_by_id[bid]
-            assert as_int(row, "source_jpegs") == resolved, f"CN46 page mismatch: {bid}"
-            assert as_int(row, "unique_source_hashes") == resolved, f"CN46 hash mismatch: {bid}"
-        elif candidates[0] == "pilot_sha256_manifest":
+            assert as_int(row, "source_jpegs") == resolved, (
+                f"CN46 page mismatch: {bid}"
+            )
+            assert as_int(row, "unique_source_hashes") == resolved, (
+                f"CN46 hash mismatch: {bid}"
+            )
+        elif layer == "pilot_sha256_manifest":
             rows = pilot_by_id[bid]
             assert len(rows) == resolved, f"pilot page mismatch: {bid}"
-            assert len({r["page_id"] for r in rows}) == resolved, f"pilot page-id mismatch: {bid}"
+            assert len({r["page_id"] for r in rows}) == resolved, (
+                f"pilot page-id mismatch: {bid}"
+            )
         else:
             row = pilot_inventory_by_id[bid]
-            assert as_int(row, "source_asset_count") == resolved, f"pilot asset mismatch: {bid}"
+            assert as_int(row, "source_asset_count") == resolved, (
+                f"pilot asset mismatch: {bid}"
+            )
 
-        if strategy in {"direct_sha256_manifest", "direct_manifest_plus_focused_gap_audit"}:
-            assert candidates[0] == "direct_sha256_manifest", f"strategy/layer mismatch: {bid}"
+        if strategy in {
+            "direct_sha256_manifest",
+            "direct_manifest_plus_focused_gap_audit",
+        }:
+            assert layer == "direct_sha256_manifest", (
+                f"strategy/layer mismatch: {bid}"
+            )
+        elif strategy == "w1_1966_sha256_manifest":
+            assert layer == "w1_1966_sha256_manifest", (
+                f"strategy/layer mismatch: {bid}"
+            )
         elif strategy == "existing_pilot_or_cn46_manifest":
-            assert candidates[0] in {
+            assert layer in {
                 "cn46_sha256_manifest",
                 "pilot_sha256_manifest",
                 "pilot_reconstructible_unanchored",
@@ -223,20 +341,36 @@ def main() -> None:
         else:
             raise AssertionError(f"unexpected canonical strategy: {bid}: {strategy}")
 
-    assert not missing_layer, f"canonical objects without documentary layer: {missing_layer}"
+    assert not missing_layer, (
+        f"canonical objects without documentary layer: {missing_layer}"
+    )
     assert not overlaps, f"overlapping canonical layers: {overlaps}"
 
     cn46_outside = sorted(set(cn46_by_id) - historical)
-    page_count = sum(as_int(r_by_id[bid], "resolved_source_assets") for bid in canonical)
-    internal_holes = sum(as_int(r_by_id[bid], "internal_unserved_positions") for bid in canonical)
-    terminal_synthetic = sum(as_int(r_by_id[bid], "terminal_synthetic") for bid in canonical)
-    unanchored = sorted(bid for bid, layer in coverage.items() if layer == "pilot_reconstructible_unanchored")
+    page_count = sum(
+        as_int(r_by_id[bid], "resolved_source_assets") for bid in canonical
+    )
+    internal_holes = sum(
+        as_int(r_by_id[bid], "internal_unserved_positions") for bid in canonical
+    )
+    terminal_synthetic = sum(
+        as_int(r_by_id[bid], "terminal_synthetic") for bid in canonical
+    )
+    unanchored = sorted(
+        bid
+        for bid, layer in coverage.items()
+        if layer == "pilot_reconstructible_unanchored"
+    )
 
-    assert len(historical) == 37, len(historical)
-    assert len(aliases) == 4, len(aliases)
-    assert len(canonical) == 33, len(canonical)
-    assert page_count == 5926, page_count
-    assert internal_holes == 3, internal_holes
+    assert len(historical) == EXPECTED_HISTORICAL, len(historical)
+    assert len(aliases) == EXPECTED_ALIASES, len(aliases)
+    assert len(canonical) == EXPECTED_CANONICAL, len(canonical)
+    assert page_count == EXPECTED_SOURCE_PAGES, page_count
+    assert internal_holes == EXPECTED_INTERNAL_GAPS, internal_holes
+    assert terminal_synthetic == EXPECTED_TERMINAL_SYNTHETIC, terminal_synthetic
+    assert not cn46_outside, (
+        f"CN46 objects outside exhaustive W1 denominator: {cn46_outside}"
+    )
     if pilot_rows:
         assert len(pilot_by_id) == 4
         assert sum(len(v) for v in pilot_by_id.values()) == 759
@@ -244,7 +378,11 @@ def main() -> None:
         assert pilot_anchor_files_validated == 9
         assert pilot_anchor_summary_validated
 
-    status = "ready" if not unanchored else "blocked_missing_versioned_pilot_sha_manifest"
+    status = (
+        "ready"
+        if not unanchored
+        else "blocked_missing_versioned_pilot_sha_manifest"
+    )
     result = {
         "schema": SCHEMA,
         "wave": "W1",
@@ -260,6 +398,8 @@ def main() -> None:
             layer: sum(v == layer for v in coverage.values())
             for layer in sorted(set(coverage.values()))
         },
+        "supplemental_historical_identities": 3,
+        "legacy_family_readiness_identities": 37,
         "pilot_sha256_objects": len(pilot_by_id),
         "pilot_sha256_pages": sum(len(v) for v in pilot_by_id.values()),
         "pilot_prior_ocr_byte_matches": pilot_byte_matches,
@@ -267,16 +407,23 @@ def main() -> None:
         "pilot_anchor_summary_validated": pilot_anchor_summary_validated,
         "unanchored_pilot_objects": unanchored,
         "cn46_objects_outside_w1_readiness": cn46_outside,
-        "interpretation": "Cryptographic readiness validates source identity and routing only; it does not make OCR text verified or the wave semantic-ready.",
+        "interpretation": (
+            "Exhaustive cryptographic readiness validates source identity and routing "
+            "for all 40 W1 historical identities only; it does not make OCR text "
+            "verified or the wave semantic-ready."
+        ),
     }
 
     output = Path(args.output)
     output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
     print(json.dumps(result, ensure_ascii=False, indent=2))
 
     if args.require_cryptographic_ready and status != "ready":
-        raise SystemExit("W1 is not cryptographically ready for full FTRL")
+        raise SystemExit("W1 is not cryptographically ready for exhaustive full FTRL")
 
 
 if __name__ == "__main__":

--- a/scripts/run_ftrl_w1.py
+++ b/scripts/run_ftrl_w1.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run LTMD-U1 W1 Ciencias Naturales through the FTRL pipeline."""
+"""Run exhaustive LTMD-U1 W1 Ciencias Naturales through the FTRL pipeline."""
 from __future__ import annotations
 
 import argparse
@@ -10,6 +10,8 @@ import sqlite3
 import subprocess
 import sys
 from pathlib import Path
+
+EXPECTED_W1_SOURCE_PAGES = 6516
 
 
 def require_environment() -> None:
@@ -52,7 +54,9 @@ def write_rows(path: Path, rows: list[dict[str, str]]) -> None:
         writer.writerows(rows)
 
 
-def balanced_shards(rows: list[dict[str, str]], count: int) -> list[list[dict[str, str]]]:
+def balanced_shards(
+    rows: list[dict[str, str]], count: int
+) -> list[list[dict[str, str]]]:
     count = max(1, min(count, len(rows)))
     base, remainder = divmod(len(rows), count)
     shards: list[list[dict[str, str]]] = []
@@ -123,13 +127,19 @@ def run_ocr_shards(
                     record = json.loads(line)
                     page_id = str(record["page_id"])
                     if page_id in page_ids:
-                        raise SystemExit(f"duplicate OCR page_id across shards: {page_id}")
+                        raise SystemExit(
+                            f"duplicate OCR page_id across shards: {page_id}"
+                        )
                     page_ids.add(page_id)
-                    out.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+                    out.write(
+                        json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+                    )
                     count += 1
     temp.replace(combined)
     if count != len(rows):
-        raise SystemExit(f"combined OCR cardinality mismatch: {count} != {len(rows)}")
+        raise SystemExit(
+            f"combined OCR cardinality mismatch: {count} != {len(rows)}"
+        )
     return combined
 
 
@@ -173,8 +183,11 @@ def main() -> None:
     )
 
     rows = read_rows(asset_manifest)
-    if len(rows) != 5926:
-        raise SystemExit(f"normalized W1 asset cardinality drifted: {len(rows)}")
+    if len(rows) != EXPECTED_W1_SOURCE_PAGES:
+        raise SystemExit(
+            "normalized exhaustive W1 asset cardinality drifted: "
+            f"{len(rows)} != {EXPECTED_W1_SOURCE_PAGES}"
+        )
     if not args.full:
         rows = rows[: args.pages]
         label = f"pilot_{len(rows)}"


### PR DESCRIPTION
## Propósito

Reconciliar la FTRL de W1 Ciencias Naturales con el denominador maestro exhaustivo LTMD-U1 antes de cualquier nueva corrida OCR integral.

## Hallazgo

La cohorte FTRL previa contenía 37 identidades históricas / 33 objetos canónicos / 5,926 JPEG fuente, mientras `data/catalog/ltmd_u1_coverage.csv` contiene 40 identidades en `operational_domain=ciencias_naturales`.

Las tres identidades faltantes no son retenciones ni fuentes no resueltas:

- `H1966P6CI374` — 178 JPEG fuente, SHA-256 versionado;
- `H1966P6CI375` — 162 JPEG fuente, SHA-256 versionado;
- `H1993P6CI209` / `LTMD-CN6-G1993-DH` — 250 JPEG fuente en CN46.

Total suplementario: 590 páginas. Cohorte exhaustiva corregida: **40 identidades / 36 objetos canónicos / 4 aliases / 6,516 JPEG fuente / 3 huecos internos documentados**.

## Implementación

- conserva intacto el registro histórico `ciencias_naturales_family_asset_readiness.csv` de 37 identidades;
- añade un gate 40/40 contra el denominador maestro;
- normaliza las tres disposiciones suplementarias desde manifiestos ya versionados;
- eleva `build_ftrl_w1_inputs.py` a la cohorte exhaustiva 6,516;
- eleva el preflight a `LTMD_FTRL_W1_PREFLIGHT_0.3`;
- actualiza piloto runtime y gate full-corpus a 40/36/6,516;
- desactiva como disparador exhaustivo el sello antiguo de 5,926 páginas y reserva `ltmd_u1_w1_exhaustive_full_run_stamp.json` para la corrida corregida;
- preregistra `docs/FTRL_W1_FULL_EXECUTION_PROTOCOL_0_2.md`, que supersede operativamente 0.1 para afirmaciones de exhaustividad.

## Regla de interpretación

Este PR no declara W1 `corpus_ready`, `ocr_available` ni `semantic_ready`. Primero deben pasar los gates del PR; después se activará una corrida integral nueva de 6,516 páginas y se validará su evidencia text-free.