### PR TITLE
CI: reportar cierre de corrida integral W1 en issue #15

### DIFF
--- a/.github/workflows/report-ftrl-w1-full.yml
+++ b/.github/workflows/report-ftrl-w1-full.yml
@@ -1,0 +1,40 @@
+name: Report exhaustive FTRL W1 full-run completion
+
+on:
+  workflow_run:
+    workflows: ['Validate exhaustive FTRL W1 full corpus']
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  report-w1-full-run:
+    if: >-
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish text-free run checkpoint to issue 15
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run;
+            const body = [
+              '### FTRL W1 — cierre automático de corrida integral exhaustiva',
+              '',
+              `- Workflow run: ${run.id}`,
+              `- Conclusion: \`${run.conclusion}\``,
+              `- Event: \`${run.event}\``,
+              `- Head SHA: \`${run.head_sha}\``,
+              `- Run URL: ${run.html_url}`,
+              '',
+              'Este checkpoint es exclusivamente técnico y text-free. Una conclusión `success` no promueve por sí sola W1 a `text_verified` ni `semantic_ready`; primero debe validarse la evidencia agregada de la corrida.'
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 15,
+              body,
+            });


### PR DESCRIPTION
Añade un observador `workflow_run` para la corrida integral exhaustiva W1. Al terminar, registra en el issue #15 únicamente run ID, conclusión, evento, commit y URL de Actions. No publica OCR, snippets, imágenes ni índices.

El objetivo es hacer auditable la ejecución larga disparada por `push` y eliminar la dependencia de inspección manual de Actions. El comentario no promueve automáticamente estados científicos; la evidencia agregada debe revisarse por separado.