### PR TITLE
FTRL W3: congelar arquitectura distribuida de 52 shards

### DIFF
--- a/.github/workflows/run-ftrl-w3-distributed.yml
+++ b/.github/workflows/run-ftrl-w3-distributed.yml
@@ -1,0 +1,223 @@
+name: Run exhaustive distributed FTRL W3
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w3_distributed_run_stamp.json'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ftrl-w3-distributed-exhaustive
+  cancel-in-progress: false
+
+jobs:
+  shard:
+    name: shard-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51]
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Validate private preservation canon
+        run: python scripts/validate_private_corpus_storage_contract.py
+
+      - name: Execute deterministic W3 shard
+        run: |
+          python scripts/run_ftrl_w3_distributed_shard.py \
+            --shard-index '${{ matrix.shard }}' \
+            --shard-count 52 \
+            --output-dir local/ftrl-w3-distributed
+
+      - name: Assert public shard evidence contains no restricted text
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          idx = int(os.environ['SHARD'])
+          p = Path(f'local/ftrl-w3-distributed/shard_{idx:02d}_of_52/w3_shard_{idx:02d}_of_52_evidence.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W3_DISTRIBUTED_SHARD_0.1'
+          assert data['status'] == 'validated'
+          assert data['page_records'] in (399, 400)
+          forbidden = {'ocr_text_raw', 'search_text', 'snippet', 'text'}
+          def walk(x):
+              if isinstance(x, dict):
+                  assert not (forbidden & set(x)), forbidden & set(x)
+                  for v in x.values(): walk(v)
+              elif isinstance(x, list):
+                  for v in x: walk(v)
+          walk(data)
+          PY
+
+      - name: Build and encrypt restricted shard archive
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          IDX=$(printf '%02d' "$SHARD")
+          DIR="local/ftrl-w3-distributed/shard_${IDX}_of_52"
+          HANDOFF="local/private-handoff-w3-shard-${IDX}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz" \
+            "w3_shard_${IDX}_of_52_page_ocr.jsonl" \
+            "w3_shard_${IDX}_of_52_ocr_search.sqlite" \
+            "w3_shard_${IDX}_of_52_qc_queue.json" \
+            "w3_shard_${IDX}_of_52_asset_manifest.csv" \
+            "w3_shard_${IDX}_of_52_run_manifest.json" \
+            "w3_shard_${IDX}_of_52_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w3-shard-${IDX}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz" \
+            -out "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w3-shard-${IDX}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w3-shard-${IDX}.pass" \
+            -out "$HANDOFF/w3_shard_${IDX}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz.enc" "$HANDOFF/w3_shard_${IDX}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz" "/tmp/w3-shard-${IDX}.pass"
+
+      - name: Write text-free encrypted handoff manifest
+        env:
+          SHARD: ${{ matrix.shard }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          idx = int(os.environ['SHARD']); tag = f'{idx:02d}'
+          handoff = Path(f'local/private-handoff-w3-shard-{tag}')
+          evidence = Path(f'local/ftrl-w3-distributed/shard_{tag}_of_52/w3_shard_{tag}_of_52_evidence.json')
+          e = json.loads(evidence.read_text(encoding='utf-8'))
+          def desc(name):
+              p = handoff / name; h = hashlib.sha256(p.read_bytes()).hexdigest()
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h}
+          payload = f'w3_shard_{tag}_restricted.tar.gz.enc'
+          key = f'w3_shard_{tag}_passphrase.rsa-oaep.enc'
+          m = {
+              'schema': 'LTMD_PRIVATE_FTRL_W3_SHARD_HANDOFF_0.1', 'wave': 'W3',
+              'shard_index': idx, 'shard_count': 52, 'page_records': e['page_records'],
+              'source_commit': os.environ['GH_SHA'], 'workflow_run_id': os.environ['GH_RUN_ID'],
+              'encryption': {'payload': 'AES-256-CBC + PBKDF2-SHA256, 250000 iterations', 'key_wrap': 'RSA-4096 OAEP SHA-256', 'public_key_sha256': '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'},
+              'files': [desc(payload), desc(key), desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded': False,
+              'destination_policy': 'private Google Drive; Actions artifact is temporary encrypted handoff only',
+              'archival_complete': False,
+          }
+          (handoff / f'w3_shard_{tag}_private_handoff_manifest.json').write_text(json.dumps(m, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+      - name: Prove no plaintext restricted archive is uploaded
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          IDX=$(printf '%02d' "$SHARD")
+          HANDOFF="local/private-handoff-w3-shard-${IDX}"
+          test ! -f "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz"
+          test -f "$HANDOFF/w3_shard_${IDX}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w3_shard_${IDX}_passphrase.rsa-oaep.enc"
+          grep -q 'BEGIN PUBLIC KEY' security/ltmd_archive_public.pem
+
+      - name: Upload encrypted shard handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w3-shard-${{ matrix.shard }}-private-encrypted
+          path: local/private-handoff-w3-shard-*/
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Upload text-free shard evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w3-shard-${{ matrix.shard }}-text-free-evidence
+          path: |
+            local/ftrl-w3-distributed/shard_*/w3_shard_*_evidence.json
+            local/ftrl-w3-distributed/shard_*/w3_shard_*_run_manifest.json
+            local/ftrl-w3-distributed/shard_*/w3_shard_*_qc_summary.json
+            local/ftrl-w3-distributed/shard_*/w3_shard_*_asset_manifest.csv
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: validate-global-distributed-union
+    needs: shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Download all text-free shard evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ltmd-u1-w3-shard-*-text-free-evidence
+          path: local/w3-distributed-evidence
+          merge-multiple: false
+      - name: Rebuild canonical expected W3 inputs
+        run: |
+          mkdir -p local/w3-distributed-expected
+          python scripts/build_ftrl_w3_inputs.py \
+            --asset-output local/w3-distributed-expected/asset_manifest.csv \
+            --processing-output local/w3-distributed-expected/processing_inventory.csv
+      - name: Validate exact exhaustive union of 52 shards
+        run: |
+          python scripts/validate_ftrl_w3_distributed.py \
+            --evidence-root local/w3-distributed-evidence \
+            --asset-manifest local/w3-distributed-expected/asset_manifest.csv \
+            --processing-inventory local/w3-distributed-expected/processing_inventory.csv \
+            --shard-count 52 \
+            --output local/ltmd_u1_w3_distributed_global_evidence.json
+      - name: Upload global text-free distributed evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w3-distributed-global-text-free-evidence
+          path: local/ltmd_u1_w3_distributed_global_evidence.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Report distributed W3 computational validation
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W3 distribuido — validación computacional exhaustiva COMPLETA en run ${GITHUB_RUN_ID}: 52 shards, 130 identidades, 114 objetos canónicos y 20,765/20,765 páginas, unión única y exacta; SQLite/FTS5 y QC validados por shard. Los productos restringidos sólo existen en handoffs cifrados. Estado archivístico permanece archival_complete=no hasta consolidar/verificar una sola copia canónica en Google Drive privado. text_verified y semantic_ready permanecen en falso."
+
+  report-failure:
+    name: report-distributed-failure
+    if: failure()
+    needs: [shard, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report W3 distributed failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W3 distribuido — corrida ${GITHUB_RUN_ID} NO completó todos sus gates. No se promueve W3 ni se declara archival_complete. Los shards exitosos cifrados pueden conservarse temporalmente como evidencia diagnóstica, pero no sustituyen la unión exhaustiva 20,765/20,765."

--- a/.github/workflows/validate-ftrl-w3-distributed-config.yml
+++ b/.github/workflows/validate-ftrl-w3-distributed-config.yml
@@ -1,0 +1,101 @@
+name: Validate distributed FTRL W3 configuration
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/run_ftrl_w3_distributed_shard.py'
+      - 'scripts/validate_ftrl_w3_distributed.py'
+      - 'scripts/consolidate_ftrl_w3_distributed.py'
+      - 'data/research/ltmd_u1_w3_distributed_topology.json'
+      - '.github/workflows/run-ftrl-w3-distributed.yml'
+      - '.github/workflows/validate-ftrl-w3-distributed-config.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/run_ftrl_w3_distributed_shard.py'
+      - 'scripts/validate_ftrl_w3_distributed.py'
+      - 'scripts/consolidate_ftrl_w3_distributed.py'
+      - 'data/research/ltmd_u1_w3_distributed_topology.json'
+      - '.github/workflows/run-ftrl-w3-distributed.yml'
+      - '.github/workflows/validate-ftrl-w3-distributed-config.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-distributed-config:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile distributed code
+        run: |
+          python -m py_compile \
+            scripts/run_ftrl_w3_distributed_shard.py \
+            scripts/validate_ftrl_w3_distributed.py \
+            scripts/consolidate_ftrl_w3_distributed.py
+      - name: Rebuild W3 canonical inputs without OCR
+        run: |
+          mkdir -p local/w3-config
+          python scripts/preflight_ftrl_w3.py --output local/w3-config/preflight.json
+          python scripts/build_ftrl_w3_inputs.py \
+            --asset-output local/w3-config/asset_manifest.csv \
+            --processing-output local/w3-config/processing_inventory.csv
+      - name: Assert frozen 52-shard topology
+        run: |
+          python - <<'PY'
+          import csv, json
+          from collections import Counter
+          from pathlib import Path
+          topology = json.loads(Path('data/research/ltmd_u1_w3_distributed_topology.json').read_text(encoding='utf-8'))
+          assert topology['schema'] == 'LTMD_FTRL_W3_DISTRIBUTED_TOPOLOGY_0.1'
+          assert topology['historical_identities'] == 130
+          assert topology['canonical_processing_objects'] == 114
+          assert topology['canonical_source_pages'] == 20765
+          assert topology['pilot']['workflow_run_id'] == '32852599812'
+          assert topology['pilot']['pages'] == 100
+          assert topology['pilot']['execution_step_seconds'] == 81
+          assert topology['pilot']['sqlite_integrity'] == 'ok'
+          assert topology['topology']['shard_count'] == 52
+          assert topology['topology']['max_parallel'] == 8
+          assert topology['topology']['shards_400_pages'] == 17
+          assert topology['topology']['shards_399_pages'] == 35
+          assert topology['full_execution_activated'] is False
+          with Path('local/w3-config/asset_manifest.csv').open(encoding='utf-8', newline='') as fh:
+              rows = list(csv.DictReader(fh))
+          rows.sort(key=lambda r: (int(r['catalog_generation']), int(r['grade_code']), r['viewer_key'], int(r['source_image_index'])))
+          assert len(rows) == 20765
+          base, rem = divmod(len(rows), 52)
+          sizes = [base + (1 if i < rem else 0) for i in range(52)]
+          assert Counter(sizes) == Counter({400: 17, 399: 35})
+          assert sum(sizes) == 20765
+          print('W3 topology validated: 17x400 + 35x399 = 20,765')
+          PY
+      - name: Assert workflow safety and no launch stamp
+        run: |
+          test ! -f data/research/ltmd_u1_w3_distributed_run_stamp.json
+          test ! -f security/ltmd_archive_private.pem
+          python - <<'PY'
+          from pathlib import Path
+          wf = Path('.github/workflows/run-ftrl-w3-distributed.yml').read_text(encoding='utf-8')
+          assert 'workflow_dispatch:' in wf
+          assert "data/research/ltmd_u1_w3_distributed_run_stamp.json" in wf
+          assert 'max-parallel: 8' in wf
+          assert '--shard-count 52' in wf
+          assert 'retention-days: 3' in wf
+          assert 'openssl enc -aes-256-cbc' in wf
+          assert 'RSA-4096 OAEP SHA-256' in wf
+          assert 'Upload encrypted shard handoff only' in wf
+          assert 'Upload text-free shard evidence' in wf
+          assert 'Validate exact exhaustive union of 52 shards' in wf
+          assert '--shard-count 52' in wf
+          assert '20,765/20,765' in wf
+          assert 'private Google Drive' in wf
+          print('W3 distributed workflow safety validated; no productive launch stamp present')
+          PY

--- a/data/research/ltmd_u1_w3_distributed_topology.json
+++ b/data/research/ltmd_u1_w3_distributed_topology.json
@@ -1,0 +1,68 @@
+{
+  "schema": "LTMD_FTRL_W3_DISTRIBUTED_TOPOLOGY_0.1",
+  "effective_date": "2026-08-25",
+  "wave": "W3",
+  "operational_domain": "espanol_lengua",
+  "historical_identities": 130,
+  "canonical_processing_objects": 114,
+  "canonical_source_pages": 20765,
+  "pilot": {
+    "workflow_run_id": "32852599812",
+    "source_commit": "0e972fddce8e4efe4f194447c6e2dd33e81c95e7",
+    "pages": 100,
+    "execution_step_seconds": 81,
+    "observed_seconds_per_page": 0.81,
+    "sqlite_integrity": "ok",
+    "page_rows": 100,
+    "fts_rows": 100,
+    "qc_page_records": 100,
+    "mean_ocr_confidence": 81.6888244,
+    "median_ocr_confidence": 90.023849,
+    "pages_flagged_for_qc": 29,
+    "zero_search_text_pages": 5,
+    "interpretation": "runtime and technical quality anchor only; not text verification or semantic validation"
+  },
+  "cross_wave_runtime_anchor": {
+    "wave": "W1",
+    "distributed_run_id": "32807213503",
+    "pages_per_shard": "407-408",
+    "observed_ocr_execution_seconds_per_page_examples": "approximately 0.94-1.02",
+    "interpretation": "second empirical anchor supporting an approximately 400-page shard target"
+  },
+  "topology": {
+    "algorithm": "stable sort (catalog_generation, grade_code, viewer_key, source_image_index) + balanced contiguous partition",
+    "shard_count": 52,
+    "max_parallel": 8,
+    "shards_400_pages": 17,
+    "shards_399_pages": 35,
+    "expected_total_pages": 20765,
+    "per_job_timeout_minutes": 330,
+    "reason": "Preserve the approximately 400-page shard size already validated operationally in W1 while applying the observed W3 pilot runtime. The topology favors fault isolation and reproducible restartability over minimizing artifact count."
+  },
+  "required_gates": {
+    "w1_computationally_validated": true,
+    "w1_archival_complete": true,
+    "all_52_shards_validated": true,
+    "global_union_exact_20765_of_20765": true,
+    "global_union_unique": true,
+    "same_source_commit_and_workflow_run": true,
+    "all_shard_sqlite_integrity_ok": true,
+    "all_shard_fts_cardinality_ok": true,
+    "all_shard_qc_cardinality_ok": true,
+    "restricted_outputs_plaintext_public_upload": false
+  },
+  "preservation": {
+    "private_handoffs_encrypted_before_upload": true,
+    "actions_artifacts_temporary": true,
+    "drive_final_policy": "consolidate privately into one canonical W3 corpus package, verify checksums/privacy, then remove redundant temporary handoffs",
+    "archival_complete_before_promotion": true
+  },
+  "epistemic_guards": [
+    "distributed_computationally_validated != archival_complete",
+    "ocr_available != text_verified",
+    "corpus_ready != semantic_ready",
+    "search_hit != historical_claim",
+    "zero_hits != demonstrated_absence"
+  ],
+  "full_execution_activated": false
+}

--- a/docs/FTRL_W3_DISTRIBUTED_EXECUTION_0_1.md
+++ b/docs/FTRL_W3_DISTRIBUTED_EXECUTION_0_1.md
@@ -1,0 +1,48 @@
+# FTRL W3 — ejecución distribuida 0.1
+
+## Alcance
+
+Este protocolo fija la arquitectura exhaustiva de `W3 Español/Lengua` después del cierre canónico de W1 y de la medición controlada de runtime de W3. No implica validación textual ni semántica.
+
+Denominador operativo: **130 identidades históricas, 114 objetos canónicos y 20,765 páginas fuente**.
+
+## Evidencia para congelar la topología
+
+El piloto canónico `32852599812`, sobre el commit `0e972fddce8e4efe4f194447c6e2dd33e81c95e7`, procesó 100/100 páginas y validó SQLite/FTS5/QC. La fase de ejecución duró 81 segundos. El manifiesto registró 100 `page_rows`, 100 `fts_rows`, `sqlite_integrity=ok`, confianza OCR media 81.6888244 y mediana 90.023849; 29 páginas quedaron señaladas para QC. Estos indicadores son técnicos: `ocr_available != text_verified`.
+
+W1 aporta una segunda referencia empírica: sus shards de 407–408 páginas completaron OCR/SQLite/FTS5/QC de forma estable, con ejemplos observados alrededor de 0.94–1.02 segundos por página en la etapa de ejecución.
+
+## Topología congelada
+
+W3 se particiona de forma determinista mediante orden estable `(catalog_generation, grade_code, viewer_key, source_image_index)` y partición contigua balanceada en **52 shards**:
+
+- 17 shards × 400 páginas;
+- 35 shards × 399 páginas;
+- total exacto: 20,765 páginas;
+- máximo 8 shards concurrentes.
+
+La elección conserva aproximadamente el tamaño por shard ya validado en W1. Se privilegia aislamiento de fallas, reiniciabilidad y trazabilidad frente a reducir el número de jobs.
+
+## Gates de ejecución
+
+Cada shard debe reconstruir los inputs canónicos, verificar el gate W1, ejecutar OCR, crear SQLite/FTS5, validar integridad y cardinalidad, construir QC y producir evidencia sin texto restringido. Los 52 shards deben compartir un mismo commit y workflow run.
+
+El gate global sólo pasa si la unión de hashes de identidad de página es **exactamente 20,765/20,765, única y sin extras**, contra el manifiesto canónico W3.
+
+## Preservación
+
+Los productos restringidos de cada shard se comprimen y cifran antes de cualquier upload de Actions. La clave simétrica se envuelve con la clave pública archivística del proyecto. Actions funciona únicamente como handoff temporal.
+
+Después de la validación computacional global, los handoffs se recuperan en entorno privado, se descifran y se consolidan mediante `scripts/consolidate_ftrl_w3_distributed.py`. Conforme al canon 0.2, Drive debe terminar con **una sola copia canónica consolidada de W3**, verificada por checksums y privacidad; los handoffs redundantes pueden eliminarse después del cierre.
+
+## Estados epistemológicos
+
+Incluso tras una ejecución exhaustiva exitosa:
+
+- `distributed_computationally_validated != archival_complete`;
+- `ocr_available != text_verified`;
+- `corpus_ready != semantic_ready`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`.
+
+La arquitectura productiva sólo se lanza mediante el stamp versionado `data/research/ltmd_u1_w3_distributed_run_stamp.json`, que se crea separadamente después de que esta configuración pase CI y sea fusionada a `main`.

--- a/scripts/consolidate_ftrl_w3_distributed.py
+++ b/scripts/consolidate_ftrl_w3_distributed.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Privately consolidate decrypted distributed W3 FTRL shards.
+
+Run only inside the private preservation environment after encrypted shard
+handoffs have been decrypted. Produced OCR JSONL/SQLite/QC are restricted.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 20765
+EXPECTED_HISTORICAL = 130
+EXPECTED_CANONICAL = 114
+EXPECTED_SHARDS = 52
+SCHEMA = "LTMD_FTRL_W3_PRIVATE_CONSOLIDATION_0.1"
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def descriptor(path: Path) -> dict:
+    return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def expected_hashes(asset_manifest: Path, processing_inventory: Path) -> set[str]:
+    proc = list(csv.DictReader(processing_inventory.open(encoding="utf-8", newline="")))
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(proc) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL:
+        raise SystemExit("W3 processing denominator drift")
+    rows = list(csv.DictReader(asset_manifest.open(encoding="utf-8", newline="")))
+    selected = [r for r in rows if r["asset_status"] == "source_jpeg" and r["viewer_key"] in canonical]
+    if len(selected) != EXPECTED_PAGES:
+        raise SystemExit(f"W3 canonical source page drift: {len(selected)}")
+    hashes = {page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in selected}
+    if len(hashes) != EXPECTED_PAGES:
+        raise SystemExit("W3 canonical page identities are not unique")
+    return hashes
+
+
+def load_records(root: Path, shard_count: int) -> list[dict]:
+    paths = sorted(root.rglob("w3_shard_*_page_ocr.jsonl"))
+    if len(paths) != shard_count:
+        raise SystemExit(f"expected {shard_count} decrypted W3 JSONL shards, found {len(paths)}")
+    records, page_ids, page_keys = [], set(), set()
+    for path in paths:
+        with path.open(encoding="utf-8") as fh:
+            for line_number, line in enumerate(fh, 1):
+                if not line.strip():
+                    continue
+                row = json.loads(line)
+                if row.get("wave") != "W3":
+                    raise SystemExit(f"non-W3 record in {path}:{line_number}")
+                page_id = str(row["page_id"])
+                key = (str(row["viewer_key"]), int(row["page_index"]))
+                if page_id in page_ids or key in page_keys:
+                    raise SystemExit(f"duplicate W3 page across shards: {page_id}")
+                page_ids.add(page_id); page_keys.add(key); records.append(row)
+    if len(records) != EXPECTED_PAGES:
+        raise SystemExit(f"W3 decrypted distributed total drift: {len(records)}")
+    records.sort(key=lambda r: (int(r["catalog_generation"]), int(r["grade_code"]), str(r["viewer_key"]), int(r["page_index"])))
+    return records
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shard-root", type=Path, required=True)
+    ap.add_argument("--asset-manifest", type=Path, required=True)
+    ap.add_argument("--processing-inventory", type=Path, required=True)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    ap.add_argument("--distributed-run-id", required=True)
+    ap.add_argument("--distributed-source-commit", required=True)
+    ap.add_argument("--shard-count", type=int, default=EXPECTED_SHARDS)
+    args = ap.parse_args()
+
+    records = load_records(args.shard_root, args.shard_count)
+    observed = {page_key_hash(str(r["viewer_key"]), int(r["page_index"])) for r in records}
+    expected = expected_hashes(args.asset_manifest, args.processing_inventory)
+    if observed != expected:
+        raise SystemExit(f"W3 private union mismatch: missing={len(expected-observed)}, extra={len(observed-expected)}")
+
+    out = args.output_dir; out.mkdir(parents=True, exist_ok=True)
+    jsonl = out / "ltmd_u1_w3_full_page_ocr.jsonl"
+    db = out / "ltmd_u1_w3_full_ocr_search.sqlite"
+    qc_queue = out / "ltmd_u1_w3_full_qc_queue.json"
+    qc_summary = out / "ltmd_u1_w3_full_qc_summary.json"
+    run_manifest = out / "ltmd_u1_w3_full_run_manifest.json"
+    evidence = out / "ltmd_u1_w3_private_consolidation_evidence.json"
+    with jsonl.open("w", encoding="utf-8", newline="\n") as fh:
+        for row in records:
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(args.processing_inventory), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(args.asset_manifest), "--processing-inventory", str(args.processing_inventory), "--label", "full_distributed_consolidated", "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+
+    rm = json.loads(run_manifest.read_text(encoding="utf-8")); qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["corpus"]["page_records"] != EXPECTED_PAGES:
+        raise SystemExit("W3 private consolidated run failed")
+    if rm["database"]["page_rows"] != EXPECTED_PAGES or rm["database"]["fts_rows"] != EXPECTED_PAGES or rm["database"]["sqlite_integrity"] != "ok" or qc["page_records"] != EXPECTED_PAGES:
+        raise SystemExit("W3 private consolidated database/QC failure")
+    if rm["database"]["historical_identities"] != EXPECTED_HISTORICAL:
+        raise SystemExit(f"W3 historical identity drift: {rm['database']['historical_identities']}")
+
+    payload = {
+        "schema": SCHEMA, "status": "private_consolidation_validated", "wave": "W3", "domain": "Español/Lengua",
+        "distributed_run_id": str(args.distributed_run_id), "distributed_source_commit": args.distributed_source_commit,
+        "shard_count": args.shard_count, "historical_identities": EXPECTED_HISTORICAL,
+        "canonical_processing_objects": EXPECTED_CANONICAL, "page_records": EXPECTED_PAGES,
+        "page_partition_complete": True, "page_partition_unique": True, "sqlite_integrity": "ok", "fts_rows": EXPECTED_PAGES,
+        "products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue), descriptor(qc_summary), descriptor(run_manifest)],
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(), "archival_complete": False,
+        "epistemic_guards": ["private_consolidation_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready"],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "page_records": EXPECTED_PAGES, "evidence": str(evidence)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w3_distributed_shard.py
+++ b/scripts/run_ftrl_w3_distributed_shard.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Run one deterministic LTMD-U1 W3 FTRL shard.
+
+Restricted OCR/SQLite/QC remain under local/ and must be encrypted by the
+workflow before any Actions upload. Public evidence is metadata/hash only.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 20765
+EXPECTED_HISTORICAL = 130
+EXPECTED_CANONICAL = 114
+DEFAULT_SHARDS = 52
+SCHEMA = "LTMD_FTRL_W3_DISTRIBUTED_SHARD_0.1"
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows:
+        raise SystemExit(f"refusing to write empty shard: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def sorted_source_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    return sorted(rows, key=lambda r: (
+        int(r["catalog_generation"]), int(r["grade_code"]),
+        r["viewer_key"], int(r["source_image_index"]),
+    ))
+
+
+def balanced_slice(rows: list[dict[str, str]], index: int, count: int) -> list[dict[str, str]]:
+    if count < 1 or not 0 <= index < count:
+        raise SystemExit("invalid shard index/count")
+    base, remainder = divmod(len(rows), count)
+    start = index * base + min(index, remainder)
+    size = base + (1 if index < remainder else 0)
+    return rows[start:start + size]
+
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None:
+        raise SystemExit("Tesseract is required")
+    langs = subprocess.run(["tesseract", "--list-langs"], check=True, capture_output=True, text=True).stdout.splitlines()
+    if "spa" not in {x.strip() for x in langs}:
+        raise SystemExit("Spanish Tesseract language data is required")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    finally:
+        conn.close()
+
+
+def descriptor(path: Path) -> dict:
+    return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+
+def jsonl_hashes(path: Path) -> tuple[list[str], int]:
+    hashes, count = [], 0
+    with path.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if row.get("wave") != "W3":
+                raise SystemExit(f"non-W3 record at {path}:{line_number}")
+            hashes.append(page_key_hash(str(row["viewer_key"]), int(row["page_index"])))
+            count += 1
+    return sorted(hashes), count
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--shard-index", type=int, required=True)
+    ap.add_argument("--shard-count", type=int, default=DEFAULT_SHARDS)
+    ap.add_argument("--output-dir", type=Path, default=Path("local/ftrl-w3-distributed"))
+    args = ap.parse_args()
+
+    run([sys.executable, "scripts/guard_ftrl_w3_activation.py", "--json"])
+    require_environment()
+    root = args.output_dir
+    root.mkdir(parents=True, exist_ok=True)
+    shard_name = f"shard_{args.shard_index:02d}_of_{args.shard_count:02d}"
+    shard_dir = root / shard_name
+    shard_dir.mkdir(parents=True, exist_ok=True)
+
+    preflight = root / "ltmd_u1_w3_preflight.json"
+    full_asset = root / "ltmd_u1_w3_asset_manifest.csv"
+    processing = root / "ltmd_u1_w3_processing_inventory.csv"
+    run([sys.executable, "scripts/preflight_ftrl_w3.py", "--output", str(preflight)])
+    run([sys.executable, "scripts/build_ftrl_w3_inputs.py", "--asset-output", str(full_asset), "--processing-output", str(processing)])
+
+    proc = read_csv(processing)
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(proc) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL:
+        raise SystemExit("W3 processing denominator drift")
+
+    rows = sorted_source_rows(read_csv(full_asset))
+    if len(rows) != EXPECTED_PAGES:
+        raise SystemExit(f"W3 source cardinality drift: {len(rows)} != {EXPECTED_PAGES}")
+    shard_rows = balanced_slice(rows, args.shard_index, args.shard_count)
+    expected_hashes = sorted(page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in shard_rows)
+    if len(expected_hashes) != len(set(expected_hashes)):
+        raise SystemExit("duplicate expected page key inside shard")
+
+    prefix = f"w3_{shard_name}"
+    shard_asset = shard_dir / f"{prefix}_asset_manifest.csv"
+    jsonl = shard_dir / f"{prefix}_page_ocr.jsonl"
+    db = shard_dir / f"{prefix}_ocr_search.sqlite"
+    run_manifest = shard_dir / f"{prefix}_run_manifest.json"
+    qc_queue = shard_dir / f"{prefix}_qc_queue.json"
+    qc_summary = shard_dir / f"{prefix}_qc_summary.json"
+    evidence = shard_dir / f"{prefix}_evidence.json"
+    write_csv(shard_asset, shard_rows)
+
+    run([sys.executable, "scripts/build_page_ocr_corpus.py", "--asset-manifest", str(shard_asset), "--processing-inventory", str(processing), "--wave", "W3", "--output", str(jsonl), "--cache-dir", str(shard_dir / "assets"), "--resume"])
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(processing), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(shard_asset), "--processing-inventory", str(processing), "--label", shard_name, "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+
+    actual_hashes, actual_count = jsonl_hashes(jsonl)
+    if actual_count != len(shard_rows) or actual_hashes != expected_hashes:
+        raise SystemExit("W3 shard page inventory mismatch")
+    rm = json.loads(run_manifest.read_text(encoding="utf-8"))
+    qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["database"]["sqlite_integrity"] != "ok":
+        raise SystemExit("W3 shard validation failed")
+    pages = len(shard_rows)
+    if rm["corpus"]["page_records"] != pages or rm["database"]["page_rows"] != pages or rm["database"]["fts_rows"] != pages or qc["page_records"] != pages:
+        raise SystemExit("W3 shard cardinality drift")
+
+    payload = {
+        "schema": SCHEMA, "status": "validated", "wave": "W3", "domain": "Español/Lengua",
+        "shard_index": args.shard_index, "shard_count": args.shard_count, "page_records": pages,
+        "page_key_hashes": expected_hashes,
+        "canonical_viewers_in_shard": len({r["viewer_key"] for r in shard_rows}),
+        "source_partition": {"full_source_pages": EXPECTED_PAGES, "algorithm": "stable sort (catalog_generation, grade_code, viewer_key, source_image_index) + balanced contiguous partition"},
+        "validation": {"sqlite_integrity": "ok", "sqlite_pages": rm["database"]["page_rows"], "fts_rows": rm["database"]["fts_rows"], "qc_page_records": qc["page_records"]},
+        "restricted_products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue)],
+        "text_free_products": [descriptor(shard_asset), descriptor(run_manifest), descriptor(qc_summary)],
+        "execution": rm.get("execution"),
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": ["distributed_computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim"],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "shard": args.shard_index, "pages": pages, "evidence": str(evidence)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_ftrl_w3_distributed.py
+++ b/scripts/validate_ftrl_w3_distributed.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate exhaustive, unique, text-free evidence for distributed W3 FTRL."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 20765
+EXPECTED_HISTORICAL = 130
+EXPECTED_CANONICAL = 114
+DEFAULT_SHARDS = 52
+SCHEMA = "LTMD_FTRL_W3_DISTRIBUTED_GLOBAL_0.1"
+SHARD_SCHEMA = "LTMD_FTRL_W3_DISTRIBUTED_SHARD_0.1"
+FORBIDDEN_KEYS = {"ocr_text_raw", "search_text", "snippet", "text"}
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def walk_no_text(value) -> None:
+    if isinstance(value, dict):
+        hits = FORBIDDEN_KEYS & set(value)
+        if hits:
+            raise AssertionError(f"forbidden restricted-text key(s): {sorted(hits)}")
+        for child in value.values():
+            walk_no_text(child)
+    elif isinstance(value, list):
+        for child in value:
+            walk_no_text(child)
+
+
+def expected_hashes(asset_manifest: Path, processing_inventory: Path) -> set[str]:
+    processing = list(csv.DictReader(processing_inventory.open(encoding="utf-8", newline="")))
+    canonical = {r["viewer_key"] for r in processing if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(processing) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL:
+        raise AssertionError("W3 processing denominator drift")
+    rows = list(csv.DictReader(asset_manifest.open(encoding="utf-8", newline="")))
+    selected = [r for r in rows if r["asset_status"] == "source_jpeg" and r["viewer_key"] in canonical]
+    if len(selected) != EXPECTED_PAGES:
+        raise AssertionError(f"W3 source page drift: {len(selected)}")
+    hashes = {page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in selected}
+    if len(hashes) != EXPECTED_PAGES:
+        raise AssertionError("expected W3 page identities are not unique")
+    return hashes
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--evidence-root", type=Path, required=True)
+    ap.add_argument("--asset-manifest", type=Path, required=True)
+    ap.add_argument("--processing-inventory", type=Path, required=True)
+    ap.add_argument("--shard-count", type=int, default=DEFAULT_SHARDS)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    paths = sorted(args.evidence_root.rglob("w3_shard_*_evidence.json"))
+    if len(paths) != args.shard_count:
+        raise AssertionError(f"expected {args.shard_count} shard evidence files, found {len(paths)}")
+
+    shard_rows, all_hashes = [], []
+    commits, runs = set(), set()
+    for path in paths:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        walk_no_text(data)
+        if data["schema"] != SHARD_SCHEMA or data["status"] != "validated" or data["wave"] != "W3" or data["shard_count"] != args.shard_count:
+            raise AssertionError(f"invalid shard evidence: {path}")
+        pages = int(data["page_records"])
+        v = data["validation"]
+        if v["sqlite_integrity"] != "ok" or v["sqlite_pages"] != pages or v["fts_rows"] != pages or v["qc_page_records"] != pages:
+            raise AssertionError(f"W3 shard validation/cardinality drift: {path}")
+        hashes = list(data["page_key_hashes"])
+        if len(hashes) != pages or len(set(hashes)) != pages:
+            raise AssertionError(f"W3 shard page-key drift: {path}")
+        all_hashes.extend(hashes)
+        execution = data.get("execution") or {}
+        vcs, ci = execution.get("vcs") or {}, execution.get("ci") or {}
+        if vcs.get("dirty_tracked_worktree") is not False:
+            raise AssertionError(f"dirty tracked worktree: {path}")
+        if vcs.get("commit"):
+            commits.add(vcs["commit"])
+        if ci.get("run_id"):
+            runs.add(str(ci["run_id"]))
+        shard_rows.append(data)
+
+    indices = sorted(int(x["shard_index"]) for x in shard_rows)
+    if indices != list(range(args.shard_count)):
+        raise AssertionError(f"incomplete W3 shard index set: {indices}")
+    if len(commits) != 1 or len(runs) != 1:
+        raise AssertionError(f"W3 shards do not share one commit/run: commits={sorted(commits)}, runs={sorted(runs)}")
+
+    counts = Counter(int(x["page_records"]) for x in shard_rows)
+    if sum(k * v for k, v in counts.items()) != EXPECTED_PAGES:
+        raise AssertionError(f"W3 distributed page total drift: {counts}")
+    if len(all_hashes) != EXPECTED_PAGES or len(set(all_hashes)) != EXPECTED_PAGES:
+        raise AssertionError("W3 distributed union has duplicate or missing page hashes")
+    expected = expected_hashes(args.asset_manifest, args.processing_inventory)
+    observed = set(all_hashes)
+    if observed != expected:
+        raise AssertionError(f"W3 union differs from canonical manifest: missing={len(expected-observed)}, extra={len(observed-expected)}")
+
+    output = {
+        "schema": SCHEMA, "status": "distributed_computationally_validated", "wave": "W3", "domain": "Español/Lengua",
+        "historical_identities": EXPECTED_HISTORICAL, "canonical_processing_objects": EXPECTED_CANONICAL,
+        "page_records": EXPECTED_PAGES, "shard_count": args.shard_count,
+        "shard_page_count_distribution": {str(k): v for k, v in sorted(counts.items())},
+        "source_commit": next(iter(commits)), "workflow_run_id": next(iter(runs)),
+        "page_partition_complete": True, "page_partition_unique": True,
+        "all_shard_sqlite_integrity_ok": True, "all_shard_fts_cardinality_ok": True, "all_shard_qc_cardinality_ok": True,
+        "restricted_outputs_publicly_uploaded_plaintext": False, "archival_complete": False,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": ["distributed_computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim"],
+    }
+    walk_no_text(output)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(output, ensure_ascii=False, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Congela la arquitectura exhaustiva de W3 a partir de dos anclas empíricas: piloto W3 de 100 páginas (`32852599812`, 81 s en la fase de ejecución, SQLite/FTS5 100/100) y shards W1 de ~400 páginas ya validados.

Topología propuesta y preregistrada:
- 20,765 páginas canónicas;
- 52 shards deterministas por orden estable `(generation, grade, viewer_key, source_image_index)`;
- 17×400 + 35×399;
- máximo 8 concurrentes;
- OCR/SQLite/FTS5/QC por shard;
- cifrado de restringidos antes de upload;
- evidencia pública text-free;
- gate global exacto y único 20,765/20,765;
- consolidación posterior únicamente en entorno privado;
- Drive termina con una sola copia canónica W3 conforme al canon 0.2.

Este PR **no lanza** la corrida exhaustiva: el stamp productivo no existe y CI lo verifica. La activación se hará separadamente sólo después de validar y fusionar esta arquitectura.