### PR TITLE
Preservation: archivar historia Git completa y metadatos operativos

### DIFF
--- a/.github/workflows/preserve-github-operational-archive.yml
+++ b/.github/workflows/preserve-github-operational-archive.yml
@@ -1,0 +1,84 @@
+name: Preserve LTMD GitHub operational history
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_github_operational_archive_stamp.json'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: preserve-ltmd-github-operational-history
+  cancel-in-progress: false
+
+jobs:
+  export-github-history:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify GitHub CLI authentication
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh auth status
+          gh api rate_limit > /tmp/rate-limit-before.json
+
+      - name: Export exhaustive operational metadata and retained logs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python scripts/export_github_operational_archive.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --output-dir local/github-operational-archive
+
+      - name: Package provider export without altering source bytes
+        run: |
+          set -euo pipefail
+          tar -C local -czf local/ltmd_github_operational_archive.tar.gz github-operational-archive
+          sha256sum local/ltmd_github_operational_archive.tar.gz > local/ARCHIVE_SHA256.txt
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          p = Path('local/github-operational-archive/archive_manifest.json')
+          m = json.loads(p.read_text(encoding='utf-8'))
+          assert m['schema'] == 'LTMD_GITHUB_OPERATIONAL_EXPORT_0.1'
+          assert m['repository'] == 'fersandovalgtz/libro-texto-mexicano-digital'
+          assert m['source_commit']
+          assert m['workflow_run_id']
+          assert m['actions_runs_exported'] >= 1
+          assert m['files']
+          print(json.dumps({k: m[k] for k in ('pull_requests_exported','actions_runs_exported','actions_log_available_count','actions_log_unavailable_count','negative_result_count')}, sort_keys=True))
+          PY
+
+      - name: Prove export contains no LTMD restricted corpus workspace
+        run: |
+          test ! -e local/github-operational-archive/local/ftrl
+          test ! -e local/github-operational-archive/private
+          ! find local/github-operational-archive -type f \( -name '*page_ocr*.jsonl' -o -name '*ocr_search*.sqlite' -o -name '*qc_queue*.json' \) | grep .
+
+      - name: Upload temporary handoff for persistent Drive copy
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-github-operational-archive
+          path: |
+            local/ltmd_github_operational_archive.tar.gz
+            local/ARCHIVE_SHA256.txt
+            local/github-operational-archive/archive_manifest.json
+            local/github-operational-archive/SHA256SUMS.txt
+            local/github-operational-archive/negative_results.jsonl
+          if-no-files-found: error
+          retention-days: 2

--- a/.github/workflows/preserve-repo-snapshot.yml
+++ b/.github/workflows/preserve-repo-snapshot.yml
@@ -19,18 +19,49 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Checkout exact revision
+      - name: Checkout complete repository history
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      - name: Build repository snapshot
+      - name: Materialize all remote branch refs
         run: |
+          git fetch --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Build repository tree and complete Git-history snapshot
+        run: |
+          set -euo pipefail
           mkdir -p local/repo-snapshot
           git rev-parse HEAD > local/repo-snapshot/COMMIT.txt
           git status --short --untracked-files=no > local/repo-snapshot/GIT_STATUS.txt
           test ! -s local/repo-snapshot/GIT_STATUS.txt
+          git show-ref | sort > local/repo-snapshot/GIT_REFS.txt
+          git log --all --format='%H' | sort -u > local/repo-snapshot/COMMIT_OBJECTS.txt
+
           tar --exclude='.git' --exclude='local' --exclude='private' --exclude='data/raw' --exclude='data/work' \
             -czf local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz .
-          sha256sum local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz > local/repo-snapshot/SHA256SUMS.txt
+
+          git bundle create local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle --all
+          git bundle verify local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle \
+            > local/repo-snapshot/GIT_BUNDLE_VERIFY.txt 2>&1
+
+          sha256sum \
+            local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz \
+            local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle \
+            local/repo-snapshot/COMMIT.txt \
+            local/repo-snapshot/GIT_REFS.txt \
+            local/repo-snapshot/COMMIT_OBJECTS.txt \
+            local/repo-snapshot/GIT_BUNDLE_VERIFY.txt \
+            > local/repo-snapshot/SHA256SUMS.txt
+
+      - name: Assert history bundle is independently cloneable
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/ltmd-bundle-check
+          git clone local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle /tmp/ltmd-bundle-check
+          test "$(git -C /tmp/ltmd-bundle-check rev-parse HEAD)" = "$(cat local/repo-snapshot/COMMIT.txt)"
+          test -n "$(git -C /tmp/ltmd-bundle-check rev-list --all --count)"
 
       - name: Upload repository snapshot
         uses: actions/upload-artifact@v4
