### PR TITLE
FTRL W3: preparar runtime con gate obligatorio W1

### DIFF
--- a/.github/workflows/validate-ftrl-w3-runtime-pilot.yml
+++ b/.github/workflows/validate-ftrl-w3-runtime-pilot.yml
@@ -1,0 +1,111 @@
+name: Validate guarded FTRL W3 runtime pilot
+
+on:
+  workflow_dispatch:
+    inputs:
+      pages:
+        description: 'Number of canonical W3 pages to process after W1 gate'
+        required: true
+        default: '12'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ftrl-w3-runtime-pilot
+  cancel-in-progress: false
+
+jobs:
+  pilot-w3:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Execute W3 pilot only after canonical W1 gate
+        env:
+          PILOT_PAGES: ${{ inputs.pages }}
+        run: |
+          case "$PILOT_PAGES" in
+            ''|*[!0-9]*) echo 'pages must be a positive integer' >&2; exit 1 ;;
+          esac
+          test "$PILOT_PAGES" -ge 1
+          test "$PILOT_PAGES" -le 100
+          python scripts/run_ftrl_w3.py \
+            --pages "$PILOT_PAGES" \
+            --output-dir local/ftrl
+
+      - name: Assert pilot integrity and no epistemic promotion
+        env:
+          PILOT_PAGES: ${{ inputs.pages }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          pages = int(os.environ['PILOT_PAGES'])
+          label = f'pilot_{pages}'
+          manifest = json.loads(Path(f'local/ftrl/ltmd_u1_w3_{label}_run_manifest.json').read_text(encoding='utf-8'))
+          qc = json.loads(Path(f'local/ftrl/ltmd_u1_w3_{label}_qc_summary.json').read_text(encoding='utf-8'))
+          preflight = json.loads(Path('local/ftrl/ltmd_u1_w3_preflight.json').read_text(encoding='utf-8'))
+          assert preflight['schema'] == 'LTMD_FTRL_W3_PREFLIGHT_0.1'
+          assert preflight['historical_identities'] == 130
+          assert preflight['canonical_processing_objects'] == 114
+          assert preflight['canonical_source_pages'] == 20765
+          assert preflight['ftrl_runtime_activated'] is False
+          assert preflight['corpus_ready'] is False
+          assert preflight['semantic_ready'] is False
+          assert manifest['schema_version'] == 'LTMD_FTRL_RUN_0.1'
+          assert manifest['status'] == 'validated'
+          assert manifest['corpus']['page_records'] == pages
+          assert manifest['database']['page_rows'] == pages
+          assert manifest['database']['fts_rows'] == pages
+          assert manifest['database']['sqlite_integrity'] == 'ok'
+          assert manifest['corpus']['waves'] == ['W3']
+          assert manifest['corpus']['source_byte_size_missing_pages'] == 0
+          assert qc['schema_version'] == 'LTMD_FTRL_QC_0.1'
+          assert qc['page_records'] == pages
+          print('Guarded W3 pilot validated; no full-corpus promotion implied')
+          PY
+
+      - name: Prove restricted pilot outputs remain non-publishable
+        env:
+          PILOT_PAGES: ${{ inputs.pages }}
+        run: |
+          label="pilot_${PILOT_PAGES}"
+          for path in \
+            "local/ftrl/ltmd_u1_w3_${label}_page_ocr.jsonl" \
+            "local/ftrl/ltmd_u1_w3_${label}_ocr_search.sqlite" \
+            "local/ftrl/ltmd_u1_w3_${label}_qc_queue.json"; do
+            test -f "$path"
+            git check-ignore -q "$path"
+          done
+
+      - name: Upload text-free pilot evidence only
+        env:
+          PILOT_PAGES: ${{ inputs.pages }}
+        run: |
+          mkdir -p local/w3-pilot-evidence
+          label="pilot_${PILOT_PAGES}"
+          cp local/ftrl/ltmd_u1_w3_preflight.json local/w3-pilot-evidence/
+          cp "local/ftrl/ltmd_u1_w3_${label}_run_manifest.json" local/w3-pilot-evidence/
+          cp "local/ftrl/ltmd_u1_w3_${label}_qc_summary.json" local/w3-pilot-evidence/
+
+      - name: Publish text-free pilot evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w3-runtime-pilot-text-free-evidence
+          path: local/w3-pilot-evidence/
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/validate-ftrl-w3-runtime-scaffold.yml
+++ b/.github/workflows/validate-ftrl-w3-runtime-scaffold.yml
@@ -1,0 +1,94 @@
+name: Validate FTRL W3 runtime scaffold
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/guard_ftrl_w3_activation.py'
+      - 'scripts/run_ftrl_w3.py'
+      - 'data/research/ltmd_u1_w3_runtime_readiness.json'
+      - 'docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md'
+      - '.github/workflows/validate-ftrl-w3-runtime-pilot.yml'
+      - '.github/workflows/validate-ftrl-w3-runtime-scaffold.yml'
+      - 'scripts/preflight_ftrl_w3.py'
+      - 'scripts/build_ftrl_w3_inputs.py'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/guard_ftrl_w3_activation.py'
+      - 'scripts/run_ftrl_w3.py'
+      - 'data/research/ltmd_u1_w3_runtime_readiness.json'
+      - 'docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md'
+      - '.github/workflows/validate-ftrl-w3-runtime-pilot.yml'
+      - '.github/workflows/validate-ftrl-w3-runtime-scaffold.yml'
+      - 'scripts/preflight_ftrl_w3.py'
+      - 'scripts/build_ftrl_w3_inputs.py'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-runtime-scaffold:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Compile W3 runtime code
+        run: |
+          python -m py_compile \
+            scripts/guard_ftrl_w3_activation.py \
+            scripts/run_ftrl_w3.py \
+            scripts/preflight_ftrl_w3.py \
+            scripts/build_ftrl_w3_inputs.py
+
+      - name: Revalidate exhaustive W3 inputs without OCR
+        run: |
+          python scripts/preflight_ftrl_w3.py --output local/ftrl/ltmd_u1_w3_preflight.json
+          python scripts/build_ftrl_w3_inputs.py \
+            --asset-output local/ftrl/ltmd_u1_w3_asset_manifest.csv \
+            --processing-output local/ftrl/ltmd_u1_w3_processing_inventory.csv
+
+      - name: Assert non-bypassable sequencing and inactive full run
+        run: |
+          python - <<'PY'
+          import csv, json
+          from pathlib import Path
+
+          readiness = json.loads(Path('data/research/ltmd_u1_w3_runtime_readiness.json').read_text(encoding='utf-8'))
+          assert readiness['schema'] == 'LTMD_U1_W3_RUNTIME_READINESS_0.1'
+          assert readiness['historical_identities'] == 130
+          assert readiness['canonical_processing_objects'] == 114
+          assert readiness['canonical_source_pages'] == 20765
+          assert readiness['activation_gate']['required_predecessor'] == 'W1'
+          assert readiness['activation_gate']['required_w1_validated_identities'] == 40
+          assert readiness['activation_gate']['bypass_allowed'] is False
+          assert readiness['runtime']['full_execution_activated'] is False
+          assert readiness['runtime']['full_execution_topology_frozen'] is False
+          assert readiness['preservation']['required_before_full_activation'] is True
+
+          runner = Path('scripts/run_ftrl_w3.py').read_text(encoding='utf-8')
+          guard = Path('scripts/guard_ftrl_w3_activation.py').read_text(encoding='utf-8')
+          pilot = Path('.github/workflows/validate-ftrl-w3-runtime-pilot.yml').read_text(encoding='utf-8')
+          assert '--skip-w1-gate' not in runner
+          assert 'guard_ftrl_w3_activation.py' in runner
+          assert 'EXPECTED_W1_IDENTITIES = 40' in guard
+          assert 'workflow_dispatch:' in pilot
+          assert 'push:' not in pilot
+          assert '--full' not in pilot
+
+          with Path('local/ftrl/ltmd_u1_w3_processing_inventory.csv').open(encoding='utf-8', newline='') as fh:
+              processing = list(csv.DictReader(fh))
+          with Path('local/ftrl/ltmd_u1_w3_asset_manifest.csv').open(encoding='utf-8', newline='') as fh:
+              pages = list(csv.DictReader(fh))
+          assert len(processing) == 130
+          assert sum(int(r['is_canonical_processing_object']) for r in processing) == 114
+          assert len(pages) == 20765
+          print('W3 runtime scaffold is guarded, exhaustive, and not activated')
+          PY

--- a/data/research/ltmd_u1_w3_runtime_readiness.json
+++ b/data/research/ltmd_u1_w3_runtime_readiness.json
@@ -1,0 +1,39 @@
+{
+  "schema": "LTMD_U1_W3_RUNTIME_READINESS_0.1",
+  "effective_date": "2026-08-24",
+  "wave": "W3",
+  "operational_domain": "espanol_lengua",
+  "historical_identities": 130,
+  "canonical_processing_objects": 114,
+  "canonical_source_pages": 20765,
+  "documented_internal_source_gaps": 8,
+  "activation_gate": {
+    "required_predecessor": "W1",
+    "required_w1_validated_identities": 40,
+    "required_w1_corpus_ready_identities": 40,
+    "required_w1_ocr_available_identities": 40,
+    "guard_script": "scripts/guard_ftrl_w3_activation.py",
+    "bypass_allowed": false
+  },
+  "runtime": {
+    "runner": "scripts/run_ftrl_w3.py",
+    "pilot_workflow": ".github/workflows/validate-ftrl-w3-runtime-pilot.yml",
+    "full_execution_activated": false,
+    "full_execution_topology_frozen": false,
+    "topology_decision_basis": "Freeze only after W1 observed wall time and a post-W1 W3 pilot establish whether a single hosted job can safely process 20,765 pages within platform limits."
+  },
+  "preservation": {
+    "required_before_full_activation": true,
+    "canonical_policy": "docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md",
+    "destination": "private_google_drive",
+    "archival_complete": false
+  },
+  "epistemic_guards": [
+    "runtime_ready != runtime_activated",
+    "preflight_ready != corpus_ready",
+    "prior_ocr_anchor != ftrl_validated",
+    "computationally_validated != archival_complete",
+    "ocr_available != text_verified",
+    "corpus_ready != semantic_ready"
+  ]
+}

--- a/docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md
+++ b/docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md
@@ -1,0 +1,61 @@
+# FTRL LTMD-U1 W3 Español/Lengua — preparación de runtime 0.1
+
+**Fecha:** 24 de agosto de 2026  
+**Estado:** runtime preparado, no activado  
+**Autoridad superior:** `FTRL_U1_EXHAUSTIVE_EXECUTION_PROTOCOL_0_2.md`
+
+## Regla de activación
+
+Ningún OCR FTRL W3 puede iniciar mientras el ledger maestro no registre las 40 identidades W1 como `validated`, `corpus_ready=1` y `ocr_available=1`. Esta condición es ejecutable mediante `scripts/guard_ftrl_w3_activation.py` y no tiene bypass en `scripts/run_ftrl_w3.py`.
+
+La separación epistemológica se conserva: el gate no exige `text_verified` ni `semantic_ready`; de hecho, una promoción automática de esas capas sería un error metodológico.
+
+## Runtime preparado
+
+`scripts/run_ftrl_w3.py` adapta el pipeline FTRL general a la topología W3 congelada en el preflight:
+
+- 130 identidades documentales;
+- 114 objetos canónicos;
+- 20,765 páginas fuente canónicas;
+- construcción OCR por página;
+- SQLite/FTS5;
+- validación de cardinalidad;
+- manifiesto text-free de ejecución;
+- cola QC restringida y resumen QC text-free.
+
+El modo piloto procesa un subconjunto explícito de páginas después de pasar el gate W1. El modo completo existe en el runner, pero **no queda todavía asociado a un sello de activación ni a un workflow integral automático**.
+
+## Por qué la topología completa aún no se congela
+
+W3 contiene 20,765 páginas, aproximadamente tres veces el volumen W1. Antes de decidir si el full run debe ejecutarse en un solo job, con mayor paralelismo o mediante una estrategia particionada reproducible, se requiere evidencia observada de:
+
+1. tiempo total real del full run W1;
+2. comportamiento de descarga/OCR bajo el runner hospedado;
+3. tiempo y estabilidad de un piloto W3 posterior al cierre W1;
+4. límites efectivos de la plataforma y tamaño esperado de los productos restringidos.
+
+No se extrapola una arquitectura de ejecución sin esos datos. Esta decisión evita diseñar una corrida que pueda exceder límites operativos y evita cambiar la topología a mitad de una ejecución científica.
+
+## Preservación obligatoria
+
+Antes de crear cualquier sello que active W3 completo, deberá existir y validarse el mecanismo de preservación privada correspondiente. OCR completo, SQLite/FTS5 y QC detallado deberán terminar en la bóveda privada de Google Drive, cifrados durante cualquier handoff temporal, conforme a `LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md`.
+
+Por tanto, la secuencia futura obligatoria es:
+
+**W1 validado → piloto W3 → decisión de topología completa → workflow de preservación W3 validado → sello de full run W3 → validación → copia privada → `archival_complete`.**
+
+## Estados que permanecen falsos
+
+La preparación del runtime no cambia el ledger de completitud de W3. Hasta una corrida integral validada:
+
+- `ftrl_status=pending`;
+- `corpus_ready=0`;
+- `ocr_available=0` en sentido FTRL;
+- `text_verified=0`;
+- `semantic_ready=0`;
+- `archival_complete=0`.
+
+`runtime_ready != runtime_activated`  
+`preflight_ready != corpus_ready`  
+`prior_ocr_anchor != ftrl_validated`  
+`computationally_validated != archival_complete`

--- a/scripts/guard_ftrl_w3_activation.py
+++ b/scripts/guard_ftrl_w3_activation.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Block any W3 OCR runtime until exhaustive W1 is technically validated."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from pathlib import Path
+
+LEDGER = Path("data/research/ltmd_u1_ftrl_completion_ledger.csv")
+EXPECTED_W1_IDENTITIES = 40
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable status")
+    args = parser.parse_args()
+
+    with LEDGER.open(encoding="utf-8", newline="") as fh:
+        rows = [row for row in csv.DictReader(fh) if row.get("wave") == "W1"]
+
+    if len(rows) != EXPECTED_W1_IDENTITIES:
+        raise SystemExit(
+            f"W1 denominator drift: {len(rows)} != {EXPECTED_W1_IDENTITIES}"
+        )
+
+    validated = [row for row in rows if row.get("ftrl_status") == "validated"]
+    corpus_ready = [row for row in rows if row.get("corpus_ready") == "1"]
+    ocr_available = [row for row in rows if row.get("ocr_available") == "1"]
+    semantic_promotions = [row for row in rows if row.get("semantic_ready") == "1"]
+    text_promotions = [row for row in rows if row.get("text_verified") == "1"]
+
+    ready = (
+        len(validated) == EXPECTED_W1_IDENTITIES
+        and len(corpus_ready) == EXPECTED_W1_IDENTITIES
+        and len(ocr_available) == EXPECTED_W1_IDENTITIES
+        and not semantic_promotions
+        and not text_promotions
+    )
+
+    status = {
+        "schema": "LTMD_FTRL_W3_ACTIVATION_GUARD_0.1",
+        "w1_historical_identities": len(rows),
+        "w1_validated_identities": len(validated),
+        "w1_corpus_ready_identities": len(corpus_ready),
+        "w1_ocr_available_identities": len(ocr_available),
+        "w1_text_verified_identities": len(text_promotions),
+        "w1_semantic_ready_identities": len(semantic_promotions),
+        "w3_runtime_allowed": ready,
+        "rule": "W3 OCR runtime requires exhaustive technical W1 closure; text/semantic validation remain separate",
+    }
+    if args.json:
+        print(json.dumps(status, ensure_ascii=False, sort_keys=True))
+    else:
+        print(
+            "W3 activation gate: "
+            f"W1 validated={len(validated)}/{EXPECTED_W1_IDENTITIES}, "
+            f"corpus_ready={len(corpus_ready)}/{EXPECTED_W1_IDENTITIES}, "
+            f"ocr_available={len(ocr_available)}/{EXPECTED_W1_IDENTITIES}"
+        )
+
+    if not ready:
+        raise SystemExit(
+            "W3 OCR runtime BLOCKED: exhaustive W1 has not yet been promoted to validated/corpus_ready/ocr_available in the canonical ledger"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w3.py
+++ b/scripts/run_ftrl_w3.py
@@ -125,15 +125,16 @@ def main() -> None:
     parser.add_argument("--pages", type=int, default=12)
     parser.add_argument("--workers", type=int, default=2)
     parser.add_argument("--output-dir", type=Path, default=Path("local/ftrl"))
-    parser.add_argument("--skip-w1-gate", action="store_true", help="Local developer escape hatch only; CI workflows must never use this")
     args = parser.parse_args()
 
     if args.pages < 1:
         raise SystemExit("--pages must be >= 1")
     if args.workers < 1:
         raise SystemExit("--workers must be >= 1")
-    if not args.skip_w1_gate:
-        run([sys.executable, "scripts/guard_ftrl_w3_activation.py", "--json"])
+
+    # Non-bypassable project gate: W3 OCR must never start before W1 is
+    # canonically promoted to validated/corpus_ready/ocr_available for 40/40.
+    run([sys.executable, "scripts/guard_ftrl_w3_activation.py", "--json"])
     require_environment()
     args.output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/run_ftrl_w3.py
+++ b/scripts/run_ftrl_w3.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Run LTMD-U1 W3 Español/Lengua through FTRL after the W1 activation gate."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+EXPECTED_W3_SOURCE_PAGES = 20765
+
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None:
+        raise SystemExit("Tesseract is required but was not found on PATH")
+    langs = subprocess.run(
+        ["tesseract", "--list-langs"], check=True, capture_output=True, text=True
+    ).stdout.splitlines()
+    if "spa" not in {lang.strip() for lang in langs}:
+        raise SystemExit("Tesseract Spanish language data ('spa') is required")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    except sqlite3.OperationalError as exc:
+        raise SystemExit("SQLite FTS5 support is required") from exc
+    finally:
+        conn.close()
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_rows(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows:
+        raise SystemExit(f"cannot write empty shard: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def balanced_shards(rows: list[dict[str, str]], count: int) -> list[list[dict[str, str]]]:
+    count = max(1, min(count, len(rows)))
+    base, remainder = divmod(len(rows), count)
+    shards = []
+    start = 0
+    for index in range(count):
+        size = base + (1 if index < remainder else 0)
+        shards.append(rows[start : start + size])
+        start += size
+    assert sum(len(shard) for shard in shards) == len(rows)
+    return shards
+
+
+def run_ocr_shards(*, rows, processing_inventory, output_dir, workers) -> Path:
+    shard_dir = output_dir / "w3" / "shards"
+    cache_root = output_dir / "w3" / "assets"
+    shards = balanced_shards(rows, workers)
+    processes = []
+    outputs = []
+    for index, shard_rows in enumerate(shards):
+        manifest = shard_dir / f"asset_manifest_{index:02d}.csv"
+        output = shard_dir / f"page_ocr_{index:02d}.jsonl"
+        cache = cache_root / f"shard_{index:02d}"
+        write_rows(manifest, shard_rows)
+        outputs.append(output)
+        command = [
+            sys.executable, "scripts/build_page_ocr_corpus.py",
+            "--asset-manifest", str(manifest),
+            "--processing-inventory", str(processing_inventory),
+            "--wave", "W3",
+            "--output", str(output),
+            "--cache-dir", str(cache),
+            "--resume",
+        ]
+        print("+", " ".join(command), flush=True)
+        processes.append((index, subprocess.Popen(command)))
+
+    failed = []
+    for index, process in processes:
+        code = process.wait()
+        if code:
+            failed.append((index, code))
+    if failed:
+        raise SystemExit(f"W3 OCR shard failure(s): {failed}")
+
+    combined = output_dir / "ltmd_u1_w3_full_page_ocr.jsonl"
+    temp = combined.with_name(combined.name + ".tmp")
+    page_ids = set()
+    count = 0
+    with temp.open("w", encoding="utf-8", newline="\n") as out:
+        for path in outputs:
+            with path.open(encoding="utf-8") as fh:
+                for line in fh:
+                    if not line.strip():
+                        continue
+                    record = json.loads(line)
+                    page_id = str(record["page_id"])
+                    if page_id in page_ids:
+                        raise SystemExit(f"duplicate OCR page_id across shards: {page_id}")
+                    page_ids.add(page_id)
+                    out.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+                    count += 1
+    temp.replace(combined)
+    if count != len(rows):
+        raise SystemExit(f"combined OCR cardinality mismatch: {count} != {len(rows)}")
+    return combined
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--full", action="store_true")
+    parser.add_argument("--pages", type=int, default=12)
+    parser.add_argument("--workers", type=int, default=2)
+    parser.add_argument("--output-dir", type=Path, default=Path("local/ftrl"))
+    parser.add_argument("--skip-w1-gate", action="store_true", help="Local developer escape hatch only; CI workflows must never use this")
+    args = parser.parse_args()
+
+    if args.pages < 1:
+        raise SystemExit("--pages must be >= 1")
+    if args.workers < 1:
+        raise SystemExit("--workers must be >= 1")
+    if not args.skip_w1_gate:
+        run([sys.executable, "scripts/guard_ftrl_w3_activation.py", "--json"])
+    require_environment()
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    preflight = args.output_dir / "ltmd_u1_w3_preflight.json"
+    run([sys.executable, "scripts/preflight_ftrl_w3.py", "--output", str(preflight)])
+
+    asset_manifest = args.output_dir / "ltmd_u1_w3_asset_manifest.csv"
+    processing_inventory = args.output_dir / "ltmd_u1_w3_processing_inventory.csv"
+    run([
+        sys.executable, "scripts/build_ftrl_w3_inputs.py",
+        "--asset-output", str(asset_manifest),
+        "--processing-output", str(processing_inventory),
+    ])
+
+    rows = read_rows(asset_manifest)
+    if len(rows) != EXPECTED_W3_SOURCE_PAGES:
+        raise SystemExit(
+            f"normalized W3 asset cardinality drifted: {len(rows)} != {EXPECTED_W3_SOURCE_PAGES}"
+        )
+
+    if not args.full:
+        rows = rows[: args.pages]
+        label = f"pilot_{len(rows)}"
+        pilot_manifest = args.output_dir / f"ltmd_u1_w3_{label}_asset_manifest.csv"
+        write_rows(pilot_manifest, rows)
+        provenance_asset_manifest = pilot_manifest
+        jsonl = args.output_dir / f"ltmd_u1_w3_{label}_page_ocr.jsonl"
+        run([
+            sys.executable, "scripts/build_page_ocr_corpus.py",
+            "--asset-manifest", str(pilot_manifest),
+            "--processing-inventory", str(processing_inventory),
+            "--wave", "W3",
+            "--output", str(jsonl),
+            "--cache-dir", str(args.output_dir / "w3" / "assets" / label),
+            "--resume",
+        ])
+    else:
+        label = "full"
+        provenance_asset_manifest = asset_manifest
+        jsonl = run_ocr_shards(
+            rows=rows,
+            processing_inventory=processing_inventory,
+            output_dir=args.output_dir,
+            workers=args.workers,
+        )
+
+    db = args.output_dir / f"ltmd_u1_w3_{label}_ocr_search.sqlite"
+    run_manifest = args.output_dir / f"ltmd_u1_w3_{label}_run_manifest.json"
+    qc_queue = args.output_dir / f"ltmd_u1_w3_{label}_qc_queue.json"
+    qc_summary = args.output_dir / f"ltmd_u1_w3_{label}_qc_summary.json"
+
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(processing_inventory), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([
+        sys.executable, "scripts/summarize_ftrl_run.py",
+        "--input", str(jsonl), "--db", str(db),
+        "--asset-manifest", str(provenance_asset_manifest),
+        "--processing-inventory", str(processing_inventory),
+        "--label", label, "--output", str(run_manifest),
+    ])
+    run([
+        sys.executable, "scripts/build_ftrl_qc_queue.py",
+        "--input", str(jsonl),
+        "--queue-output", str(qc_queue),
+        "--summary-output", str(qc_summary),
+    ])
+
+    print(f"FTRL W3 {label} ready: {db}")
+    print(f"Run provenance manifest: {run_manifest}")
+    print(f"Text-free QC summary: {qc_summary}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Prepara el runtime de W3 Español/Lengua sin activar OCR ni congelar todavía la topología de la corrida completa.

Añade:
- guard ejecutable que exige W1 40/40 `validated`, `corpus_ready` y `ocr_available` antes de cualquier OCR W3;
- runner W3 sin bypass del gate;
- workflow manual de piloto, sin trigger `push` y sin `--full`;
- contrato machine-readable de readiness;
- protocolo que difiere la arquitectura del full run hasta observar el tiempo real W1 y un piloto W3 posterior;
- gate CI que comprueba 130 identidades, 114 canónicos, 20,765 páginas y que no exista activación completa ni bypass.

El proyecto mantiene `runtime_ready != runtime_activated`; W3 sigue `pending` en el ledger. Antes de cualquier full run deberá existir y validarse el mecanismo de preservación privada en Google Drive conforme al canon vigente.