### PR TITLE
Preservation: registrar cierres verificables de GitHub, Git y Notion

### DIFF
--- a/.github/workflows/validate-ltmd-archive-closures.yml
+++ b/.github/workflows/validate-ltmd-archive-closures.yml
@@ -1,0 +1,43 @@
+name: Validate LTMD archive closure evidence
+
+on:
+  push:
+    branches:
+      - 'preservation/archive-closures-2026-08-24'
+    paths:
+      - 'data/research/ltmd_github_operational_archive_closure_2026_08_24.json'
+      - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24.json'
+      - 'data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json'
+      - 'scripts/validate_ltmd_archive_closures.py'
+      - '.github/workflows/validate-ltmd-archive-closures.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_github_operational_archive_closure_2026_08_24.json'
+      - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24.json'
+      - 'data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json'
+      - 'scripts/validate_ltmd_archive_closures.py'
+      - '.github/workflows/validate-ltmd-archive-closures.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-closures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Compile validator
+        run: python -m py_compile scripts/validate_ltmd_archive_closures.py
+
+      - name: Validate text-free archive closure evidence
+        run: python scripts/validate_ltmd_archive_closures.py

--- a/data/research/ltmd_git_history_snapshot_closure_2026_08_24.json
+++ b/data/research/ltmd_git_history_snapshot_closure_2026_08_24.json
@@ -1,0 +1,50 @@
+{
+  "schema": "LTMD_COMPLETE_GIT_HISTORY_ARCHIVE_CLOSURE_0.1",
+  "effective_date": "2026-08-24",
+  "repository": "fersandovalgtz/libro-texto-mexicano-digital",
+  "source": {
+    "workflow_run_id": "32791856141",
+    "source_commit": "842a41536c96b5e73486c23e97609a05dcf5de45",
+    "artifact_id": "9543397514",
+    "artifact_name": "ltmd-repository-snapshot",
+    "artifact_zip_bytes": 183170565,
+    "artifact_zip_sha256": "cf1befbf8bdfb25569c47eac5bf545f5111ccaca57973241391e4b32ef9cb447",
+    "workflow_conclusion": "success"
+  },
+  "git_history": {
+    "bundle_verified": true,
+    "independently_cloneable": true,
+    "branches_preserved": true,
+    "tags_preserved": true,
+    "pull_request_refs_preserved": true
+  },
+  "persistent_archive": {
+    "provider": "google_drive",
+    "logical_destination": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/01_REPO_SNAPSHOTS",
+    "storage_form": "three reversible binary volumes plus manifest",
+    "volume_count": 3,
+    "volumes": [
+      {
+        "sequence": 0,
+        "bytes": 90000000,
+        "sha256": "a15c8db996b3e39d3c8f405e26fd249dc71e19a1e64bc2cd487c6c16d837d867"
+      },
+      {
+        "sequence": 1,
+        "bytes": 90000000,
+        "sha256": "deb3c051549d03c7b78b669b298080842e48a60890f43924966f626413ed79d0"
+      },
+      {
+        "sequence": 2,
+        "bytes": 3170565,
+        "sha256": "a8da596fbaa3315d8bd3342536f55c798f8b341f29879d9521b932a99f763c25"
+      }
+    ],
+    "all_volumes_shared": false,
+    "all_volumes_redownload_verified": true,
+    "reconstructed_bytes": 183170565,
+    "reconstructed_sha256": "cf1befbf8bdfb25569c47eac5bf545f5111ccaca57973241391e4b32ef9cb447",
+    "reconstructed_matches_origin_artifact": true
+  },
+  "archival_complete": true
+}