@@ -38,8 +69,12 @@ jobs:
           name: ltmd-repository-snapshot
           path: |
             local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz
+            local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle
             local/repo-snapshot/COMMIT.txt
             local/repo-snapshot/GIT_STATUS.txt
+            local/repo-snapshot/GIT_REFS.txt
+            local/repo-snapshot/COMMIT_OBJECTS.txt
+            local/repo-snapshot/GIT_BUNDLE_VERIFY.txt
             local/repo-snapshot/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/validate-total-preservation-canon.yml
+++ b/.github/workflows/validate-total-preservation-canon.yml
@@ -8,9 +8,13 @@ on:
       - 'docs/LTMD_TOTAL_PRESERVATION_CANON_0_1.md'
       - 'docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md'
       - 'data/research/ltmd_private_corpus_storage_contract.json'
+      - 'data/research/ltmd_github_operational_archive_contract.json'
       - 'data/research/ltmd_u1_ftrl_wave_state.json'
       - 'data/research/ltmd_u1_w5_archival_closure.json'
       - 'scripts/validate_total_preservation_canon.py'
+      - 'scripts/export_github_operational_archive.py'
+      - '.github/workflows/preserve-repo-snapshot.yml'
+      - '.github/workflows/preserve-github-operational-archive.yml'
       - '.github/workflows/validate-total-preservation-canon.yml'
   pull_request:
     branches: [main]
@@ -18,9 +22,13 @@ on:
       - 'docs/LTMD_TOTAL_PRESERVATION_CANON_0_1.md'
       - 'docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md'
       - 'data/research/ltmd_private_corpus_storage_contract.json'
+      - 'data/research/ltmd_github_operational_archive_contract.json'
       - 'data/research/ltmd_u1_ftrl_wave_state.json'
       - 'data/research/ltmd_u1_w5_archival_closure.json'
       - 'scripts/validate_total_preservation_canon.py'
+      - 'scripts/export_github_operational_archive.py'
+      - '.github/workflows/preserve-repo-snapshot.yml'
+      - '.github/workflows/preserve-github-operational-archive.yml'
       - '.github/workflows/validate-total-preservation-canon.yml'
   workflow_dispatch:
 
@@ -40,5 +48,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Validate preservation contract and W5 closure
+      - name: Compile preservation exporters and validators
+        run: |
+          python -m py_compile \
+            scripts/validate_total_preservation_canon.py \
+            scripts/export_github_operational_archive.py
+
+      - name: Validate total preservation, Git history, GitHub archive, and W5 closure
         run: python scripts/validate_total_preservation_canon.py

