### PR TITLE
FTRL W3: lanzar piloto guardado de 100 páginas

### DIFF
--- a/.github/workflows/validate-ftrl-w3-runtime-pilot.yml
+++ b/.github/workflows/validate-ftrl-w3-runtime-pilot.yml
@@ -7,6 +7,10 @@ on:
         description: 'Number of canonical W3 pages to process after W1 gate'
         required: true
         default: '12'
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w3_runtime_pilot_stamp.json'
 
 permissions:
   contents: read
@@ -34,22 +38,43 @@ jobs:
           sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
           tesseract --list-langs | grep -Fx spa
 
-      - name: Execute W3 pilot only after canonical W1 gate
+      - name: Resolve guarded pilot page count
         env:
-          PILOT_PAGES: ${{ inputs.pages }}
+          DISPATCH_PAGES: ${{ inputs.pages }}
         run: |
+          set -euo pipefail
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            PILOT_PAGES="$DISPATCH_PAGES"
+          else
+            PILOT_PAGES="$(python - <<'PY'
+          import json
+          from pathlib import Path
+          p = Path('data/research/ltmd_u1_w3_runtime_pilot_stamp.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W3_RUNTIME_PILOT_STAMP_0.1'
+          assert data['wave'] == 'W3'
+          assert data['execution_mode'] == 'runtime_pilot_only'
+          assert data['full_corpus_activation'] is False
+          assert data['text_verified'] is False
+          assert data['semantic_ready'] is False
+          print(data['pages'])
+          PY
+          )"
+          fi
           case "$PILOT_PAGES" in
             ''|*[!0-9]*) echo 'pages must be a positive integer' >&2; exit 1 ;;
           esac
           test "$PILOT_PAGES" -ge 1
           test "$PILOT_PAGES" -le 100
+          echo "PILOT_PAGES=$PILOT_PAGES" >> "$GITHUB_ENV"
+
+      - name: Execute W3 pilot only after canonical W1 gate
+        run: |
           python scripts/run_ftrl_w3.py \
             --pages "$PILOT_PAGES" \
             --output-dir local/ftrl
 
       - name: Assert pilot integrity and no epistemic promotion
-        env:
-          PILOT_PAGES: ${{ inputs.pages }}
         run: |
           python - <<'PY'
           import json, os
@@ -80,8 +105,6 @@ jobs:
           PY
 
       - name: Prove restricted pilot outputs remain non-publishable
-        env:
-          PILOT_PAGES: ${{ inputs.pages }}
         run: |
           label="pilot_${PILOT_PAGES}"
           for path in \
@@ -93,8 +116,6 @@ jobs:
           done
 
       - name: Upload text-free pilot evidence only
-        env:
-          PILOT_PAGES: ${{ inputs.pages }}
         run: |
           mkdir -p local/w3-pilot-evidence
           label="pilot_${PILOT_PAGES}"
@@ -105,7 +126,7 @@ jobs:
       - name: Publish text-free pilot evidence
         uses: actions/upload-artifact@v4
         with:
-          name: ltmd-u1-w3-runtime-pilot-text-free-evidence
+          name: ltmd-u1-w3-runtime-pilot-${{ env.PILOT_PAGES }}-text-free-evidence
           path: local/w3-pilot-evidence/
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/validate-ftrl-w3-runtime-scaffold.yml
+++ b/.github/workflows/validate-ftrl-w3-runtime-scaffold.yml
@@ -6,6 +6,7 @@ on:
       - 'scripts/guard_ftrl_w3_activation.py'
       - 'scripts/run_ftrl_w3.py'
       - 'data/research/ltmd_u1_w3_runtime_readiness.json'
+      - 'data/research/ltmd_u1_w3_runtime_pilot_stamp.json'
       - 'docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md'
       - '.github/workflows/validate-ftrl-w3-runtime-pilot.yml'
       - '.github/workflows/validate-ftrl-w3-runtime-scaffold.yml'
@@ -17,6 +18,7 @@ on:
       - 'scripts/guard_ftrl_w3_activation.py'
       - 'scripts/run_ftrl_w3.py'
       - 'data/research/ltmd_u1_w3_runtime_readiness.json'
+      - 'data/research/ltmd_u1_w3_runtime_pilot_stamp.json'
       - 'docs/FTRL_W3_RUNTIME_READINESS_PROTOCOL_0_1.md'
       - '.github/workflows/validate-ftrl-w3-runtime-pilot.yml'
       - '.github/workflows/validate-ftrl-w3-runtime-scaffold.yml'
@@ -62,6 +64,7 @@ jobs:
           from pathlib import Path
 
           readiness = json.loads(Path('data/research/ltmd_u1_w3_runtime_readiness.json').read_text(encoding='utf-8'))
