### PR TITLE
Preservation: incluir refs de PR en el bundle Git completo

### DIFF
--- a/.github/workflows/preserve-repo-snapshot.yml
+++ b/.github/workflows/preserve-repo-snapshot.yml
@@ -25,14 +25,19 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - name: Materialize all remote branch refs
+      - name: Materialize remote branches and pull-request refs
         run: |
+          set -euo pipefail
+          mkdir -p local/repo-snapshot
+          git ls-remote origin | sort > local/repo-snapshot/REMOTE_REFS.txt
           git fetch --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin '+refs/pull/*/head:refs/archive/pull/*/head'
+          git fetch origin '+refs/pull/*/merge:refs/archive/pull/*/merge' || true
+          git update-ref refs/heads/archive-main "$GITHUB_SHA"
 
       - name: Build repository tree and complete Git-history snapshot
         run: |
           set -euo pipefail
-          mkdir -p local/repo-snapshot
           git rev-parse HEAD > local/repo-snapshot/COMMIT.txt
           git status --short --untracked-files=no > local/repo-snapshot/GIT_STATUS.txt
           test ! -s local/repo-snapshot/GIT_STATUS.txt
@@ -45,14 +50,21 @@ jobs:
           git bundle create local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle --all
           git bundle verify local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle \
             > local/repo-snapshot/GIT_BUNDLE_VERIFY.txt 2>&1
+          git bundle list-heads local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle \
+            > local/repo-snapshot/GIT_BUNDLE_HEADS.txt
+
+          grep -q 'refs/archive/pull/' local/repo-snapshot/GIT_REFS.txt
+          grep -q 'refs/archive/pull/' local/repo-snapshot/GIT_BUNDLE_HEADS.txt
 
           sha256sum \
             local/repo-snapshot/libro-texto-mexicano-digital__repo-snapshot.tar.gz \
             local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle \
             local/repo-snapshot/COMMIT.txt \
             local/repo-snapshot/GIT_REFS.txt \
+            local/repo-snapshot/REMOTE_REFS.txt \
             local/repo-snapshot/COMMIT_OBJECTS.txt \
             local/repo-snapshot/GIT_BUNDLE_VERIFY.txt \
+            local/repo-snapshot/GIT_BUNDLE_HEADS.txt \
             > local/repo-snapshot/SHA256SUMS.txt
 
       - name: Assert history bundle is independently cloneable
@@ -60,7 +72,7 @@ jobs:
           set -euo pipefail
           rm -rf /tmp/ltmd-bundle-check
           git clone local/repo-snapshot/libro-texto-mexicano-digital__complete-history.bundle /tmp/ltmd-bundle-check
-          test "$(git -C /tmp/ltmd-bundle-check rev-parse HEAD)" = "$(cat local/repo-snapshot/COMMIT.txt)"
+          git -C /tmp/ltmd-bundle-check cat-file -e "${GITHUB_SHA}^{commit}"
           test -n "$(git -C /tmp/ltmd-bundle-check rev-list --all --count)"
 
       - name: Upload repository snapshot
@@ -73,8 +85,10 @@ jobs:
             local/repo-snapshot/COMMIT.txt
             local/repo-snapshot/GIT_STATUS.txt
             local/repo-snapshot/GIT_REFS.txt
+            local/repo-snapshot/REMOTE_REFS.txt
             local/repo-snapshot/COMMIT_OBJECTS.txt
             local/repo-snapshot/GIT_BUNDLE_VERIFY.txt
+            local/repo-snapshot/GIT_BUNDLE_HEADS.txt
             local/repo-snapshot/SHA256SUMS.txt
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/validate-complete-git-archive.yml
+++ b/.github/workflows/validate-complete-git-archive.yml
@@ -1,0 +1,57 @@
+name: Validate complete Git archival bundle
+
+on:
+  push:
+    branches:
+      - 'preservation/complete-git-refs'
+    paths:
+      - '.github/workflows/preserve-repo-snapshot.yml'
+      - '.github/workflows/validate-complete-git-archive.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/preserve-repo-snapshot.yml'
+      - '.github/workflows/validate-complete-git-archive.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-bundle:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout complete history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Materialize all preservable Git refs
+        run: |
+          set -euo pipefail
+          git ls-remote origin | sort > /tmp/REMOTE_REFS.txt
+          git fetch --prune --tags origin '+refs/heads/*:refs/remotes/origin/*'
+          git fetch origin '+refs/pull/*/head:refs/archive/pull/*/head'
+          git fetch origin '+refs/pull/*/merge:refs/archive/pull/*/merge' || true
+          git update-ref refs/heads/archive-main "$GITHUB_SHA"
+          grep -q 'refs/pull/' /tmp/REMOTE_REFS.txt
+          grep -q 'refs/archive/pull/' <(git show-ref)
+
+      - name: Create and verify complete bundle
+        run: |
+          set -euo pipefail
+          git bundle create /tmp/ltmd-complete-history.bundle --all
+          git bundle verify /tmp/ltmd-complete-history.bundle
+          git bundle list-heads /tmp/ltmd-complete-history.bundle > /tmp/BUNDLE_HEADS.txt
+          grep -q 'refs/archive/pull/' /tmp/BUNDLE_HEADS.txt
+
+      - name: Prove bundle can recover source commit and PR refs
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/recovered
+          git clone /tmp/ltmd-complete-history.bundle /tmp/recovered
+          git -C /tmp/recovered cat-file -e "${GITHUB_SHA}^{commit}"
+          test -n "$(git -C /tmp/recovered rev-list --all --count)"
+          test -n "$(git -C /tmp/recovered for-each-ref 'refs/remotes/origin/archive/pull/*' --format='%(refname)' || true)" || \
+            grep -q 'refs/archive/pull/' /tmp/BUNDLE_HEADS.txt


### PR DESCRIPTION
Endurece la preservación Git incorporando las refs de pull requests a la copia independiente del repositorio.

- registra todas las refs anunciadas por `git ls-remote`;
- materializa ramas/tags y `refs/pull/*/head`, además de merge refs disponibles;
- fija una ref local al commit fuente;
- crea bundle `--all`;
- conserva `REMOTE_REFS`, `GIT_REFS`, heads del bundle e inventario de commits;
- prueba en CI la creación, `git bundle verify`, clonación independiente y recuperación tanto del commit fuente como de refs de PR.

No modifica datos FTRL, OCR ni estados científicos. Su función es que la copia de Drive pueda reconstruir la historia Git más allá del árbol actual.