### PR TITLE
Preservation: cerrar snapshot secuencia 8 tras PR #52

### DIFF
--- a/.github/workflows/validate-ltmd-archive-closures.yml
+++ b/.github/workflows/validate-ltmd-archive-closures.yml
@@ -3,10 +3,11 @@ name: Validate LTMD archive closure evidence
 on:
   push:
     branches:
-      - 'preservation/archive-closures-2026-08-24'
+      - 'preservation/**'
     paths:
       - 'data/research/ltmd_github_operational_archive_closure_2026_08_24.json'
       - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24.json'
+      - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24_seq8.json'
       - 'data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json'
       - 'scripts/validate_ltmd_archive_closures.py'
       - '.github/workflows/validate-ltmd-archive-closures.yml'
@@ -15,6 +16,7 @@ on:
     paths:
       - 'data/research/ltmd_github_operational_archive_closure_2026_08_24.json'
       - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24.json'
+      - 'data/research/ltmd_git_history_snapshot_closure_2026_08_24_seq8.json'
       - 'data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json'
       - 'scripts/validate_ltmd_archive_closures.py'
       - '.github/workflows/validate-ltmd-archive-closures.yml'

--- a/data/research/ltmd_git_history_snapshot_closure_2026_08_24_seq8.json
+++ b/data/research/ltmd_git_history_snapshot_closure_2026_08_24_seq8.json
@@ -1,0 +1,61 @@
+{
+  "schema": "LTMD_COMPLETE_GIT_HISTORY_ARCHIVE_CLOSURE_0.1",
+  "effective_date": "2026-08-24",
+  "repository": "fersandovalgtz/libro-texto-mexicano-digital",
+  "checkpoint": "repository_snapshot_sequence_8_after_pr_52",
+  "source": {
+    "workflow_run_id": "32806500511",
+    "source_commit": "5b988f666f291352021bf10c2a615cb17138da85",
+    "preserved_architecture_commit": "1c3576c32766a9627a6027890fe1909175c1eecc",
+    "artifact_id": "9548322517",
+    "artifact_name": "ltmd-repository-snapshot",
+    "artifact_zip_bytes": 183214572,
+    "artifact_zip_sha256": "2e5de59fb33142649d347d18ba8a2102d654c41ddfb94e8ca5cbec0d014cdd8d",
+    "workflow_conclusion": "success"
+  },
+  "git_history": {
+    "bundle_verified": true,
+    "independently_cloneable": true,
+    "branches_preserved": true,
+    "tags_preserved": true,
+    "pull_request_refs_preserved": true
+  },
+  "persistent_archive": {
+    "provider": "google_drive",
+    "logical_destination": "LTMD-U1 — corpus FTRL privado/00_CANON_y_manifiestos/01_REPO_SNAPSHOTS",
+    "storage_form": "three reversible binary volumes plus manifest",
+    "volume_count": 3,
+    "volumes": [
+      {
+        "sequence": 0,
+        "bytes": 90000000,
+        "sha256": "3d72d2d64ac4216dd546799444ca283da915750825d14d0c17e3263ff1e73e19"
+      },
+      {
+        "sequence": 1,
+        "bytes": 90000000,
+        "sha256": "1cf06b59da7e74f08626d34562719ed0b049ef8e517adc229d1d725e4191513f"
+      },
+      {
+        "sequence": 2,
+        "bytes": 3214572,
+        "sha256": "46d802dbdc2e49eb8a596ec45c41a4bca25bb02b704be23308547a80297ae8dd"
+      }
+    ],
+    "manifest_present": true,
+    "all_volumes_shared": false,
+    "all_volumes_redownload_verified": true,
+    "reconstructed_bytes": 183214572,
+    "reconstructed_sha256": "2e5de59fb33142649d347d18ba8a2102d654c41ddfb94e8ca5cbec0d014cdd8d",
+    "reconstructed_matches_origin_artifact": true,
+    "zip_integrity_test_passed": true
+  },
+  "scope": {
+    "repository_code_and_git_history_only": true,
+    "w1_exhaustive_distributed_run_launched": false,
+    "w1_computationally_validated": false,
+    "w1_archival_complete": false,
+    "w3_unblocked": false
+  },
+  "archival_complete": true
+}