--- a/data/research/ltmd_github_operational_archive_closure_2026_08_24.json
+++ b/data/research/ltmd_github_operational_archive_closure_2026_08_24.json
@@ -1,0 +1,46 @@
+{
+  "schema": "LTMD_GITHUB_OPERATIONAL_ARCHIVE_CLOSURE_0.1",
+  "effective_date": "2026-08-24",
+  "repository": "fersandovalgtz/libro-texto-mexicano-digital",
+  "source": {
+    "workflow_run_id": "32791474215",
+    "source_commit": "277a6bbfc2778970cb3a3ec3fab167d66ca0711b",
+    "artifact_id": "9544242907",
+    "artifact_name": "ltmd-github-operational-archive",
+    "artifact_zip_bytes": 26650402,
+    "artifact_zip_sha256": "7145b30407cd8de18b616d005b9f69957b362498108187e5d47e9c598a57f74f",
+    "workflow_conclusion": "success"
+  },
+  "persistent_archive": {
+    "provider": "google_drive",
+    "logical_destination": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/02_GITHUB_METADATA_EXPORTS",
+    "copied": true,
+    "destination_shared": false,
+    "destination_bytes": 26650402,
+    "redownload_verified": true,
+    "redownload_sha256": "7145b30407cd8de18b616d005b9f69957b362498108187e5d47e9c598a57f74f",
+    "matches_origin_artifact": true
+  },
+  "scope": {
+    "provider_visible_metadata": [
+      "issues",
+      "issue_comments_and_events",
+      "pull_requests_reviews_and_review_comments",
+      "releases",
+      "tags",
+      "branches",
+      "labels",
+      "milestones",
+      "commit_comments",
+      "contributors",
+      "workflows",
+      "workflow_runs",
+      "jobs",
+      "retained_logs",
+      "artifact_catalog"
+    ],
+    "unavailable_provider_objects_are_recorded_as_negative_results": true,
+    "restricted_ftrl_plaintext_included": false
+  },
+  "archival_complete": true
+}

--- a/data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json
+++ b/data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json
@@ -1,0 +1,24 @@
+{
+  "schema": "LTMD_NOTION_CONTINUITY_ARCHIVE_CLOSURE_0.1",
+  "effective_date": "2026-08-24",
+  "canonical_notion_page": "LTMD — procedimiento canónico de preservación GitHub ↔ Google Drive",
+  "persistent_archive": {
+    "provider": "google_drive",
+    "logical_destination": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/03_NOTION_CONTINUITY_EXPORTS",
+    "native_snapshot_preserved": true,
+    "immutable_text_snapshot_preserved": true,
+    "immutable_text_file_name": "LTMD_Notion_canon_snapshot__2026-08-24T2124-0600.txt",
+    "immutable_text_bytes": 13181,
+    "immutable_text_sha256": "08a642846906dcd69eace0488ef53120177366f2c40328c40fc8802d4d511b9f",
+    "destination_shared": false,
+    "redownload_verified": true,
+    "redownload_sha256": "08a642846906dcd69eace0488ef53120177366f2c40328c40fc8802d4d511b9f",
+    "matches_exported_source": true
+  },
+  "continuity_rule": {
+    "chat_is_single_source_of_truth": false,
+    "notion_is_single_copy_of_data_or_code": false,
+    "github_drive_notion_are_complementary": true
+  },
+  "archival_complete": true
+}

