### PR TITLE
FTRL W3: congelar preflight exhaustivo Español/Lengua

### DIFF
--- a/.github/workflows/validate-ftrl-w3-preflight.yml
+++ b/.github/workflows/validate-ftrl-w3-preflight.yml
@@ -1,0 +1,72 @@
+name: Validate FTRL W3 preflight
+
+on:
+  pull_request:
+    paths:
+      - 'data/catalog/ltmd_u1_coverage.csv'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - 'data/catalog/ltmd_u1_w3_spanish_*.csv'
+      - 'scripts/preflight_ftrl_w3.py'
+      - 'scripts/build_ftrl_w3_inputs.py'
+      - 'docs/FTRL_W3_PREFLIGHT_PROTOCOL_0_1.md'
+      - '.github/workflows/validate-ftrl-w3-preflight.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/catalog/ltmd_u1_coverage.csv'
+      - 'data/catalog/ltmd_u1_retained_source_register.csv'
+      - 'data/catalog/ltmd_u1_w3_spanish_*.csv'
+      - 'scripts/preflight_ftrl_w3.py'
+      - 'scripts/build_ftrl_w3_inputs.py'
+      - 'docs/FTRL_W3_PREFLIGHT_PROTOCOL_0_1.md'
+      - '.github/workflows/validate-ftrl-w3-preflight.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  preflight-w3:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate W3 topology and cryptographic source anchors
+        run: python scripts/preflight_ftrl_w3.py --output local/ftrl/ltmd_u1_w3_preflight.json
+
+      - name: Build normalized W3 FTRL inputs
+        run: |
+          python scripts/build_ftrl_w3_inputs.py \
+            --asset-output local/ftrl/ltmd_u1_w3_asset_manifest.csv \
+            --processing-output local/ftrl/ltmd_u1_w3_processing_inventory.csv
+
+      - name: Assert normalized cardinalities and FTRL contract
+        run: |
+          python - <<'PY'
+          import csv, json
+          from pathlib import Path
+          p=json.loads(Path('local/ftrl/ltmd_u1_w3_preflight.json').read_text())
+          assert p['schema']=='LTMD_FTRL_W3_PREFLIGHT_0.1'
+          assert p['status']=='ready_for_ftrl_runtime_after_w1_gate'
+          assert p['historical_identities']==130
+          assert p['canonical_processing_objects']==114
+          assert p['alias_identities']==16
+          assert p['canonical_source_pages']==20765
+          assert p['documented_internal_source_gaps']==8
+          assert p['identity_level_active_retentions']==0
+          assert p['corpus_ready'] is False and p['semantic_ready'] is False
+          with open('local/ftrl/ltmd_u1_w3_processing_inventory.csv',encoding='utf-8',newline='') as fh: inv=list(csv.DictReader(fh))
+          with open('local/ftrl/ltmd_u1_w3_asset_manifest.csv',encoding='utf-8',newline='') as fh: pages=list(csv.DictReader(fh))
+          assert len(inv)==130
+          assert sum(int(r['is_canonical_processing_object']) for r in inv)==114
+          assert all(r['technical_identity_covered']=='1' for r in inv)
+          assert len(pages)==20765
+          assert all(int(r['byte_size'])>0 for r in pages)
+          PY

