### PR TITLE
Preservación: respaldar snapshot del repo en Drive

### DIFF
--- a/.github/workflows/preserve-repo-snapshot.yml
+++ b/.github/workflows/preserve-repo-snapshot.yml
@@ -1,0 +1,45 @@
+name: Preserve LTMD repository snapshot
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_repo_snapshot_drive_stamp.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preserve-ltmd-repo-snapshot
+  cancel-in-progress: false
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Build repository snapshot
+        run: |
+          mkdir -p local/repo-snapshot
+          git rev-parse HEAD > local/repo-snapshot/COMMIT.txt
+          git status --short --untracked-files=no > local/repo-snapshot/GIT_STATUS.txt
+          test ! -s local/repo-snapshot/GIT_STATUS.txt
+          tar --exclude='.git' --exclude='local' --exclude='private' --exclude='data/raw' --exclude='data/work' \
+            -czf local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz .
+          sha256sum local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz > local/repo-snapshot/SHA256SUMS.txt
+
+      - name: Upload repository snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-repository-snapshot
+          path: |
+            local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz
+            local/repo-snapshot/COMMIT.txt
+            local/repo-snapshot/GIT_STATUS.txt
+            local/repo-snapshot/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 2

--- a/data/research/ltmd_repo_snapshot_drive_stamp.json
+++ b/data/research/ltmd_repo_snapshot_drive_stamp.json
@@ -1,0 +1,10 @@
+{
+  "schema": "LTMD_REPO_SNAPSHOT_DRIVE_0.1",
+  "effective_date": "2026-08-24",
+  "source_branch": "main",
+  "destination": "private_google_drive",
+  "logical_destination": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/01_REPO_SNAPSHOTS",
+  "include": "versioned repository tree excluding .git and private/local/raw workspaces",
+  "required_outputs": ["repository_tar_gz", "commit_sha", "git_status", "sha256sums"],
+  "reason": "Maintain a private Drive backup of the scientific infrastructure in addition to GitHub as the public source of truth."
+}


### PR DESCRIPTION
Añade una corrida puntual que empaqueta el árbol versionado de `main` —excluyendo `.git`, `local/`, `private/`, `data/raw/` y `data/work/`—, registra commit y SHA-256 y publica un artefacto temporal para copiarlo a la bóveda privada de Google Drive. No contiene OCR privado ni altera el canon científico; complementa GitHub como fuente pública con una copia privada de preservación.