--- a/scripts/validate_ltmd_archive_closures.py
+++ b/scripts/validate_ltmd_archive_closures.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Validate text-free LTMD archive-closure evidence without private Drive identifiers."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+GH = Path("data/research/ltmd_github_operational_archive_closure_2026_08_24.json")
+GIT = Path("data/research/ltmd_git_history_snapshot_closure_2026_08_24.json")
+NOTION = Path("data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json")
+SHA = re.compile(r"^[0-9a-f]{64}$")
+
+
+def load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def assert_sha(value: str) -> None:
+    assert SHA.fullmatch(value), value
+
+
+def no_private_locator(value) -> None:
+    if isinstance(value, dict):
+        forbidden_keys = {"drive_id", "file_id", "folder_id", "drive_url", "private_url"}
+        assert not (forbidden_keys & set(value)), forbidden_keys & set(value)
+        for child in value.values():
+            no_private_locator(child)
+    elif isinstance(value, list):
+        for child in value:
+            no_private_locator(child)
+    elif isinstance(value, str):
+        assert "drive.google.com" not in value
+        assert "docs.google.com" not in value
+        assert "BEGIN PRIVATE KEY" not in value
+        assert "BEGIN RSA PRIVATE KEY" not in value
+
+
+def main() -> None:
+    gh, git, notion = map(load, (GH, GIT, NOTION))
+
+    assert gh["schema"] == "LTMD_GITHUB_OPERATIONAL_ARCHIVE_CLOSURE_0.1"
+    assert gh["source"]["workflow_run_id"] == "32791474215"
+    assert gh["source"]["artifact_zip_bytes"] == 26650402
+    assert_sha(gh["source"]["artifact_zip_sha256"])
+    assert gh["source"]["artifact_zip_sha256"] == gh["persistent_archive"]["redownload_sha256"]
+    assert gh["persistent_archive"]["destination_shared"] is False
+    assert gh["persistent_archive"]["redownload_verified"] is True
+    assert gh["persistent_archive"]["matches_origin_artifact"] is True
+    assert gh["scope"]["restricted_ftrl_plaintext_included"] is False
+    assert gh["archival_complete"] is True
+
+    assert git["schema"] == "LTMD_COMPLETE_GIT_HISTORY_ARCHIVE_CLOSURE_0.1"
+    assert git["source"]["workflow_run_id"] == "32791856141"
+    assert git["source"]["artifact_zip_bytes"] == 183170565
+    assert_sha(git["source"]["artifact_zip_sha256"])
+    assert git["git_history"]["bundle_verified"] is True
+    assert git["git_history"]["independently_cloneable"] is True
+    assert git["git_history"]["pull_request_refs_preserved"] is True
+    archive = git["persistent_archive"]
+    assert archive["volume_count"] == 3
+    assert [v["bytes"] for v in archive["volumes"]] == [90000000, 90000000, 3170565]
+    for volume in archive["volumes"]:
+        assert_sha(volume["sha256"])
+    assert sum(v["bytes"] for v in archive["volumes"]) == git["source"]["artifact_zip_bytes"]
+    assert archive["all_volumes_shared"] is False
+    assert archive["all_volumes_redownload_verified"] is True
+    assert archive["reconstructed_bytes"] == git["source"]["artifact_zip_bytes"]
+    assert archive["reconstructed_sha256"] == git["source"]["artifact_zip_sha256"]
+    assert archive["reconstructed_matches_origin_artifact"] is True
+    assert git["archival_complete"] is True
+
+    assert notion["schema"] == "LTMD_NOTION_CONTINUITY_ARCHIVE_CLOSURE_0.1"
+    n = notion["persistent_archive"]
+    assert n["immutable_text_bytes"] == 13181
+    assert_sha(n["immutable_text_sha256"])
+    assert n["destination_shared"] is False
+    assert n["redownload_verified"] is True
+    assert n["redownload_sha256"] == n["immutable_text_sha256"]
+    assert n["matches_exported_source"] is True
+    assert notion["continuity_rule"]["chat_is_single_source_of_truth"] is False
+    assert notion["archival_complete"] is True
+
+    for payload in (gh, git, notion):
+        no_private_locator(payload)
+
+    print("LTMD archive closure evidence: OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Registra como evidencia pública `text-free` tres cierres archivísticos ya materialmente verificados en Google Drive privado, sin publicar IDs, URLs privadas ni corpus restringido.

- Historia operativa GitHub: run 32791474215; 26,650,402 bytes; SHA-256 `7145b30407cd8de18b616d005b9f69957b362498108187e5d47e9c598a57f74f`; copia y re-descarga idénticas.
- Historia Git completa: run 32791856141; 183,170,565 bytes; SHA-256 `cf1befbf8bdfb25569c47eac5bf545f5111ccaca57973241391e4b32ef9cb447`; preservación en tres volúmenes reversibles por límite del conector, con reensamblado exacto; bundle probado clonable e incluyendo refs de PR.
- Continuidad Notion: snapshot TXT inmutable de 13,181 bytes; SHA-256 `08a642846906dcd69eace0488ef53120177366f2c40328c40fc8802d4d511b9f`; copia privada y re-descarga idénticas.

Añade un validador que comprueba tamaños, hashes, estados de privacidad declarados y ausencia de localizadores privados de Drive o material de clave privada.