+          stamp = json.loads(Path('data/research/ltmd_u1_w3_runtime_pilot_stamp.json').read_text(encoding='utf-8'))
           assert readiness['schema'] == 'LTMD_U1_W3_RUNTIME_READINESS_0.1'
           assert readiness['historical_identities'] == 130
           assert readiness['canonical_processing_objects'] == 114
@@ -75,6 +78,17 @@ jobs:
           assert readiness['runtime']['full_execution_topology_frozen'] is False
           assert readiness['preservation']['required_before_full_activation'] is True
 
+          assert stamp['schema'] == 'LTMD_FTRL_W3_RUNTIME_PILOT_STAMP_0.1'
+          assert stamp['wave'] == 'W3'
+          assert stamp['execution_mode'] == 'runtime_pilot_only'
+          assert 1 <= int(stamp['pages']) <= 100
+          assert stamp['prerequisite']['w1_computationally_validated'] is True
+          assert stamp['prerequisite']['w1_archival_complete'] is True
+          assert stamp['full_corpus_activation'] is False
+          assert stamp['corpus_ready'] is False
+          assert stamp['text_verified'] is False
+          assert stamp['semantic_ready'] is False
+
           runner = Path('scripts/run_ftrl_w3.py').read_text(encoding='utf-8')
           guard = Path('scripts/guard_ftrl_w3_activation.py').read_text(encoding='utf-8')
           pilot = Path('.github/workflows/validate-ftrl-w3-runtime-pilot.yml').read_text(encoding='utf-8')
@@ -82,7 +96,10 @@ jobs:
           assert 'guard_ftrl_w3_activation.py' in runner
           assert 'EXPECTED_W1_IDENTITIES = 40' in guard
           assert 'workflow_dispatch:' in pilot
-          assert 'push:' not in pilot
+          assert 'push:' in pilot
+          assert 'branches: [main]' in pilot
+          assert "data/research/ltmd_u1_w3_runtime_pilot_stamp.json" in pilot
+          assert 'full_corpus_activation' in pilot
           assert '--full' not in pilot
 
           with Path('local/ftrl/ltmd_u1_w3_processing_inventory.csv').open(encoding='utf-8', newline='') as fh:
@@ -92,5 +109,5 @@ jobs:
           assert len(processing) == 130
           assert sum(int(r['is_canonical_processing_object']) for r in processing) == 114
           assert len(pages) == 20765
-          print('W3 runtime scaffold is guarded, exhaustive, archive-gated, and not activated')
+          print('W3 runtime scaffold is guarded, stamp-bounded, archive-gated, and not fully activated')
           PY

--- a/data/research/ltmd_u1_w3_runtime_pilot_stamp.json
+++ b/data/research/ltmd_u1_w3_runtime_pilot_stamp.json
@@ -1,0 +1,23 @@
+{
+  "schema": "LTMD_FTRL_W3_RUNTIME_PILOT_STAMP_0.1",
+  "effective_date": "2026-08-25",
+  "run_sequence": 1,
+  "wave": "W3",
+  "operational_domain": "espanol_lengua",
+  "pages": 100,
+  "canonical_source_pages": 20765,
+  "canonical_processing_objects": 114,
+  "historical_identities": 130,
+  "prerequisite": {
+    "w1_computationally_validated": true,
+    "w1_archival_complete": true,
+    "w1_closure_source": "data/research/ltmd_u1_w1_archival_closure.json"
+  },
+  "execution_mode": "runtime_pilot_only",
+  "purpose": "Measure observed W3 OCR/SQLite/FTS5 wall time after the canonical W1 gate, using the maximum allowed 100-page pilot before freezing full-corpus topology.",
+  "full_corpus_activation": false,
+  "corpus_ready": false,
+  "text_verified": false,
+  "semantic_ready": false,
+  "preservation_policy": "Pilot restricted outputs remain ephemeral and non-publishable; only text-free evidence is uploaded. Full private preservation applies after topology selection and exhaustive W3 execution."
+}


### PR DESCRIPTION
Prepara y activa, al fusionarse a `main`, un piloto W3 estrictamente limitado a 100 páginas para medir runtime antes de congelar la topología exhaustiva de 20,765 páginas.

Cambios:
- mantiene `workflow_dispatch` para pruebas manuales;
- añade trigger canónico por stamp en `main`;
- el stamp fija 100 páginas, W1 validado + archivado y `full_corpus_activation=false`;
- resuelve el tamaño del piloto desde el stamp en push;
- conserva los guards epistemológicos (`corpus_ready=false`, `text_verified=false`, `semantic_ready=false`);
- sólo publica evidencia text-free; OCR/SQLite/QC restringidos del piloto permanecen efímeros y no se archivan como corpus.

La fusión de este PR debe lanzar una única medición de runtime de 100 páginas. No activa W3 completo.