--- a/scripts/validate_ltmd_archive_closures.py
+++ b/scripts/validate_ltmd_archive_closures.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 GH = Path("data/research/ltmd_github_operational_archive_closure_2026_08_24.json")
 GIT = Path("data/research/ltmd_git_history_snapshot_closure_2026_08_24.json")
+GIT_SEQ8 = Path("data/research/ltmd_git_history_snapshot_closure_2026_08_24_seq8.json")
 NOTION = Path("data/research/ltmd_notion_continuity_snapshot_closure_2026_08_24.json")
 SHA = re.compile(r"^[0-9a-f]{64}$")
 
@@ -36,8 +37,34 @@ def no_private_locator(value) -> None:
         assert "BEGIN RSA PRIVATE KEY" not in value
 
 
+def validate_git_snapshot(payload: dict, *, run_id: str, total_bytes: int, volume_bytes: list[int]) -> None:
+    assert payload["schema"] == "LTMD_COMPLETE_GIT_HISTORY_ARCHIVE_CLOSURE_0.1"
+    assert payload["source"]["workflow_run_id"] == run_id
+    assert payload["source"]["artifact_zip_bytes"] == total_bytes
+    assert_sha(payload["source"]["artifact_zip_sha256"])
+    assert payload["source"]["workflow_conclusion"] == "success"
+    assert payload["git_history"]["bundle_verified"] is True
+    assert payload["git_history"]["independently_cloneable"] is True
+    assert payload["git_history"]["branches_preserved"] is True
+    assert payload["git_history"]["tags_preserved"] is True
+    assert payload["git_history"]["pull_request_refs_preserved"] is True
+    archive = payload["persistent_archive"]
+    assert archive["volume_count"] == len(volume_bytes)
+    assert [v["bytes"] for v in archive["volumes"]] == volume_bytes
+    for volume in archive["volumes"]:
+        assert_sha(volume["sha256"])
+    assert sum(v["bytes"] for v in archive["volumes"]) == total_bytes
+    assert archive["all_volumes_shared"] is False
+    assert archive["all_volumes_redownload_verified"] is True
+    assert archive["reconstructed_bytes"] == total_bytes
+    assert_sha(archive["reconstructed_sha256"])
+    assert archive["reconstructed_sha256"] == payload["source"]["artifact_zip_sha256"]
+    assert archive["reconstructed_matches_origin_artifact"] is True
+    assert payload["archival_complete"] is True
+
+
 def main() -> None:
-    gh, git, notion = map(load, (GH, GIT, NOTION))
+    gh, git, git_seq8, notion = map(load, (GH, GIT, GIT_SEQ8, NOTION))
 
     assert gh["schema"] == "LTMD_GITHUB_OPERATIONAL_ARCHIVE_CLOSURE_0.1"
     assert gh["source"]["workflow_run_id"] == "32791474215"
@@ -50,25 +77,26 @@ def main() -> None:
     assert gh["scope"]["restricted_ftrl_plaintext_included"] is False
     assert gh["archival_complete"] is True
 
