### PR TITLE
Preservación: cerrar deuda archivística W5 en Drive privado

### DIFF
--- a/.github/workflows/preserve-ftrl-w5-private.yml
+++ b/.github/workflows/preserve-ftrl-w5-private.yml
@@ -1,0 +1,188 @@
+name: Preserve validated FTRL W5 private corpus
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w5_private_preservation_stamp.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: preserve-ftrl-w5-private
+  cancel-in-progress: false
+
+jobs:
+  preserve-w5:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Announce private preservation run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 — preservación privada iniciada. Run ${GITHUB_RUN_ID}; commit ${GITHUB_SHA}; alcance 18 identidades / 15 objetos canónicos / 2,653 páginas. La salida restringida sólo se cargará como handoff cifrado; destino canónico final: Google Drive privado. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Validate private preservation canon
+        run: python scripts/validate_private_corpus_storage_contract.py
+
+      - name: Reconstruct complete validated W5 FTRL
+        run: |
+          python scripts/run_ftrl_w5_pilot.py \
+            --full \
+            --run-preregistered-queries \
+            --output-dir local/ftrl
+
+      - name: Assert validated W5 corpus before archiving
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          manifest = json.loads(Path('local/ftrl/ltmd_u1_w5_full_run_manifest.json').read_text(encoding='utf-8'))
+          summary = json.loads(Path('local/ftrl/ltmd_u1_w5_query_summary.json').read_text(encoding='utf-8'))
+          assert manifest['status'] == 'validated'
+          assert manifest['corpus']['page_records'] == 2653
+          assert manifest['database']['page_rows'] == 2653
+          assert manifest['database']['fts_rows'] == 2653
+          assert manifest['database']['sqlite_integrity'] == 'ok'
+          assert manifest['corpus']['canonical_viewers'] == 15
+          assert manifest['database']['historical_identities'] == 18
+          assert summary['queries']
+          PY
+
+      - name: Build restricted archive locally
+        run: |
+          mkdir -p local/private-handoff
+          tar -czf local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz \
+            local/ftrl/ltmd_u1_w5_full_page_ocr.jsonl \
+            local/ftrl/ltmd_u1_w5_full_ocr_search.sqlite \
+            local/ftrl/ltmd_u1_w5_query_candidates.json \
+            local/ftrl/ltmd_u1_w5_full_run_manifest.json \
+            local/ftrl/ltmd_u1_w5_query_summary.json \
+            data/catalog/ltmd_u1_w5_history_asset_manifest.csv \
+            data/catalog/ltmd_u1_w5_history_processing_inventory.csv \
+            data/research/ltmd_ftrl_w5_preregistered_queries.csv
+
+      - name: Encrypt restricted archive for private Drive handoff
+        run: |
+          openssl rand -base64 48 > /tmp/ltmd_archive.pass
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz \
+            -out local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz.enc \
+            -pass file:/tmp/ltmd_archive.pass
+          openssl pkeyutl -encrypt \
+            -pubin \
+            -inkey security/ltmd_archive_public.pem \
+            -in /tmp/ltmd_archive.pass \
+            -out local/private-handoff/ltmd_u1_w5_archive_passphrase.rsa-oaep.enc \
+            -pkeyopt rsa_padding_mode:oaep \
+            -pkeyopt rsa_oaep_md:sha256
+          sha256sum \
+            local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz.enc \
+            local/private-handoff/ltmd_u1_w5_archive_passphrase.rsa-oaep.enc \
+            > local/private-handoff/SHA256SUMS.txt
+          rm -f local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz /tmp/ltmd_archive.pass
+
+      - name: Write text-free private handoff manifest
+        env:
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          root = Path('local/private-handoff')
+          def digest(name):
+              p = root / name
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': hashlib.sha256(p.read_bytes()).hexdigest()}
+          out = {
+              'schema': 'LTMD_PRIVATE_FTRL_HANDOFF_0.1',
+              'wave': 'W5',
+              'domain': 'Historia',
+              'historical_identities': 18,
+              'canonical_processing_objects': 15,
+              'page_records': 2653,
+              'source_commit': os.environ['GH_SHA'],
+              'workflow_run_id': os.environ['GH_RUN_ID'],
+              'encryption': {
+                  'payload': 'AES-256-CBC + PBKDF2-SHA256, 250000 iterations',
+                  'key_wrap': 'RSA-4096 OAEP SHA-256',
+                  'public_key_sha256': '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'
+              },
+              'files': [
+                  digest('ltmd_u1_w5_full_restricted.tar.gz.enc'),
+                  digest('ltmd_u1_w5_archive_passphrase.rsa-oaep.enc'),
+                  digest('SHA256SUMS.txt'),
+              ],
+              'destination_policy': 'private Google Drive; encrypted Actions artifact is temporary handoff only',
+              'archival_complete': False
+          }
+          (root / 'ltmd_u1_w5_private_handoff_manifest.json').write_text(json.dumps(out, indent=2) + '\n', encoding='utf-8')
+          PY
+
+      - name: Prove no plaintext restricted archive is uploaded
+        run: |
+          test ! -f local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz
+          test ! -f /tmp/ltmd_archive.pass
+          test -f local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz.enc
+          test -f local/private-handoff/ltmd_u1_w5_archive_passphrase.rsa-oaep.enc
+          grep -q 'BEGIN PUBLIC KEY' security/ltmd_archive_public.pem
+
+      - name: Upload encrypted private handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w5-private-encrypted-handoff
+          path: |
+            local/private-handoff/ltmd_u1_w5_full_restricted.tar.gz.enc
+            local/private-handoff/ltmd_u1_w5_archive_passphrase.rsa-oaep.enc
+            local/private-handoff/SHA256SUMS.txt
+            local/private-handoff/ltmd_u1_w5_private_handoff_manifest.json
+          if-no-files-found: error
+          retention-days: 2
+
+      - name: Report encrypted handoff ready
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          m = json.loads(Path('local/private-handoff/ltmd_u1_w5_private_handoff_manifest.json').read_text(encoding='utf-8'))
+          payload = next(x for x in m['files'] if x['name'].endswith('.tar.gz.enc'))
+          repo = os.environ['GITHUB_REPOSITORY']
+          run_id = os.environ['GITHUB_RUN_ID']
+          body = (
+              f"FTRL W5 — handoff privado cifrado LISTO. Run {run_id}; "
+              f"2,653/2,653 páginas validadas; SHA-256 del payload cifrado: `{payload['sha256']}`; "
+              f"artifact: `ltmd-u1-w5-private-encrypted-handoff`. "
+              f"Este estado todavía es `archival_complete=no` hasta verificar la copia persistente en Google Drive privado. "
+              f"Run: https://github.com/{repo}/actions/runs/{run_id}"
+          )
+          Path('local/private-handoff/issue15-ready.txt').write_text(body, encoding='utf-8')
+          PY
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body-file local/private-handoff/issue15-ready.txt
+
+      - name: Report private preservation failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W5 — preservación privada FALLÓ en run ${GITHUB_RUN_ID}. No se declara `archival_complete`. No se debe sustituir por un archivo parcial ni por OCR no verificado. Run: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/.github/workflows/validate-private-corpus-preservation.yml
+++ b/.github/workflows/validate-private-corpus-preservation.yml
@@ -7,10 +7,12 @@ on:
       - 'docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md'
       - 'data/research/ltmd_private_corpus_storage_contract.json'
       - 'data/research/ltmd_u1_w1_private_preservation_stamp.json'