--- a/data/research/ltmd_github_operational_archive_contract.json
+++ b/data/research/ltmd_github_operational_archive_contract.json
@@ -1,0 +1,62 @@
+{
+  "schema": "LTMD_GITHUB_OPERATIONAL_ARCHIVE_0.1",
+  "effective_date": "2026-08-24",
+  "purpose": "Persist GitHub-hosted project history that is not fully represented by a working-tree repository snapshot or Git bundle.",
+  "repository": "fersandovalgtz/libro-texto-mexicano-digital",
+  "persistent_destination_logical": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/02_GITHUB_METADATA_EXPORTS",
+  "archive_surface": [
+    "repository_metadata",
+    "issues_all_states",
+    "issue_comments",
+    "issue_events",
+    "pull_requests_all_states",
+    "pull_request_reviews",
+    "pull_request_review_comments",
+    "releases",
+    "tags",
+    "branches",
+    "labels",
+    "milestones",
+    "commit_comments",
+    "contributors",
+    "actions_workflows",
+    "actions_workflow_runs",
+    "actions_run_jobs",
+    "actions_run_logs_when_provider_retains_them",
+    "actions_artifact_inventory"
+  ],
+  "pagination_policy": "exhaustive provider pagination for every collection endpoint",
+  "actions_logs_policy": {
+    "attempt_all_known_runs": true,
+    "unavailable_or_expired_logs": "record negative result with run id; never fabricate",
+    "logs_are_archived_as_provider_bytes": true
+  },
+  "actions_artifacts_policy": {
+    "inventory_all": true,
+    "bulk_duplicate_artifact_bytes_here": false,
+    "reason": "Canonical artifact bytes are preserved by their product-specific or repository-snapshot flows; this archive records the complete Actions artifact inventory and linkage so duplication does not create a competing archive authority."
+  },
+  "required_outputs": [
+    "github_operational_metadata_tar_gz",
+    "archive_manifest_json",
+    "sha256sums",
+    "negative_results_jsonl"
+  ],
+  "manifest_requirements": [
+    "repository",
+    "source_commit",
+    "workflow_run_id",
+    "generated_at_utc",
+    "exported_files_with_sha256_and_bytes",
+    "actions_log_available_count",
+    "actions_log_unavailable_count"
+  ],
+  "invariants": {
+    "chat_is_not_archive": true,
+    "git_bundle_does_not_replace_operational_metadata_archive": true,
+    "operational_metadata_archive_does_not_replace_git_bundle": true,
+    "actions_artifact_inventory_does_not_replace_product_archival": true,
+    "unavailable_history_must_be_recorded_negatively": true,
+    "persistent_drive_copy_required": true
+  }
+}

