### PR TITLE
Preservación: activar archivo privado W1 en Drive

### DIFF
--- a/.github/workflows/preserve-ftrl-w1-private.yml
+++ b/.github/workflows/preserve-ftrl-w1-private.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: preserve-ftrl-w1-private
@@ -21,6 +22,12 @@ jobs:
     steps:
       - name: Checkout exact revision
         uses: actions/checkout@v4
+
+      - name: Announce private preservation run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W1 — preservación privada iniciada. Run ${GITHUB_RUN_ID}; commit ${GITHUB_SHA}; alcance 40 identidades / 36 objetos canónicos / 6,516 páginas. La salida restringida sólo se cargará como handoff cifrado; destino canónico final: Google Drive privado. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -154,3 +161,33 @@ jobs:
             local/private-handoff/ltmd_u1_w1_private_handoff_manifest.json
           if-no-files-found: error
           retention-days: 2
+
+      - name: Report encrypted handoff ready
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          m = json.loads(Path('local/private-handoff/ltmd_u1_w1_private_handoff_manifest.json').read_text(encoding='utf-8'))
+          payload = next(x for x in m['files'] if x['name'].endswith('.tar.gz.enc'))
+          repo = os.environ['GITHUB_REPOSITORY']
+          run_id = os.environ['GITHUB_RUN_ID']
+          body = (
+              f"FTRL W1 — handoff privado cifrado LISTO. Run {run_id}; "
+              f"6,516/6,516 páginas validadas; SHA-256 del payload cifrado: `{payload['sha256']}`; "
+              f"artifact: `ltmd-u1-w1-private-encrypted-handoff`. "
+              f"Este estado todavía es `archival_complete=no` hasta verificar la copia persistente en Google Drive privado. "
+              f"Run: https://github.com/{repo}/actions/runs/{run_id}"
+          )
+          Path('local/private-handoff/issue15-ready.txt').write_text(body, encoding='utf-8')
+          PY
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body-file local/private-handoff/issue15-ready.txt
+
+      - name: Report private preservation failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W1 — preservación privada FALLÓ en run ${GITHUB_RUN_ID}. No se declara `archival_complete`. No se debe sustituir por un archivo parcial ni por OCR no verificado. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/validate-private-corpus-preservation.yml
+++ b/.github/workflows/validate-private-corpus-preservation.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - 'docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md'
       - 'data/research/ltmd_private_corpus_storage_contract.json'
+      - 'data/research/ltmd_u1_w1_private_preservation_stamp.json'
       - 'security/ltmd_archive_public.pem'
       - 'scripts/validate_private_corpus_storage_contract.py'
       - '.github/workflows/validate-private-corpus-preservation.yml'
+      - '.github/workflows/preserve-ftrl-w1-private.yml'
       - '.gitignore'
   workflow_dispatch:
 

--- a/data/research/ltmd_u1_w1_private_preservation_stamp.json
+++ b/data/research/ltmd_u1_w1_private_preservation_stamp.json
@@ -1,0 +1,17 @@
+{
+  "schema": "LTMD_FTRL_W1_PRIVATE_PRESERVATION_ACTIVATION_0.1",
+  "effective_date": "2026-08-24",
+  "wave": "W1",
+  "domain": "Ciencias Naturales",
+  "historical_identities": 40,
+  "canonical_processing_objects": 36,
+  "source_admitted_jpegs": 6516,
+  "destination": "private_google_drive",
+  "logical_destination": "LTMD-U1 — corpus FTRL privado/W1 — Ciencias Naturales/run_32768285396__d3ad64f__2026-08-24",
+  "encryption_handoff": "required",
+  "archive_public_key_sha256": "78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d",
+  "source_full_run_id": "32768285396",
+  "source_full_run_commit": "d3ad64f789570fb7a2b8557dcb0c69c7a2beca6d",
+  "reason": "Persistent preservation canon was adopted after the original exhaustive W1 run had started; its ephemeral workspace cannot be retroactively converted into a persistent private archive.",
+  "rule": "This stamp authorizes a reproducible preservation rerun. It does not alter the scientific denominator, OCR methodology, source manifests, or semantic status."
+}


### PR DESCRIPTION
Activa una reconstrucción de preservación de W1 Ciencias Naturales bajo el canon privado fusionado en PR #41. La corrida vuelve a generar exactamente la cohorte exhaustiva 40 identidades / 36 objetos canónicos / 6,516 páginas, la valida y crea únicamente un handoff cifrado para su custodia persistente en Google Drive privado.

No cambia el denominador, los manifiestos fuente, la metodología OCR ni el estado semántico. La repetición es necesaria porque la corrida exhaustiva original comenzó antes de adoptarse el canon y su filesystem de Actions era efímero.