+      - 'data/research/ltmd_u1_w5_private_preservation_stamp.json'
       - 'security/ltmd_archive_public.pem'
       - 'scripts/validate_private_corpus_storage_contract.py'
       - '.github/workflows/validate-private-corpus-preservation.yml'
       - '.github/workflows/preserve-ftrl-w1-private.yml'
+      - '.github/workflows/preserve-ftrl-w5-private.yml'
       - '.gitignore'
   workflow_dispatch:
 

--- a/data/research/ltmd_u1_w5_private_preservation_stamp.json
+++ b/data/research/ltmd_u1_w5_private_preservation_stamp.json
@@ -1,0 +1,17 @@
+{
+  "schema": "LTMD_FTRL_W5_PRIVATE_PRESERVATION_ACTIVATION_0.1",
+  "effective_date": "2026-08-24",
+  "wave": "W5",
+  "domain": "Historia",
+  "historical_identities": 18,
+  "canonical_processing_objects": 15,
+  "source_admitted_jpegs": 2653,
+  "destination": "private_google_drive",
+  "logical_destination": "LTMD-U1 — corpus FTRL privado/W5 — Historia/run_32748987531__e200b252__2026-08-24",
+  "encryption_handoff": "required",
+  "archive_public_key_sha256": "78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d",
+  "source_validated_run_id": "32748987531",
+  "source_validated_run_commit": "e200b252d3acadf4b56cee33d6ff92f4040d8e1c",
+  "reason": "W5 was computationally validated before persistent private preservation became canonical; this reproducible rerun closes the archival debt.",
+  "rule": "This stamp authorizes a preservation rerun only. It does not alter the validated W5 scientific cohort or semantic status."
+}


### PR DESCRIPTION
Aplica retroactivamente el canon de preservación privada a W5 Historia, cuya corrida integral de 2,653 páginas ya fue validada técnicamente antes de adoptar almacenamiento persistente.

Añade una reconstrucción de preservación que valida 18 identidades / 15 objetos canónicos / 2,653 páginas, conserva OCR, SQLite y candidatos de consulta dentro de un paquete cifrado y publica sólo un handoff cifrado temporal para su traslado a Google Drive privado. También incorpora W5 al gate del canon de almacenamiento.

No altera la cohorte científica W5 ni sus resultados previos; cierra únicamente la deuda `archival_complete`.