-    assert git["schema"] == "LTMD_COMPLETE_GIT_HISTORY_ARCHIVE_CLOSURE_0.1"
-    assert git["source"]["workflow_run_id"] == "32791856141"
-    assert git["source"]["artifact_zip_bytes"] == 183170565
-    assert_sha(git["source"]["artifact_zip_sha256"])
-    assert git["git_history"]["bundle_verified"] is True
-    assert git["git_history"]["independently_cloneable"] is True
-    assert git["git_history"]["pull_request_refs_preserved"] is True
-    archive = git["persistent_archive"]
-    assert archive["volume_count"] == 3
-    assert [v["bytes"] for v in archive["volumes"]] == [90000000, 90000000, 3170565]
-    for volume in archive["volumes"]:
-        assert_sha(volume["sha256"])
-    assert sum(v["bytes"] for v in archive["volumes"]) == git["source"]["artifact_zip_bytes"]
-    assert archive["all_volumes_shared"] is False
-    assert archive["all_volumes_redownload_verified"] is True
-    assert archive["reconstructed_bytes"] == git["source"]["artifact_zip_bytes"]
-    assert archive["reconstructed_sha256"] == git["source"]["artifact_zip_sha256"]
-    assert archive["reconstructed_matches_origin_artifact"] is True
-    assert git["archival_complete"] is True
+    validate_git_snapshot(
+        git,
+        run_id="32791856141",
+        total_bytes=183170565,
+        volume_bytes=[90000000, 90000000, 3170565],
+    )
+
+    validate_git_snapshot(
+        git_seq8,
+        run_id="32806500511",
+        total_bytes=183214572,
+        volume_bytes=[90000000, 90000000, 3214572],
+    )
+    assert git_seq8["persistent_archive"]["manifest_present"] is True
+    assert git_seq8["persistent_archive"]["zip_integrity_test_passed"] is True
+    assert git_seq8["scope"]["repository_code_and_git_history_only"] is True
+    assert git_seq8["scope"]["w1_exhaustive_distributed_run_launched"] is False
+    assert git_seq8["scope"]["w1_computationally_validated"] is False
+    assert git_seq8["scope"]["w1_archival_complete"] is False
+    assert git_seq8["scope"]["w3_unblocked"] is False
 
     assert notion["schema"] == "LTMD_NOTION_CONTINUITY_ARCHIVE_CLOSURE_0.1"
     n = notion["persistent_archive"]
@@ -81,7 +109,7 @@ def main() -> None:
     assert notion["continuity_rule"]["chat_is_single_source_of_truth"] is False
     assert notion["archival_complete"] is True
 
-    for payload in (gh, git, notion):
+    for payload in (gh, git, git_seq8, notion):
         no_private_locator(payload)
 
     print("LTMD archive closure evidence: OK")


### PR DESCRIPTION
## Propósito

Registrar de forma versionada y verificable el cierre archivístico del snapshot de repositorio generado después de integrar la arquitectura distribuida W1 del PR #52.

## Evidencia incorporada

- workflow de preservación: `32806500511` (`success`);
- commit preservado de la arquitectura W1: `1c3576c32766a9627a6027890fe1909175c1eecc`;
- commit que dispara el snapshot secuencia 8: `5b988f666f291352021bf10c2a615cb17138da85`;
- artefacto originario: 183,214,572 bytes;
- SHA-256 originario y reconstruido: `2e5de59fb33142649d347d18ba8a2102d654c41ddfb94e8ca5cbec0d014cdd8d`;
- persistencia privada en Drive mediante tres volúmenes reversibles de 90,000,000 + 90,000,000 + 3,214,572 bytes y manifiesto;
- redescarga de los tres volúmenes, reconstrucción exacta y prueba de integridad ZIP satisfactoria.

## Cambios

- añade `ltmd_git_history_snapshot_closure_2026_08_24_seq8.json` sin IDs ni URLs privadas;
- amplía el validador para comprobar simultáneamente el cierre histórico anterior y la secuencia 8;
- amplía el workflow de validación a nuevos checkpoints de preservación bajo ramas `preservation/**`.

## Alcance epistemológico

Este cierre corresponde exclusivamente al código y a la historia Git. **No** declara completado W1 como corpus: la corrida exhaustiva distribuida no se ha lanzado; `w1_computationally_validated=false`, `w1_archival_complete=false` y W3 continúa bloqueado.