--- a/docs/FTRL_W3_PREFLIGHT_PROTOCOL_0_1.md
+++ b/docs/FTRL_W3_PREFLIGHT_PROTOCOL_0_1.md
@@ -1,0 +1,54 @@
+# FTRL LTMD-U1 W3 Español/Lengua — protocolo de preflight 0.1
+
+**Fecha:** 24 de agosto de 2026  
+**Estado:** preparación técnica; no activa OCR FTRL integral  
+**Autoridad superior:** `FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md`
+
+## Propósito
+
+Congelar y validar la topología de entrada de W3 antes de cualquier corrida FTRL. Este preflight reutiliza exclusivamente evidencia técnica ya versionada y no promueve resultados semánticos ni declara W3 como corpus FTRL terminado.
+
+## Denominador y topología congelados
+
+- 130 identidades documentales W3 (`operational_domain=espanol_lengua`).
+- 114 objetos canónicos de procesamiento.
+- 16 identidades cubiertas por relaciones técnicas demostradas: 8 aliases byte-exactos y 8 resoluciones de ruta 2018→2019 con coincidencia SHA-256 y tamaño por activo.
+- 20,765 JPEG fuente canónicos con SHA-256 y tamaño conocidos.
+- 109 posiciones terminales sintéticas en los objetos canónicos.
+- 7 objetos canónicos con huecos internos explícitos; 8 posiciones internas no servidas en total.
+- 0 identidades W3 en `active_retention` o `final_exception` del registro residual U1.
+
+Los ocho huecos son posiciones de página documentadas en representaciones digitales por lo demás cubiertas; no se rellenan, sustituyen ni renumeran. Su existencia no autoriza inferir ausencia bibliográfica en la edición física.
+
+## Evidencia OCR previa
+
+Existe una capa OCR técnica anterior para los 114 objetos canónicos y 20,765 páginas, con verificación SHA-256 y cero páginas marcadas como `unresolved`. Esa capa funciona únicamente como **ancla técnica de cardinalidad y procedencia**. No equivale a una corrida FTRL validada y no permite promover `corpus_ready`, `text_verified` ni `semantic_ready`.
+
+## Gates del preflight
+
+El preflight debe fallar si cambia cualquiera de estos invariantes:
+
+1. denominador W3 distinto de 130;
+2. conjunto de identidades distinto del inventario maestro;
+3. número de objetos canónicos distinto de 114;
+4. número o mapeo de aliases distinto de 16;
+5. manifiesto canónico distinto de 20,765 páginas;
+6. fuente con tamaño no positivo o SHA-256 inválido;
+7. más o menos de 8 huecos internos documentados;
+8. una relación 2018→2019 sin resolución completa o sin igualdad de SHA-256/tamaño;
+9. una identidad W3 apareciendo como retención/excepción global sin revisión explícita del protocolo;
+10. cualquier intento de presentar el OCR previo como validación FTRL o semántica.
+
+## Activación posterior
+
+Mientras W1 permanezca como gate técnico activo, este protocolo sólo autoriza **preflight y normalización de inputs**. La corrida FTRL integral W3 requiere una activación posterior deliberada después del cierre técnico de W1 conforme a la secuencia logística vigente.
+
+La preservación privada de cualquier futura corrida integral W3 deberá cumplir además `LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md` y conservar OCR/SQLite/QC completos en la bóveda privada de Google Drive.
+
+## Separación epistemológica
+
+`preflight_ready != corpus_ready`  
+`prior_ocr_anchor != ftrl_validated`  
+`ocr_available != text_verified`  
+`corpus_ready != semantic_ready`  
+`search_hit != historical_claim`