--- a/scripts/export_github_operational_archive.py
+++ b/scripts/export_github_operational_archive.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Export public GitHub operational history for persistent LTMD archiving.
+
+The exporter captures repository-level collections exhaustively via GitHub API
+pagination, then enriches pull requests with reviews and Actions runs with jobs
+and retained log bytes. Missing/expired dynamic resources are recorded as
+negative results rather than fabricated or silently omitted.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCHEMA = "LTMD_GITHUB_OPERATIONAL_EXPORT_0.1"
+
+
+def sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def gh_json(endpoint: str, output: Path, *, paginate: bool = True) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["gh", "api"]
+    if paginate:
+        cmd += ["--paginate", "--slurp"]
+    cmd.append(endpoint)
+    with output.open("wb") as out:
+        subprocess.run(cmd, check=True, stdout=out)
+
+
+def gh_binary(endpoint: str, output: Path) -> tuple[bool, str]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with output.open("wb") as out:
+        proc = subprocess.run(
+            ["gh", "api", endpoint],
+            stdout=out,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    if proc.returncode == 0 and output.stat().st_size > 0:
+        return True, ""
+    output.unlink(missing_ok=True)
+    return False, proc.stderr.decode("utf-8", errors="replace").strip()
+
+
+def flatten_page_arrays(path: Path) -> list[dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[dict] = []
+    for page in data:
+        if isinstance(page, list):
+            out.extend(x for x in page if isinstance(x, dict))
+    return out
+
+
+def flatten_object_collection(path: Path, key: str) -> list[dict]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    out: list[dict] = []
+    for page in data:
+        if isinstance(page, dict):
+            value = page.get(key, [])
+            if isinstance(value, list):
+                out.extend(x for x in value if isinstance(x, dict))
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--output-dir", type=Path, default=Path("local/github-operational-archive"))
+    args = parser.parse_args()
+
+    if not args.repository or "/" not in args.repository:
+        raise SystemExit("--repository owner/name is required")
+    if not os.environ.get("GH_TOKEN"):
+        raise SystemExit("GH_TOKEN is required")
+    if subprocess.run(["gh", "--version"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode:
+        raise SystemExit("GitHub CLI is required")
+
+    root = args.output_dir
+    data_dir = root / "data"
+    dynamic_dir = root / "dynamic"
+    logs_dir = root / "actions-logs"
+    root.mkdir(parents=True, exist_ok=True)
+
+    repo = args.repository
+    single = {
+        "repository.json": f"repos/{repo}",
+        "languages.json": f"repos/{repo}/languages",
+    }
+    collections = {
+        "issues_pages.json": f"repos/{repo}/issues?state=all&per_page=100",
+        "issue_comments_pages.json": f"repos/{repo}/issues/comments?per_page=100",
+        "issue_events_pages.json": f"repos/{repo}/issues/events?per_page=100",
+        "pulls_pages.json": f"repos/{repo}/pulls?state=all&per_page=100",
+        "pull_review_comments_pages.json": f"repos/{repo}/pulls/comments?per_page=100",
+        "releases_pages.json": f"repos/{repo}/releases?per_page=100",
+        "tags_pages.json": f"repos/{repo}/tags?per_page=100",
+        "branches_pages.json": f"repos/{repo}/branches?per_page=100",
+        "labels_pages.json": f"repos/{repo}/labels?per_page=100",
+        "milestones_pages.json": f"repos/{repo}/milestones?state=all&per_page=100",
+        "commit_comments_pages.json": f"repos/{repo}/comments?per_page=100",
+        "contributors_pages.json": f"repos/{repo}/contributors?anon=1&per_page=100",
+        "actions_workflows_pages.json": f"repos/{repo}/actions/workflows?per_page=100",
+        "actions_runs_pages.json": f"repos/{repo}/actions/runs?per_page=100",
+        "actions_artifacts_pages.json": f"repos/{repo}/actions/artifacts?per_page=100",
+    }
+
+    for filename, endpoint in single.items():
+        gh_json(endpoint, data_dir / filename, paginate=False)
+    for filename, endpoint in collections.items():
+        gh_json(endpoint, data_dir / filename, paginate=True)
+
+    negative: list[dict] = []
+
+    pulls = flatten_page_arrays(data_dir / "pulls_pages.json")
+    for pr in pulls:
+        number = int(pr["number"])
+        try:
+            gh_json(
+                f"repos/{repo}/pulls/{number}/reviews?per_page=100",
+                dynamic_dir / "pull-reviews" / f"pr_{number}.json",
+                paginate=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            negative.append({"type": "pull_reviews", "id": number, "error": f"exit={exc.returncode}"})
+
+    runs = flatten_object_collection(data_dir / "actions_runs_pages.json", "workflow_runs")
+    log_available = 0
+    log_unavailable = 0
+    for run in runs:
+        run_id = int(run["id"])
+        try:
+            gh_json(
+                f"repos/{repo}/actions/runs/{run_id}/jobs?per_page=100",
+                dynamic_dir / "run-jobs" / f"run_{run_id}.json",
+                paginate=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            negative.append({"type": "run_jobs", "id": run_id, "error": f"exit={exc.returncode}"})
+
+        ok, error = gh_binary(
+            f"repos/{repo}/actions/runs/{run_id}/logs",
+            logs_dir / f"run_{run_id}.zip",
+        )
+        if ok:
+            log_available += 1
+        else:
+            log_unavailable += 1
+            negative.append({"type": "run_logs", "id": run_id, "error": error or "unavailable"})
+
+    negative_path = root / "negative_results.jsonl"
+    with negative_path.open("w", encoding="utf-8", newline="\n") as fh:
+        for item in negative:
+            fh.write(json.dumps(item, ensure_ascii=False, sort_keys=True) + "\n")
+
+    generated_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    files = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.name in {"archive_manifest.json", "SHA256SUMS.txt"}:
+            continue
+        files.append({
+            "path": path.relative_to(root).as_posix(),
+            "bytes": path.stat().st_size,
+            "sha256": sha256(path),
+        })
+
+    manifest = {
+        "schema": SCHEMA,
+        "generated_at_utc": generated_at,
+        "repository": repo,
+        "source_commit": os.environ.get("GITHUB_SHA"),
+        "workflow_run_id": os.environ.get("GITHUB_RUN_ID"),
+        "workflow_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "pull_requests_exported": len(pulls),
+        "actions_runs_exported": len(runs),
+        "actions_log_available_count": log_available,
+        "actions_log_unavailable_count": log_unavailable,
+        "negative_result_count": len(negative),
+        "actions_artifact_bytes_policy": "inventory_only_here; canonical bytes are preserved by product-specific or repository-snapshot flows",
+        "files": files,
+    }
+    (root / "archive_manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    checksum_paths = [p for p in sorted(root.rglob("*")) if p.is_file() and p.name != "SHA256SUMS.txt"]
+    with (root / "SHA256SUMS.txt").open("w", encoding="utf-8", newline="\n") as fh:
+        for path in checksum_paths:
+            fh.write(f"{sha256(path)}  {path.relative_to(root).as_posix()}\n")
+
+    print(json.dumps({
+        "status": "ok",
+        "repository": repo,
+        "pull_requests": len(pulls),
+        "actions_runs": len(runs),
+        "logs_available": log_available,
+        "logs_unavailable": log_unavailable,
+        "negative_results": len(negative),
+        "files": len(files),
+    }, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_total_preservation_canon.py
+++ b/scripts/validate_total_preservation_canon.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Validate LTMD total-preservation canon and W5 archival closure evidence."""
+"""Validate LTMD total-preservation canon, W5 closure, and GitHub archive layers."""
 from __future__ import annotations
 
 import json
 from pathlib import Path
 
 CONTRACT = Path("data/research/ltmd_private_corpus_storage_contract.json")
+GITHUB_ARCHIVE = Path("data/research/ltmd_github_operational_archive_contract.json")
 STATE = Path("data/research/ltmd_u1_ftrl_wave_state.json")
 W5 = Path("data/research/ltmd_u1_w5_archival_closure.json")
 TOTAL_CANON = Path("docs/LTMD_TOTAL_PRESERVATION_CANON_0_1.md")
 PRIVATE_CANON = Path("docs/LTMD_PRIVATE_CORPUS_PRESERVATION_CANON_0_1.md")
+SNAPSHOT_WORKFLOW = Path(".github/workflows/preserve-repo-snapshot.yml")
+GITHUB_ARCHIVE_WORKFLOW = Path(".github/workflows/preserve-github-operational-archive.yml")
+GITHUB_EXPORTER = Path("scripts/export_github_operational_archive.py")
 
 REQUIRED_CATEGORIES = {
     "repository_snapshots",
@@ -22,6 +26,27 @@ REQUIRED_CATEGORIES = {
     "preservation_audits",
     "notion_continuity",
 }
+REQUIRED_GITHUB_SURFACE = {
+    "repository_metadata",
+    "issues_all_states",
+    "issue_comments",
+    "issue_events",
+    "pull_requests_all_states",
+    "pull_request_reviews",
+    "pull_request_review_comments",
+    "releases",
+    "tags",
+    "branches",
+    "labels",
+    "milestones",
+    "commit_comments",
+    "contributors",
+    "actions_workflows",
+    "actions_workflow_runs",
+    "actions_run_jobs",
+    "actions_run_logs_when_provider_retains_them",
+    "actions_artifact_inventory",
+}
 
 
 def load(path: Path) -> dict:
@@ -29,11 +54,23 @@ def load(path: Path) -> dict:
 
 
 def main() -> None:
-    for path in (CONTRACT, STATE, W5, TOTAL_CANON, PRIVATE_CANON):
+    required_paths = (
+        CONTRACT,
+        GITHUB_ARCHIVE,
+        STATE,
+        W5,
+        TOTAL_CANON,
+        PRIVATE_CANON,
+        SNAPSHOT_WORKFLOW,
+        GITHUB_ARCHIVE_WORKFLOW,
+        GITHUB_EXPORTER,
+    )
+    for path in required_paths:
         if not path.exists():
             raise AssertionError(f"missing preservation control file: {path}")
 
     contract = load(CONTRACT)
+    github_archive = load(GITHUB_ARCHIVE)
     state = load(STATE)
     w5 = load(W5)
 
@@ -68,6 +105,55 @@ def main() -> None:
     ):
         assert inv[key] is True, key
 
+    assert github_archive["schema"] == "LTMD_GITHUB_OPERATIONAL_ARCHIVE_0.1"
+    assert github_archive["repository"] == "fersandovalgtz/libro-texto-mexicano-digital"
+    assert github_archive["persistent_destination_logical"].endswith("02_GITHUB_METADATA_EXPORTS")
+    assert REQUIRED_GITHUB_SURFACE == set(github_archive["archive_surface"])
+    assert github_archive["pagination_policy"].startswith("exhaustive")
+    assert github_archive["actions_logs_policy"]["attempt_all_known_runs"] is True
+    assert github_archive["actions_logs_policy"]["logs_are_archived_as_provider_bytes"] is True
+    assert github_archive["actions_artifacts_policy"]["inventory_all"] is True
+    assert github_archive["actions_artifacts_policy"]["bulk_duplicate_artifact_bytes_here"] is False
+    for value in github_archive["invariants"].values():
+        assert value is True
+
+    snapshot_workflow = SNAPSHOT_WORKFLOW.read_text(encoding="utf-8")
+    for marker in (
+        "fetch-depth: 0",
+        "git bundle create",
+        "git bundle verify",
+        "complete-history.bundle",
+        "git clone local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle",
+        "GIT_REFS.txt",
+        "COMMIT_OBJECTS.txt",
+    ):
+        assert marker in snapshot_workflow, marker
+
+    archive_workflow = GITHUB_ARCHIVE_WORKFLOW.read_text(encoding="utf-8")
+    for marker in (
+        "scripts/export_github_operational_archive.py",
+        "ltmd_github_operational_archive.tar.gz",
+        "ltmd-github-operational-archive",
+        "retention-days: 2",
+        "actions: read",
+        "issues: read",
+        "pull-requests: read",
+    ):
+        assert marker in archive_workflow, marker
+
+    exporter = GITHUB_EXPORTER.read_text(encoding="utf-8")
+    for marker in (
+        "--paginate",
+        "actions/runs?per_page=100",
+        "actions/runs/{run_id}/jobs?per_page=100",
+        "actions/runs/{run_id}/logs",
+        "negative_results.jsonl",
+        "actions_artifacts_pages.json",
+        "archive_manifest.json",
+        "SHA256SUMS.txt",
+    ):
+        assert marker in exporter, marker
+
     assert w5["schema"] == "LTMD_FTRL_ARCHIVAL_CLOSURE_0.1"
     assert w5["wave"] == "W5"
     assert w5["ftrl"]["run_id"] == "32748987531"
@@ -97,12 +183,26 @@ def main() -> None:
     assert sw5["archival_status"] == "archival_complete"
     assert sw5["archival_closure_evidence"] == str(W5)
 
-    combined_public = TOTAL_CANON.read_text(encoding="utf-8") + PRIVATE_CANON.read_text(encoding="utf-8")
-    forbidden_markers = ("drive.google.com/drive/folders/1", "BEGIN PRIVATE KEY", "BEGIN RSA PRIVATE KEY")
+    combined_public = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            TOTAL_CANON,
+            PRIVATE_CANON,
+            GITHUB_ARCHIVE,
+            SNAPSHOT_WORKFLOW,
+            GITHUB_ARCHIVE_WORKFLOW,
+            GITHUB_EXPORTER,
+        )
+    )
+    forbidden_markers = (
+        "drive.google.com/drive/folders/1",
+        "BEGIN PRIVATE KEY",
+        "BEGIN RSA PRIVATE KEY",
+    )
     for marker in forbidden_markers:
-        assert marker not in combined_public, f"private/sensitive marker leaked into public canon: {marker}"
+        assert marker not in combined_public, f"private/sensitive marker leaked into public preservation surface: {marker}"
 
-    print("LTMD total-preservation canon and W5 archival closure: OK")
+    print("LTMD total preservation, complete Git history, GitHub operational archive, and W5 closure: OK")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implementa la siguiente capa del canon total de preservación LTMD.

1. **Historia Git completa en Drive**
- el workflow de snapshot usa `fetch-depth: 0`, materializa refs remotas y crea `libro-texto-mexicano-digital__complete-history.bundle --all`;
- verifica el bundle y demuestra que puede clonarse de forma independiente;
- preserva refs, inventario de objetos commit y checksums junto al snapshot del árbol.

2. **Historia operativa de GitHub**
- contrato `LTMD_GITHUB_OPERATIONAL_ARCHIVE_0.1`;
- exportación paginada exhaustiva de issues, comentarios/eventos, PRs/reviews/review-comments, releases, tags, branches, labels, milestones, commit comments, contributors, workflows, runs, jobs, logs retenidos y catálogo de artifacts;
- logs ya no disponibles se registran como resultados negativos, sin inventar ni omitir silenciosamente;
- artifacts se inventarían aquí, pero sus bytes canónicos siguen los flujos de preservación de cada producto/snapshot para evitar una autoridad archivística duplicada;
- genera manifiesto, SHA-256 y tar.gz para handoff temporal y posterior copia persistente a Drive `00_CANON_y_manifiestos/02_GITHUB_METADATA_EXPORTS`.

3. El gate de preservación total valida ambas capas y prohíbe fugas de IDs privados de Drive o claves privadas.

No modifica FTRL, OCR, denominadores ni estados semánticos.