--- a/scripts/build_ftrl_w3_inputs.py
+++ b/scripts/build_ftrl_w3_inputs.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Normalize versioned W3 Español/Lengua source topology for generic FTRL."""
+from __future__ import annotations
+
+import argparse, csv, re
+from pathlib import Path
+
+VERSION="LTMD_U1_W3_FTRL_INPUTS_0.1"
+EXPECTED_HISTORICAL=130
+EXPECTED_CANONICAL=114
+EXPECTED_ALIASES=16
+EXPECTED_PAGES=20765
+SHA=re.compile(r"^[0-9a-f]{64}$")
+PROCESSING=Path("data/catalog/ltmd_u1_w3_spanish_processing_inventory.csv")
+MANIFEST=Path("data/catalog/ltmd_u1_w3_spanish_canonical_page_manifest.csv")
+
+def read(path):
+    with path.open(encoding="utf-8",newline="") as fh: return list(csv.DictReader(fh))
+
+def n(row,key):
+    v=row.get(key,"")
+    if v in {"",None}: raise AssertionError(f"missing {key}: {row}")
+    return int(float(v))
+
+def write(path, rows, fields):
+    path.parent.mkdir(parents=True,exist_ok=True)
+    with path.open("w",encoding="utf-8",newline="") as fh:
+        w=csv.DictWriter(fh,fieldnames=fields); w.writeheader(); w.writerows(rows)
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument("--asset-output",default="local/ftrl/ltmd_u1_w3_asset_manifest.csv")
+    ap.add_argument("--processing-output",default="local/ftrl/ltmd_u1_w3_processing_inventory.csv")
+    a=ap.parse_args()
+    processing=read(PROCESSING); manifest=read(MANIFEST)
+    assert len(processing)==EXPECTED_HISTORICAL
+    by={r["viewer_key"]:r for r in processing}; assert len(by)==EXPECTED_HISTORICAL
+    canonical={r["viewer_key"] for r in processing if n(r,"is_canonical_processing_object")==1}
+    assert len(canonical)==EXPECTED_CANONICAL and len(processing)-len(canonical)==EXPECTED_ALIASES
+    assert all(n(r,"ocr_identity_eligible")==1 for r in processing)
+
+    pfields=["processing_version","viewer_key","catalog_generation","grade_code","title_core","processing_mode","canonical_processing_viewer_key","technical_identity_covered","is_canonical_processing_object","declared_positions","direct_source_jpegs","persistent_internal_source_gaps","source_processing_basis","interpretive_limit"]
+    pout=[]
+    for r in processing:
+        target=r["canonical_processing_viewer_key"]; assert target in canonical
+        pout.append({"processing_version":VERSION,"viewer_key":r["viewer_key"],"catalog_generation":n(r,"catalog_generation"),"grade_code":n(r,"grade_code"),"title_core":r["title_core"],"processing_mode":r["processing_mode"],"canonical_processing_viewer_key":target,"technical_identity_covered":1,"is_canonical_processing_object":n(r,"is_canonical_processing_object"),"declared_positions":n(r,"declared_positions"),"direct_source_jpegs":n(r,"direct_source_jpegs"),"persistent_internal_source_gaps":n(r,"persistent_internal_source_gaps"),"source_processing_basis":r["evidence_basis"],"interpretive_limit":r["interpretive_limit"]})
+
+    assert len(manifest)==EXPECTED_PAGES and {r["viewer_key"] for r in manifest}==canonical
+    afields=["audit_version","viewer_key","catalog_generation","grade_code","title_core","viewer_page","source_image_index","source_asset_url","asset_status","byte_size","sha256","processing_mode","source_provenance"]
+    aout=[]; seen=set()
+    for r in manifest:
+        key=(r["viewer_key"],n(r,"source_image_index")); assert key not in seen; seen.add(key)
+        assert r["asset_status"]=="source_jpeg" and n(r,"byte_size")>0 and SHA.fullmatch(r["sha256"])
+        aout.append({"audit_version":VERSION,"viewer_key":r["viewer_key"],"catalog_generation":n(r,"catalog_generation"),"grade_code":n(r,"grade_code"),"title_core":r["title_core"],"viewer_page":n(r,"viewer_page"),"source_image_index":n(r,"source_image_index"),"source_asset_url":r["source_asset_url"],"asset_status":"source_jpeg","byte_size":n(r,"byte_size"),"sha256":r["sha256"],"processing_mode":by[r["viewer_key"]]["processing_mode"],"source_provenance":r["source_provenance"]})
+
+    write(Path(a.processing_output),pout,pfields); write(Path(a.asset_output),aout,afields)
+    print(f"Built W3 FTRL inputs: historical={len(pout)}, canonical={len(canonical)}, aliases={EXPECTED_ALIASES}, pages={len(aout)}")
+
+if __name__=="__main__": main()

--- a/scripts/preflight_ftrl_w3.py
+++ b/scripts/preflight_ftrl_w3.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Text-free preflight for exhaustive LTMD-U1 W3 Español/Lengua."""
+from __future__ import annotations
+
+import argparse, csv, hashlib, json, re
+from collections import Counter
+from pathlib import Path
+
+SCHEMA = "LTMD_FTRL_W3_PREFLIGHT_0.1"
+EXPECTED_HISTORICAL = 130
+EXPECTED_CANONICAL = 114
+EXPECTED_ALIASES = 16
+EXPECTED_EXACT = 8
+EXPECTED_ROUTE = 8
+EXPECTED_PAGES = 20765
+EXPECTED_GAPS = 8
+EXPECTED_PARTIAL = 7
+EXPECTED_TERMINAL = 109
+SHA = re.compile(r"^[0-9a-f]{64}$")
+
+P = {
+    "coverage": Path("data/catalog/ltmd_u1_coverage.csv"),
+    "processing": Path("data/catalog/ltmd_u1_w3_spanish_processing_inventory.csv"),
+    "asset_summary": Path("data/catalog/ltmd_u1_w3_spanish_asset_summary.csv"),
+    "manifest": Path("data/catalog/ltmd_u1_w3_spanish_canonical_page_manifest.csv"),
+    "gaps": Path("data/catalog/ltmd_u1_w3_spanish_canonical_gap_manifest.csv"),
+    "exact": Path("data/catalog/ltmd_u1_w3_spanish_exact_aliases.csv"),
+    "routes": Path("data/catalog/ltmd_u1_w3_spanish_2018_2019_route_relationships.csv"),
+    "ocr_summary": Path("data/catalog/ltmd_u1_w3_spanish_ocr_summary.csv"),
+    "ocr_metrics": Path("data/catalog/ltmd_u1_w3_spanish_ocr_metrics.csv"),
+    "retained": Path("data/catalog/ltmd_u1_retained_source_register.csv"),
+}
+
+def rows(path):
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+def n(row, key):
+    v = row.get(key, "")
+    if v in {"", None}: raise AssertionError(f"missing {key}: {row}")
+    return int(float(v))
+
+def fp(value):
+    raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", default="local/ftrl/ltmd_u1_w3_preflight.json")
+    a = ap.parse_args()
+
+    coverage = [r for r in rows(P["coverage"]) if r.get("operational_domain") == "espanol_lengua"]
+    processing = rows(P["processing"]); summary = rows(P["asset_summary"])
+    manifest = rows(P["manifest"]); gaps = rows(P["gaps"])
+    exact = rows(P["exact"]); routes = rows(P["routes"])
+    ocrs = rows(P["ocr_summary"]); ocrm = rows(P["ocr_metrics"])
+    retained = rows(P["retained"])
+
+    keys = {r["viewer_key"] for r in coverage}
+    assert len(coverage) == len(keys) == EXPECTED_HISTORICAL
+    by = {r["viewer_key"]: r for r in processing}
+    assert len(processing) == len(by) == EXPECTED_HISTORICAL and set(by) == keys
+    assert sum(n(r,"ocr_identity_eligible") for r in processing) == EXPECTED_HISTORICAL
+    assert all(not (r.get("block_reason") or "").strip() for r in processing)
+
+    modes = Counter(r["processing_mode"] for r in processing)
+    assert modes == {"direct_canonical":107,"partial_canonical_explicit_gap":7,"exact_byte_alias":8,"paired_route_alias_2018_to_2019":8}, modes
+    canonical = {r["viewer_key"] for r in processing if n(r,"is_canonical_processing_object") == 1}
+    aliases = set(by) - canonical
+    assert len(canonical) == EXPECTED_CANONICAL and len(aliases) == EXPECTED_ALIASES
+    assert len({by[k]["canonical_processing_viewer_key"] for k in by}) == EXPECTED_CANONICAL
+    for k,r in by.items():
+        target = r["canonical_processing_viewer_key"]
+        assert target in canonical
+        assert (target == k) == (k in canonical)
+
+    assert not [r for r in retained if r.get("viewer_key") in keys]
+    sb = {r["viewer_key"]:r for r in summary}; assert set(sb) == keys
+    cs = [sb[k] for k in canonical]
+    assert sum(n(r,"source_jpegs") for r in cs) == EXPECTED_PAGES
+    assert sum(n(r,"terminal_synthetic_candidates") for r in cs) == EXPECTED_TERMINAL
+    assert sum(n(r,"internal_unserved") for r in cs) == EXPECTED_GAPS
+    assert sum(n(r,"probe_errors") for r in cs) == 0
+
+    assert len(manifest) == EXPECTED_PAGES and {r["viewer_key"] for r in manifest} == canonical
+    seen=set(); counts=Counter()
+    for r in manifest:
+        k=(r["viewer_key"],n(r,"viewer_page")); assert k not in seen; seen.add(k)
+        counts[r["viewer_key"]]+=1
+        assert r["asset_status"] == "source_jpeg" and n(r,"byte_size") > 0 and SHA.fullmatch(r["sha256"])
+    for k in canonical: assert counts[k] == n(by[k],"direct_source_jpegs")
+
+    assert len(gaps) == EXPECTED_GAPS
+    gc=Counter(); gs=set()
+    for r in gaps:
+        k=(r["viewer_key"],n(r,"viewer_page")); assert k not in gs; gs.add(k)
+        assert r["viewer_key"] in canonical and by[r["viewer_key"]]["processing_mode"] == "partial_canonical_explicit_gap"
+        assert r["gap_state"] == "internal_unserved_position_observed" and n(r,"available_neighbours_sha_verified") == 1
+        gc[r["viewer_key"]]+=1
+    assert len(gc) == EXPECTED_PARTIAL
+    for k in canonical: assert gc[k] == n(by[k],"persistent_internal_source_gaps")
+
+    assert len(exact) == EXPECTED_EXACT
+    for r in exact:
+        alias,target=r["viewer_key"],r["canonical_viewer_key"]
+        assert alias in aliases and target in canonical and by[alias]["canonical_processing_viewer_key"] == target
+        assert by[alias]["processing_mode"] == "exact_byte_alias" and n(r,"all_pages_byte_identical_aligned") == 1
+        assert n(r,"source_jpeg_count") == n(by[target],"direct_source_jpegs")
+
+    assert len(routes) == EXPECTED_ROUTE
+    for r in routes:
+        alias,target=r["viewer_key_2018"],r["viewer_key_2019"]
+        compared=n(r,"compared_source_assets")
+        assert alias in aliases and target in canonical and by[alias]["canonical_processing_viewer_key"] == target
+        assert by[alias]["processing_mode"] == "paired_route_alias_2018_to_2019"
+        assert n(r,"complete_route_resolution") == 1 and n(r,"sha256_matches") == compared and n(r,"byte_size_matches") == compared
+        assert compared == n(by[target],"direct_source_jpegs")
+
+    assert len(ocrs) == EXPECTED_CANONICAL and {r["viewer_key"] for r in ocrs} == canonical
+    assert sum(n(r,"pages") for r in ocrs) == EXPECTED_PAGES
+    assert sum(n(r,"sha_verified") for r in ocrs) == EXPECTED_PAGES and sum(n(r,"unresolved") for r in ocrs) == 0
+    assert len(ocrm) == EXPECTED_PAGES and sum(n(r,"source_sha256_verified") for r in ocrm) == EXPECTED_PAGES
+
+    out = {
+        "schema":SCHEMA,"status":"ready_for_ftrl_runtime_after_w1_gate","wave":"W3","operational_domain":"espanol_lengua",
+        "historical_identities":130,"canonical_processing_objects":114,"alias_identities":16,"exact_byte_aliases":8,
+        "paired_route_aliases_2018_to_2019":8,"canonical_source_pages":20765,"partial_canonical_objects":7,
+        "documented_internal_source_gaps":8,"terminal_synthetic_candidates":109,"identity_level_active_retentions":0,
+        "prior_ocr_anchor":{"canonical_objects":114,"pages":20765,"sha_verified_pages":20765,"unresolved_pages":0,"interpretation":"technical_anchor_only_not_ftrl_completion"},
+        "ftrl_runtime_activated":False,"corpus_ready":False,"ocr_available_ftrl":False,"text_verified":False,"semantic_ready":False,
+        "source_fingerprints":{"processing_inventory_canonical_sha256":fp(processing),"canonical_page_manifest_canonical_sha256":fp(manifest),"gap_manifest_canonical_sha256":fp(gaps),"exact_aliases_canonical_sha256":fp(exact),"route_relationships_canonical_sha256":fp(routes)},
+        "epistemic_guards":["preflight_ready != corpus_ready","prior_ocr_anchor != ftrl_validated","ocr_available != text_verified","corpus_ready != semantic_ready","search_hit != historical_claim"]
+    }
+    p=Path(a.output); p.parent.mkdir(parents=True,exist_ok=True); p.write_text(json.dumps(out,ensure_ascii=False,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+    print(json.dumps(out,ensure_ascii=False,sort_keys=True))
+
+if __name__ == "__main__": main()


### PR DESCRIPTION
Prepara W3 Español/Lengua sin activar todavía OCR FTRL integral.

Congela y valida la evidencia ya versionada:
- 130 identidades documentales W3;
- 114 objetos canónicos;
- 16 identidades cubiertas por relaciones técnicas demostradas (8 aliases byte-exactos + 8 resoluciones de ruta 2018→2019);
- 20,765 JPEG fuente canónicos con SHA-256 y tamaño conocidos;
- 8 huecos internos documentados en 7 canónicos;
- 109 posiciones terminales sintéticas;
- 0 identidades W3 en el registro residual U1.

Añade un normalizador al contrato genérico FTRL y un gate CI text-free. La capa OCR previa se usa únicamente como ancla técnica de cardinalidad/procedencia y no se promueve como FTRL validado. `corpus_ready`, `text_verified` y `semantic_ready` permanecen falsos.

La activación de la corrida integral W3 queda explícitamente bloqueada hasta el cierre técnico de W1 conforme a la secuencia logística vigente.