### PR TITLE
FTRL W6: activate exhaustive distributed Geografía/Atlas run

### DIFF
--- a/.github/workflows/run-ftrl-w6-distributed.yml
+++ b/.github/workflows/run-ftrl-w6-distributed.yml
@@ -1,0 +1,229 @@
+name: Run exhaustive distributed FTRL W6
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w6_distributed_run_stamp.json'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ftrl-w6-distributed-exhaustive
+  cancel-in-progress: false
+
+jobs:
+  shard:
+    name: shard-${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+
+      - name: Validate private preservation canon
+        run: python scripts/validate_private_corpus_storage_contract.py
+
+      - name: Execute deterministic W6 shard
+        run: |
+          python scripts/run_ftrl_w6_distributed_shard.py \
+            --shard-index '${{ matrix.shard }}' \
+            --shard-count 16 \
+            --output-dir local/ftrl-w6-distributed
+
+      - name: Assert public shard evidence contains no restricted text
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          idx = int(os.environ['SHARD'])
+          p = Path(f'local/ftrl-w6-distributed/shard_{idx:02d}_of_16/w6_shard_{idx:02d}_of_16_evidence.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W6_DISTRIBUTED_SHARD_0.1'
+          assert data['status'] == 'validated'
+          assert data['page_records'] in (328, 329)
+          forbidden = {'ocr_text_raw', 'search_text', 'snippet', 'text'}
+          def walk(x):
+              if isinstance(x, dict):
+                  assert not (forbidden & set(x)), forbidden & set(x)
+                  for v in x.values(): walk(v)
+              elif isinstance(x, list):
+                  for v in x: walk(v)
+          walk(data)
+          PY
+
+      - name: Build and encrypt restricted shard archive
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -euo pipefail
+          IDX=$(printf '%02d' "$SHARD")
+          DIR="local/ftrl-w6-distributed/shard_${IDX}_of_16"
+          HANDOFF="local/private-handoff-w6-shard-${IDX}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz" \
+            "w6_shard_${IDX}_of_16_page_ocr.jsonl" \
+            "w6_shard_${IDX}_of_16_ocr_search.sqlite" \
+            "w6_shard_${IDX}_of_16_qc_queue.json" \
+            "w6_shard_${IDX}_of_16_asset_manifest.csv" \
+            "w6_shard_${IDX}_of_16_run_manifest.json" \
+            "w6_shard_${IDX}_of_16_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w6-shard-${IDX}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz" \
+            -out "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w6-shard-${IDX}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w6-shard-${IDX}.pass" \
+            -out "$HANDOFF/w6_shard_${IDX}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz.enc" "$HANDOFF/w6_shard_${IDX}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz" "/tmp/w6-shard-${IDX}.pass"
+
+      - name: Write text-free encrypted handoff manifest
+        env:
+          SHARD: ${{ matrix.shard }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          idx = int(os.environ['SHARD']); tag = f'{idx:02d}'
+          handoff = Path(f'local/private-handoff-w6-shard-{tag}')
+          evidence = Path(f'local/ftrl-w6-distributed/shard_{tag}_of_16/w6_shard_{tag}_of_16_evidence.json')
+          e = json.loads(evidence.read_text(encoding='utf-8'))
+          def desc(name):
+              p = handoff / name; h = hashlib.sha256(p.read_bytes()).hexdigest()
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h}
+          payload = f'w6_shard_{tag}_restricted.tar.gz.enc'
+          key = f'w6_shard_{tag}_passphrase.rsa-oaep.enc'
+          m = {
+              'schema': 'LTMD_PRIVATE_FTRL_W6_SHARD_HANDOFF_0.1', 'wave': 'W6',
+              'shard_index': idx, 'shard_count': 16, 'page_records': e['page_records'],
+              'source_commit': os.environ['GH_SHA'], 'workflow_run_id': os.environ['GH_RUN_ID'],
+              'encryption': {'payload': 'AES-256-CBC + PBKDF2-SHA256, 250000 iterations', 'key_wrap': 'RSA-4096 OAEP SHA-256', 'public_key_sha256': '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'},
+              'files': [desc(payload), desc(key), desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded': False,
+              'destination_policy': 'private Google Drive; Actions artifact is temporary encrypted handoff only',
+              'archival_complete': False,
+          }
+          (handoff / f'w6_shard_{tag}_private_handoff_manifest.json').write_text(json.dumps(m, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          PY
+
+      - name: Prove no plaintext restricted archive is uploaded
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          IDX=$(printf '%02d' "$SHARD")
+          HANDOFF="local/private-handoff-w6-shard-${IDX}"
+          test ! -f "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz"
+          test -f "$HANDOFF/w6_shard_${IDX}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w6_shard_${IDX}_passphrase.rsa-oaep.enc"
+          grep -q 'BEGIN PUBLIC KEY' security/ltmd_archive_public.pem
+
+      - name: Upload encrypted shard handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w6-shard-${{ matrix.shard }}-private-encrypted
+          path: local/private-handoff-w6-shard-*/
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Upload text-free shard evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w6-shard-${{ matrix.shard }}-text-free-evidence
+          path: |
+            local/ftrl-w6-distributed/shard_*/w6_shard_*_evidence.json
+            local/ftrl-w6-distributed/shard_*/w6_shard_*_run_manifest.json
+            local/ftrl-w6-distributed/shard_*/w6_shard_*_qc_summary.json
+            local/ftrl-w6-distributed/shard_*/w6_shard_*_asset_manifest.csv
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: validate-global-distributed-union
+    needs: shard
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout exact revision
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download all text-free shard evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ltmd-u1-w6-shard-*-text-free-evidence
+          path: local/w6-distributed-evidence
+          merge-multiple: false
+
+      - name: Rebuild canonical expected W6 inputs
+        run: |
+          mkdir -p local/w6-distributed-expected
+          python scripts/build_ftrl_w6_inputs.py \
+            --asset-output local/w6-distributed-expected/asset_manifest.csv \
+            --processing-output local/w6-distributed-expected/processing_inventory.csv
+
+      - name: Validate exact exhaustive union of 16 shards
+        run: |
+          python scripts/validate_ftrl_w6_distributed.py \
+            --evidence-root local/w6-distributed-evidence \
+            --asset-manifest local/w6-distributed-expected/asset_manifest.csv \
+            --processing-inventory local/w6-distributed-expected/processing_inventory.csv \
+            --shard-count 16 \
+            --output local/ltmd_u1_w6_distributed_global_evidence.json
+
+      - name: Upload global text-free distributed evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w6-distributed-global-text-free-evidence
+          path: local/ltmd_u1_w6_distributed_global_evidence.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Report distributed W6 computational validation
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W6 Geografía/Atlas distribuido — validación computacional exhaustiva COMPLETA en run ${GITHUB_RUN_ID}: 16 shards, 42 identidades históricas, 37 objetos canónicos y 5,258/5,258 páginas, unión única y exacta; SQLite/FTS5 y QC validados por shard. Los productos restringidos sólo existen en handoffs cifrados. Estado archivístico permanece archival_complete=no hasta consolidar/verificar una sola copia canónica en Google Drive privado. text_verified y semantic_ready permanecen en falso."
+
+  report-failure:
+    name: report-distributed-failure
+    if: failure()
+    needs: [shard, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report W6 distributed failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 15 --repo "$GITHUB_REPOSITORY" --body "FTRL W6 Geografía/Atlas distribuido — corrida ${GITHUB_RUN_ID} NO completó todos sus gates. No se promueve W6 ni se declara archival_complete. Los shards exitosos cifrados pueden conservarse temporalmente como evidencia diagnóstica, pero no sustituyen la unión exhaustiva 5,258/5,258."

--- a/data/research/ltmd_u1_w6_distributed_run_stamp.json
+++ b/data/research/ltmd_u1_w6_distributed_run_stamp.json
@@ -1,0 +1,15 @@
+{
+  "schema": "LTMD_FTRL_W6_DISTRIBUTED_RUN_STAMP_0.1",
+  "wave": "W6",
+  "domain": "Geografía/Atlas",
+  "activation_date": "2026-08-25",
+  "historical_identities": 42,
+  "canonical_processing_objects": 37,
+  "expected_pages": 5258,
+  "shard_count": 16,
+  "max_parallel": 8,
+  "trigger_policy": "merge to main triggers .github/workflows/run-ftrl-w6-distributed.yml",
+  "archival_complete": false,
+  "text_verified": false,
+  "semantic_ready": false
+}

--- a/data/research/ltmd_u1_w6_distributed_topology.json
+++ b/data/research/ltmd_u1_w6_distributed_topology.json
@@ -1,0 +1,65 @@
+{
+  "schema": "LTMD_FTRL_W6_DISTRIBUTED_TOPOLOGY_0.1",
+  "effective_date": "2026-08-25",
+  "wave": "W6",
+  "operational_domain": "geografia_atlas",
+  "historical_identities": 42,
+  "canonical_processing_objects": 37,
+  "canonical_source_pages": 5258,
+  "source_topology": {
+    "route_aliases_2018_to_2019": 5,
+    "cryptographically_recovered_same_position_pages": 2,
+    "persistent_source_gaps": 0,
+    "prior_ocr_sha_verified_pages": 5258,
+    "prior_ocr_unresolved_pages": 0,
+    "interpretation": "technical source/OCR anchor only; the prior metrics layer did not preserve page OCR text and cannot be promoted as FTRL completion"
+  },
+  "runtime_anchors": {
+    "W3": {
+      "distributed_run_id": "32853375619",
+      "pages_per_shard": "399-400",
+      "status": "computationally_validated_and_archivally_complete"
+    },
+    "W1": {
+      "distributed_run_id": "32807213503",
+      "pages_per_shard": "407-408",
+      "status": "computationally_validated_and_archivally_complete"
+    },
+    "interpretation": "cross-wave runtime anchors justify retaining an approximately 330-400 page shard scale without treating prior W6 OCR metrics as FTRL completion"
+  },
+  "topology": {
+    "algorithm": "stable sort (catalog_generation, grade_code, viewer_key, source_image_index) + balanced contiguous partition",
+    "shard_count": 16,
+    "max_parallel": 8,
+    "shards_329_pages": 10,
+    "shards_328_pages": 6,
+    "expected_total_pages": 5258,
+    "per_job_timeout_minutes": 330,
+    "reason": "Use a deterministic partition near the W1/W3 proven shard scale while limiting artifact count for the smaller W6 denominator."
+  },
+  "required_gates": {
+    "w3_archival_complete": true,
+    "all_16_shards_validated": true,
+    "global_union_exact_5258_of_5258": true,
+    "global_union_unique": true,
+    "same_source_commit_and_workflow_run": true,
+    "all_shard_sqlite_integrity_ok": true,
+    "all_shard_fts_cardinality_ok": true,
+    "all_shard_qc_cardinality_ok": true,
+    "restricted_outputs_plaintext_public_upload": false
+  },
+  "preservation": {
+    "private_handoffs_encrypted_before_upload": true,
+    "actions_artifacts_temporary": true,
+    "drive_final_policy": "consolidate privately into one canonical W6 corpus package, verify checksums/privacy, then remove redundant temporary handoffs",
+    "archival_complete_before_promotion": true
+  },
+  "epistemic_guards": [
+    "distributed_computationally_validated != archival_complete",
+    "ocr_available != text_verified",
+    "corpus_ready != semantic_ready",
+    "search_hit != historical_claim",
+    "zero_hits != demonstrated_absence"
+  ],
+  "full_execution_activated": false
+}

--- a/data/research/ltmd_u1_w6_distributed_topology.json
+++ b/data/research/ltmd_u1_w6_distributed_topology.json
@@ -61,5 +61,11 @@
     "search_hit != historical_claim",
     "zero_hits != demonstrated_absence"
   ],
-  "full_execution_activated": false
+  "activation": {
+    "date": "2026-08-25",
+    "workflow": ".github/workflows/run-ftrl-w6-distributed.yml",
+    "trigger": "data/research/ltmd_u1_w6_distributed_run_stamp.json",
+    "policy": "activate only after merge to main; merge push of run stamp starts exhaustive distributed W6"
+  },
+  "full_execution_activated": true
 }

--- a/scripts/build_ftrl_w6_inputs.py
+++ b/scripts/build_ftrl_w6_inputs.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Normalize versioned W6 Geografía/Atlas source topology for generic FTRL."""
+from __future__ import annotations
+
+import argparse, csv, re
+from pathlib import Path
+from urllib.parse import urlparse
+
+VERSION = "LTMD_U1_W6_FTRL_INPUTS_0.1"
+EXPECTED_HISTORICAL = 42
+EXPECTED_CANONICAL = 37
+EXPECTED_ALIASES = 5
+EXPECTED_PAGES = 5258
+EXPECTED_RECOVERED = 2
+SHA = re.compile(r"^[0-9a-f]{64}$")
+PROCESSING = Path("data/catalog/ltmd_u1_w6_geography_atlas_processing_inventory.csv")
+MANIFEST = Path("data/catalog/ltmd_u1_w6_geography_atlas_canonical_page_manifest.csv")
+
+def read(path):
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+def n(row, key):
+    v = row.get(key, "")
+    if v in {"", None}:
+        raise AssertionError(f"missing {key}: {row}")
+    return int(float(v))
+
+def write(path, rows, fields):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=fields); w.writeheader(); w.writerows(rows)
+
+def source_index(url: str) -> int:
+    stem = Path(urlparse(url).path).stem
+    if not stem.isdigit():
+        raise AssertionError(f"non-numeric W6 source image index: {url}")
+    return int(stem)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--asset-output", default="local/ftrl/ltmd_u1_w6_asset_manifest.csv")
+    ap.add_argument("--processing-output", default="local/ftrl/ltmd_u1_w6_processing_inventory.csv")
+    a = ap.parse_args()
+    processing = read(PROCESSING); manifest = read(MANIFEST)
+    assert len(processing) == EXPECTED_HISTORICAL
+    by = {r["viewer_key"]: r for r in processing}; assert len(by) == EXPECTED_HISTORICAL
+    canonical = {r["viewer_key"] for r in processing if n(r, "is_canonical_processing_object") == 1}
+    assert len(canonical) == EXPECTED_CANONICAL and len(processing) - len(canonical) == EXPECTED_ALIASES
+    assert all(n(r, "technical_identity_covered") == 1 and n(r, "persistent_source_gaps") == 0 for r in processing)
+
+    pfields = ["processing_version","viewer_key","catalog_generation","grade_code","title_core","processing_mode","canonical_processing_viewer_key","technical_identity_covered","is_canonical_processing_object","declared_positions","direct_source_jpegs","persistent_internal_source_gaps","source_processing_basis","interpretive_limit"]
+    pout = []
+    for r in processing:
+        target = r["canonical_processing_viewer_key"]; assert target in canonical
+        source_pages = n(r, "direct_source_pages_for_processing") + n(r, "recovered_source_pages_for_processing")
+        pout.append({
+            "processing_version": VERSION,
+            "viewer_key": r["viewer_key"],
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "processing_mode": r["processing_mode"],
+            "canonical_processing_viewer_key": target,
+            "technical_identity_covered": 1,
+            "is_canonical_processing_object": n(r, "is_canonical_processing_object"),
+            "declared_positions": n(r, "declared_positions"),
+            "direct_source_jpegs": source_pages if n(r, "is_canonical_processing_object") == 1 else 0,
+            "persistent_internal_source_gaps": 0,
+            "source_processing_basis": f"{r['topology_version']}:{r['processing_mode']}",
+            "interpretive_limit": "Technical source topology only; aliases/recovery do not imply bibliographic, curricular, semantic, or historical equivalence.",
+        })
+
+    assert len(manifest) == EXPECTED_PAGES and {r["viewer_key"] for r in manifest} == canonical
+    afields = ["audit_version","viewer_key","catalog_generation","grade_code","title_core","viewer_page","source_image_index","source_asset_url","asset_status","byte_size","sha256","processing_mode","source_provenance"]
+    aout = []; seen = set(); recovered = 0
+    for r in manifest:
+        idx = source_index(r["source_asset_url"])
+        key = (r["viewer_key"], idx); assert key not in seen; seen.add(key)
+        assert n(r, "byte_size") > 0 and SHA.fullmatch(r["sha256"])
+        provenance = r["source_kind"]
+        if r["source_kind"] == "cryptographically_recovered_same_position_reference":
+            recovered += 1
+            provenance += f":reference={r['recovery_reference_viewer_key']}:original={r['original_source_asset_url']}"
+        aout.append({
+            "audit_version": VERSION,
+            "viewer_key": r["viewer_key"],
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "viewer_page": n(r, "viewer_page"),
+            "source_image_index": idx,
+            "source_asset_url": r["source_asset_url"],
+            "asset_status": "source_jpeg",
+            "byte_size": n(r, "byte_size"),
+            "sha256": r["sha256"],
+            "processing_mode": by[r["viewer_key"]]["processing_mode"],
+            "source_provenance": provenance,
+        })
+    assert len(aout) == EXPECTED_PAGES and len(seen) == EXPECTED_PAGES and recovered == EXPECTED_RECOVERED
+    write(Path(a.processing_output), pout, pfields); write(Path(a.asset_output), aout, afields)
+    print(f"Built W6 FTRL inputs: historical={len(pout)}, canonical={len(canonical)}, aliases={EXPECTED_ALIASES}, pages={len(aout)}, recovered={recovered}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/consolidate_ftrl_w6_distributed.py
+++ b/scripts/consolidate_ftrl_w6_distributed.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Privately consolidate decrypted distributed W6 FTRL shards."""
+from __future__ import annotations
+
+import argparse, csv, hashlib, json, subprocess, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 5258
+EXPECTED_HISTORICAL = 42
+EXPECTED_CANONICAL = 37
+EXPECTED_SHARDS = 16
+SCHEMA = "LTMD_FTRL_W6_PRIVATE_CONSOLIDATION_0.1"
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True); subprocess.run(command, check=True)
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""): h.update(chunk)
+    return h.hexdigest()
+
+def descriptor(path: Path) -> dict: return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+def page_key_hash(viewer_key: str, page_index: int) -> str: return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+def expected_hashes(asset_manifest: Path, processing_inventory: Path) -> set[str]:
+    proc = list(csv.DictReader(processing_inventory.open(encoding="utf-8", newline="")))
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(proc) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL: raise SystemExit("W6 processing denominator drift")
+    rows = list(csv.DictReader(asset_manifest.open(encoding="utf-8", newline="")))
+    selected = [r for r in rows if r["asset_status"] == "source_jpeg" and r["viewer_key"] in canonical]
+    if len(selected) != EXPECTED_PAGES: raise SystemExit(f"W6 canonical source page drift: {len(selected)}")
+    hashes = {page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in selected}
+    if len(hashes) != EXPECTED_PAGES: raise SystemExit("W6 canonical page identities are not unique")
+    return hashes
+
+def load_records(root: Path, shard_count: int) -> list[dict]:
+    paths = sorted(root.rglob("w6_shard_*_page_ocr.jsonl"))
+    if len(paths) != shard_count: raise SystemExit(f"expected {shard_count} decrypted W6 JSONL shards, found {len(paths)}")
+    records, page_ids, page_keys = [], set(), set()
+    for path in paths:
+        with path.open(encoding="utf-8") as fh:
+            for line_number, line in enumerate(fh, 1):
+                if not line.strip(): continue
+                row = json.loads(line)
+                if row.get("wave") != "W6": raise SystemExit(f"non-W6 record in {path}:{line_number}")
+                page_id = str(row["page_id"]); key = (str(row["viewer_key"]), int(row["page_index"]))
+                if page_id in page_ids or key in page_keys: raise SystemExit(f"duplicate W6 page across shards: {page_id}")
+                page_ids.add(page_id); page_keys.add(key); records.append(row)
+    if len(records) != EXPECTED_PAGES: raise SystemExit(f"W6 decrypted distributed total drift: {len(records)}")
+    records.sort(key=lambda r: (int(r["catalog_generation"]), int(r["grade_code"]), str(r["viewer_key"]), int(r["page_index"])))
+    return records
+
+def main() -> None:
+    ap = argparse.ArgumentParser(); ap.add_argument("--shard-root", type=Path, required=True); ap.add_argument("--asset-manifest", type=Path, required=True); ap.add_argument("--processing-inventory", type=Path, required=True); ap.add_argument("--output-dir", type=Path, required=True); ap.add_argument("--distributed-run-id", required=True); ap.add_argument("--distributed-source-commit", required=True); ap.add_argument("--shard-count", type=int, default=EXPECTED_SHARDS); args = ap.parse_args()
+    records = load_records(args.shard_root, args.shard_count); observed = {page_key_hash(str(r["viewer_key"]), int(r["page_index"])) for r in records}; expected = expected_hashes(args.asset_manifest, args.processing_inventory)
+    if observed != expected: raise SystemExit(f"W6 private union mismatch: missing={len(expected-observed)}, extra={len(observed-expected)}")
+    out = args.output_dir; out.mkdir(parents=True, exist_ok=True)
+    jsonl = out / "ltmd_u1_w6_full_page_ocr.jsonl"; db = out / "ltmd_u1_w6_full_ocr_search.sqlite"; qc_queue = out / "ltmd_u1_w6_full_qc_queue.json"; qc_summary = out / "ltmd_u1_w6_full_qc_summary.json"; run_manifest = out / "ltmd_u1_w6_full_run_manifest.json"; evidence = out / "ltmd_u1_w6_private_consolidation_evidence.json"
+    with jsonl.open("w", encoding="utf-8", newline="\n") as fh:
+        for row in records: fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(args.processing_inventory), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(args.asset_manifest), "--processing-inventory", str(args.processing_inventory), "--label", "full_distributed_consolidated", "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+    rm = json.loads(run_manifest.read_text(encoding="utf-8")); qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["corpus"]["page_records"] != EXPECTED_PAGES: raise SystemExit("W6 private consolidated run failed")
+    if rm["database"]["page_rows"] != EXPECTED_PAGES or rm["database"]["fts_rows"] != EXPECTED_PAGES or rm["database"]["sqlite_integrity"] != "ok" or qc["page_records"] != EXPECTED_PAGES: raise SystemExit("W6 private consolidated database/QC failure")
+    if rm["database"]["historical_identities"] != EXPECTED_HISTORICAL: raise SystemExit(f"W6 historical identity drift: {rm['database']['historical_identities']}")
+    payload = {
+        "schema": SCHEMA, "status": "private_consolidation_validated", "wave": "W6", "domain": "Geografía/Atlas", "distributed_run_id": str(args.distributed_run_id), "distributed_source_commit": args.distributed_source_commit,
+        "shard_count": args.shard_count, "historical_identities": EXPECTED_HISTORICAL, "canonical_processing_objects": EXPECTED_CANONICAL, "page_records": EXPECTED_PAGES,
+        "page_partition_complete": True, "page_partition_unique": True, "sqlite_integrity": "ok", "fts_rows": EXPECTED_PAGES,
+        "products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue), descriptor(qc_summary), descriptor(run_manifest)],
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(), "archival_complete": False,
+        "epistemic_guards": ["private_consolidation_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready"],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "page_records": EXPECTED_PAGES, "evidence": str(evidence)}, sort_keys=True))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preflight_ftrl_w6.py
+++ b/scripts/preflight_ftrl_w6.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Text-free preflight for exhaustive LTMD-U1 W6 Geografía/Atlas."""
+from __future__ import annotations
+
+import argparse, csv, hashlib, json, re
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlparse
+
+SCHEMA = "LTMD_FTRL_W6_PREFLIGHT_0.1"
+EXPECTED_HISTORICAL = 42
+EXPECTED_CANONICAL = 37
+EXPECTED_ALIASES = 5
+EXPECTED_PAGES = 5258
+EXPECTED_RECOVERED = 2
+EXPECTED_TERMINAL = 36
+SHA = re.compile(r"^[0-9a-f]{64}$")
+
+P = {
+    "scope": Path("data/catalog/ltmd_u1_w6_scope.csv"),
+    "processing": Path("data/catalog/ltmd_u1_w6_geography_atlas_processing_inventory.csv"),
+    "manifest": Path("data/catalog/ltmd_u1_w6_geography_atlas_canonical_page_manifest.csv"),
+    "routes": Path("data/catalog/ltmd_u1_w6_geography_atlas_2018_2019_route_relationships.csv"),
+    "recovery": Path("data/catalog/ltmd_u1_w6_h2008p4ge273_gap_recovery.csv"),
+    "ocr_summary": Path("data/catalog/ltmd_u1_w6_geography_atlas_ocr_summary.csv"),
+    "ocr_metrics": Path("data/catalog/ltmd_u1_w6_geography_atlas_ocr_metrics.csv"),
+    "retained": Path("data/catalog/ltmd_u1_retained_source_register.csv"),
+}
+
+def rows(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+def n(row: dict[str, str], key: str) -> int:
+    v = row.get(key, "")
+    if v in {"", None}:
+        raise AssertionError(f"missing {key}: {row}")
+    return int(float(v))
+
+def fp(value) -> str:
+    raw = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+def source_index(url: str) -> int:
+    stem = Path(urlparse(url).path).stem
+    if not stem.isdigit():
+        raise AssertionError(f"non-numeric W6 source image index: {url}")
+    return int(stem)
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", default="local/ftrl/ltmd_u1_w6_preflight.json")
+    a = ap.parse_args()
+
+    scope = rows(P["scope"]); processing = rows(P["processing"]); manifest = rows(P["manifest"])
+    routes = rows(P["routes"]); recovery = rows(P["recovery"])
+    ocrs = rows(P["ocr_summary"]); ocrm = rows(P["ocr_metrics"]); retained = rows(P["retained"])
+
+    keys = {r["viewer_key"] for r in scope}
+    assert len(scope) == len(keys) == EXPECTED_HISTORICAL
+    assert {r.get("operational_domain") for r in scope} == {"geografia_atlas"}
+
+    by = {r["viewer_key"]: r for r in processing}
+    assert len(processing) == len(by) == EXPECTED_HISTORICAL and set(by) == keys
+    assert all(n(r, "technical_identity_covered") == 1 for r in processing)
+    assert all(n(r, "persistent_source_gaps") == 0 for r in processing)
+    modes = Counter(r["processing_mode"] for r in processing)
+    assert modes == {"direct_canonical": 36, "route_alias_to_2019": 5, "direct_canonical_reconciled_gap": 1}, modes
+
+    canonical = {r["viewer_key"] for r in processing if n(r, "is_canonical_processing_object") == 1}
+    aliases = set(by) - canonical
+    assert len(canonical) == EXPECTED_CANONICAL and len(aliases) == EXPECTED_ALIASES
+    for key, r in by.items():
+        target = r["canonical_processing_viewer_key"]
+        assert target in canonical
+        assert (target == key) == (key in canonical)
+
+    assert len(routes) == EXPECTED_ALIASES
+    for r in routes:
+        alias, target = r["viewer_key_2018"], r["canonical_processing_viewer_key"]
+        assert alias in aliases and target in canonical
+        assert by[alias]["processing_mode"] == "route_alias_to_2019"
+        assert n(r, "complete_route_resolution") == 1
+        compared = n(r, "compared_source_assets")
+        assert n(r, "sha256_matches") == compared and n(r, "byte_size_matches") == compared
+
+    assert len(recovery) == EXPECTED_RECOVERED
+    assert {n(r, "viewer_page") for r in recovery} == {70, 117}
+    for r in recovery:
+        assert r["viewer_key"] == "H2008P4GE273"
+        assert n(r, "candidate_live_verified") == 1
+        assert r["recovery_status"] == "cryptographically_recovered_same_position_reference"
+        assert SHA.fullmatch(r["effective_sha256"])
+        assert n(r, "effective_byte_size") > 0
+
+    assert len(manifest) == EXPECTED_PAGES and {r["viewer_key"] for r in manifest} == canonical
+    seen = set(); recovered = 0
+    for r in manifest:
+        idx = source_index(r["source_asset_url"])
+        key = (r["viewer_key"], idx)
+        assert key not in seen; seen.add(key)
+        assert n(r, "byte_size") > 0 and SHA.fullmatch(r["sha256"])
+        assert r["source_kind"] in {"direct_source_jpeg", "cryptographically_recovered_same_position_reference"}
+        if r["source_kind"] == "cryptographically_recovered_same_position_reference":
+            recovered += 1
+            assert r["viewer_key"] == "H2008P4GE273" and r["recovery_reference_viewer_key"] == "H1993P4GE196"
+    assert recovered == EXPECTED_RECOVERED and len(seen) == EXPECTED_PAGES
+
+    assert sum(n(r, "terminal_synthetic_candidates") for r in processing if n(r, "is_canonical_processing_object") == 1) == EXPECTED_TERMINAL
+    assert not [r for r in retained if r.get("viewer_key") in keys]
+
+    assert len(ocrs) == EXPECTED_CANONICAL and {r["viewer_key"] for r in ocrs} == canonical
+    assert sum(n(r, "pages") for r in ocrs) == EXPECTED_PAGES
+    assert sum(n(r, "sha_verified") for r in ocrs) == EXPECTED_PAGES
+    assert sum(n(r, "unresolved") for r in ocrs) == 0
+    assert len(ocrm) == EXPECTED_PAGES
+    assert sum(n(r, "source_sha256_verified") for r in ocrm) == EXPECTED_PAGES
+
+    out = {
+        "schema": SCHEMA,
+        "status": "ready_for_ftrl_runtime",
+        "wave": "W6",
+        "operational_domain": "geografia_atlas",
+        "historical_identities": EXPECTED_HISTORICAL,
+        "canonical_processing_objects": EXPECTED_CANONICAL,
+        "alias_identities": EXPECTED_ALIASES,
+        "route_aliases_2018_to_2019": EXPECTED_ALIASES,
+        "canonical_source_pages": EXPECTED_PAGES,
+        "cryptographically_recovered_pages": EXPECTED_RECOVERED,
+        "persistent_source_gaps": 0,
+        "terminal_synthetic_candidates": EXPECTED_TERMINAL,
+        "identity_level_active_retentions": 0,
+        "prior_ocr_anchor": {
+            "canonical_objects": EXPECTED_CANONICAL,
+            "pages": EXPECTED_PAGES,
+            "sha_verified_pages": EXPECTED_PAGES,
+            "unresolved_pages": 0,
+            "interpretation": "technical_anchor_only_not_ftrl_completion; metrics do not retain page OCR text",
+        },
+        "ftrl_runtime_activated": False,
+        "corpus_ready": False,
+        "ocr_available_ftrl": False,
+        "text_verified": False,
+        "semantic_ready": False,
+        "source_fingerprints": {
+            "processing_inventory_canonical_sha256": fp(processing),
+            "canonical_page_manifest_canonical_sha256": fp(manifest),
+            "route_relationships_canonical_sha256": fp(routes),
+            "gap_recovery_canonical_sha256": fp(recovery),
+        },
+        "epistemic_guards": [
+            "preflight_ready != ftrl_validated",
+            "prior_ocr_anchor != ftrl_validated",
+            "ocr_available != text_verified",
+            "corpus_ready != semantic_ready",
+            "search_hit != historical_claim",
+            "zero_hits != demonstrated_absence",
+        ],
+    }
+    p = Path(a.output); p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(out, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(out, ensure_ascii=False, sort_keys=True))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w6_distributed_shard.py
+++ b/scripts/run_ftrl_w6_distributed_shard.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Run one deterministic LTMD-U1 W6 FTRL shard.
+
+Restricted OCR/SQLite/QC remain under local/ and must be encrypted by the
+workflow before any Actions upload. Public evidence is metadata/hash only.
+"""
+from __future__ import annotations
+
+import argparse, csv, hashlib, json, shutil, sqlite3, subprocess, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 5258
+EXPECTED_HISTORICAL = 42
+EXPECTED_CANONICAL = 37
+DEFAULT_SHARDS = 16
+SCHEMA = "LTMD_FTRL_W6_DISTRIBUTED_SHARD_0.1"
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True); subprocess.run(command, check=True)
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""): h.update(chunk)
+    return h.hexdigest()
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh: return list(csv.DictReader(fh))
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows: raise SystemExit(f"refusing to write empty shard: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=list(rows[0])); w.writeheader(); w.writerows(rows)
+
+def sorted_source_rows(rows):
+    return sorted(rows, key=lambda r: (int(r["catalog_generation"]), int(r["grade_code"]), r["viewer_key"], int(r["source_image_index"])))
+
+def balanced_slice(rows, index, count):
+    if count < 1 or not 0 <= index < count: raise SystemExit("invalid shard index/count")
+    base, rem = divmod(len(rows), count); start = index * base + min(index, rem); size = base + (1 if index < rem else 0)
+    return rows[start:start + size]
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None: raise SystemExit("Tesseract is required")
+    langs = subprocess.run(["tesseract", "--list-langs"], check=True, capture_output=True, text=True).stdout.splitlines()
+    if "spa" not in {x.strip() for x in langs}: raise SystemExit("Spanish Tesseract language data is required")
+    conn = sqlite3.connect(":memory:")
+    try: conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    finally: conn.close()
+
+def descriptor(path: Path) -> dict:
+    return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+def jsonl_hashes(path: Path):
+    hashes, count = [], 0
+    with path.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            if not line.strip(): continue
+            row = json.loads(line)
+            if row.get("wave") != "W6": raise SystemExit(f"non-W6 record at {path}:{line_number}")
+            hashes.append(page_key_hash(str(row["viewer_key"]), int(row["page_index"]))); count += 1
+    return sorted(hashes), count
+
+def main() -> None:
+    ap = argparse.ArgumentParser(); ap.add_argument("--shard-index", type=int, required=True); ap.add_argument("--shard-count", type=int, default=DEFAULT_SHARDS); ap.add_argument("--output-dir", type=Path, default=Path("local/ftrl-w6-distributed")); args = ap.parse_args()
+    require_environment()
+    root = args.output_dir; root.mkdir(parents=True, exist_ok=True)
+    shard_name = f"shard_{args.shard_index:02d}_of_{args.shard_count:02d}"; shard_dir = root / shard_name; shard_dir.mkdir(parents=True, exist_ok=True)
+    preflight = root / "ltmd_u1_w6_preflight.json"; full_asset = root / "ltmd_u1_w6_asset_manifest.csv"; processing = root / "ltmd_u1_w6_processing_inventory.csv"
+    run([sys.executable, "scripts/preflight_ftrl_w6.py", "--output", str(preflight)])
+    run([sys.executable, "scripts/build_ftrl_w6_inputs.py", "--asset-output", str(full_asset), "--processing-output", str(processing)])
+    proc = read_csv(processing); canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(proc) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL: raise SystemExit("W6 processing denominator drift")
+    rows = sorted_source_rows(read_csv(full_asset))
+    if len(rows) != EXPECTED_PAGES: raise SystemExit(f"W6 source cardinality drift: {len(rows)} != {EXPECTED_PAGES}")
+    shard_rows = balanced_slice(rows, args.shard_index, args.shard_count)
+    expected_hashes = sorted(page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in shard_rows)
+    if len(expected_hashes) != len(set(expected_hashes)): raise SystemExit("duplicate expected page key inside shard")
+
+    prefix = f"w6_{shard_name}"; shard_asset = shard_dir / f"{prefix}_asset_manifest.csv"; jsonl = shard_dir / f"{prefix}_page_ocr.jsonl"; db = shard_dir / f"{prefix}_ocr_search.sqlite"; run_manifest = shard_dir / f"{prefix}_run_manifest.json"; qc_queue = shard_dir / f"{prefix}_qc_queue.json"; qc_summary = shard_dir / f"{prefix}_qc_summary.json"; evidence = shard_dir / f"{prefix}_evidence.json"
+    write_csv(shard_asset, shard_rows)
+    run([sys.executable, "scripts/build_page_ocr_corpus.py", "--asset-manifest", str(shard_asset), "--processing-inventory", str(processing), "--wave", "W6", "--output", str(jsonl), "--cache-dir", str(shard_dir / "assets"), "--resume"])
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(processing), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(shard_asset), "--processing-inventory", str(processing), "--label", shard_name, "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+    actual_hashes, actual_count = jsonl_hashes(jsonl)
+    if actual_count != len(shard_rows) or actual_hashes != expected_hashes: raise SystemExit("W6 shard page inventory mismatch")
+    rm = json.loads(run_manifest.read_text(encoding="utf-8")); qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["database"]["sqlite_integrity"] != "ok": raise SystemExit("W6 shard validation failed")
+    pages = len(shard_rows)
+    if rm["corpus"]["page_records"] != pages or rm["database"]["page_rows"] != pages or rm["database"]["fts_rows"] != pages or qc["page_records"] != pages: raise SystemExit("W6 shard cardinality drift")
+    payload = {
+        "schema": SCHEMA, "status": "validated", "wave": "W6", "domain": "Geografía/Atlas",
+        "shard_index": args.shard_index, "shard_count": args.shard_count, "page_records": pages,
+        "page_key_hashes": expected_hashes, "canonical_viewers_in_shard": len({r["viewer_key"] for r in shard_rows}),
+        "source_partition": {"full_source_pages": EXPECTED_PAGES, "algorithm": "stable sort (catalog_generation, grade_code, viewer_key, source_image_index) + balanced contiguous partition"},
+        "validation": {"sqlite_integrity": "ok", "sqlite_pages": rm["database"]["page_rows"], "fts_rows": rm["database"]["fts_rows"], "qc_page_records": qc["page_records"]},
+        "restricted_products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue)], "text_free_products": [descriptor(shard_asset), descriptor(run_manifest), descriptor(qc_summary)],
+        "execution": rm.get("execution"), "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": ["distributed_computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim", "zero_hits != demonstrated_absence"],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "shard": args.shard_index, "pages": pages, "evidence": str(evidence)}, sort_keys=True))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_ftrl_w6_distributed.py
+++ b/scripts/validate_ftrl_w6_distributed.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate exhaustive, unique, text-free evidence for distributed W6 FTRL."""
+from __future__ import annotations
+
+import argparse, csv, hashlib, json
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_PAGES = 5258
+EXPECTED_HISTORICAL = 42
+EXPECTED_CANONICAL = 37
+DEFAULT_SHARDS = 16
+SCHEMA = "LTMD_FTRL_W6_DISTRIBUTED_GLOBAL_0.1"
+SHARD_SCHEMA = "LTMD_FTRL_W6_DISTRIBUTED_SHARD_0.1"
+FORBIDDEN_KEYS = {"ocr_text_raw", "search_text", "snippet", "text"}
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+def walk_no_text(value) -> None:
+    if isinstance(value, dict):
+        hits = FORBIDDEN_KEYS & set(value)
+        if hits: raise AssertionError(f"forbidden restricted-text key(s): {sorted(hits)}")
+        for child in value.values(): walk_no_text(child)
+    elif isinstance(value, list):
+        for child in value: walk_no_text(child)
+
+def expected_hashes(asset_manifest: Path, processing_inventory: Path) -> set[str]:
+    proc = list(csv.DictReader(processing_inventory.open(encoding="utf-8", newline="")))
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(proc) != EXPECTED_HISTORICAL or len(canonical) != EXPECTED_CANONICAL: raise SystemExit("W6 processing denominator drift")
+    rows = list(csv.DictReader(asset_manifest.open(encoding="utf-8", newline="")))
+    selected = [r for r in rows if r["asset_status"] == "source_jpeg" and r["viewer_key"] in canonical]
+    if len(selected) != EXPECTED_PAGES: raise SystemExit(f"W6 canonical source page drift: {len(selected)}")
+    hashes = {page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in selected}
+    if len(hashes) != EXPECTED_PAGES: raise SystemExit("W6 canonical page identities are not unique")
+    return hashes
+
+def main() -> None:
+    ap = argparse.ArgumentParser(); ap.add_argument("--evidence-root", type=Path, required=True); ap.add_argument("--asset-manifest", type=Path, required=True); ap.add_argument("--processing-inventory", type=Path, required=True); ap.add_argument("--shard-count", type=int, default=DEFAULT_SHARDS); ap.add_argument("--output", type=Path, required=True); args = ap.parse_args()
+    files = sorted(args.evidence_root.rglob("w6_shard_*_evidence.json"))
+    if len(files) != args.shard_count: raise SystemExit(f"expected {args.shard_count} W6 shard evidence files, found {len(files)}")
+    expected = expected_hashes(args.asset_manifest, args.processing_inventory); observed = []; shard_indices = set(); run_ids = set(); source_commits = set(); sizes = Counter()
+    for p in files:
+        d = json.loads(p.read_text(encoding="utf-8")); walk_no_text(d)
+        if d.get("schema") != SHARD_SCHEMA or d.get("status") != "validated" or d.get("wave") != "W6": raise SystemExit(f"invalid W6 shard evidence: {p}")
+        idx = int(d["shard_index"]); shard_indices.add(idx); sizes[int(d["page_records"])] += 1
+        if int(d["shard_count"]) != args.shard_count: raise SystemExit("W6 shard-count drift")
+        hashes = list(d["page_key_hashes"])
+        if len(hashes) != int(d["page_records"]) or len(hashes) != len(set(hashes)): raise SystemExit(f"W6 shard hash cardinality failure: {p}")
+        observed.extend(hashes)
+        v = d["validation"]
+        if v["sqlite_integrity"] != "ok" or int(v["sqlite_pages"]) != int(d["page_records"]) or int(v["fts_rows"]) != int(d["page_records"]) or int(v["qc_page_records"]) != int(d["page_records"]): raise SystemExit(f"W6 shard validation cardinality failure: {p}")
+        ex = d.get("execution") or {}
+        ci = ex.get("ci") or {}
+        vcs = ex.get("vcs") or {}
+        if ci.get("run_id"): run_ids.add(str(ci["run_id"]))
+        if ci.get("sha"): source_commits.add(str(ci["sha"]))
+        elif vcs.get("commit"): source_commits.add(str(vcs["commit"]))
+    if shard_indices != set(range(args.shard_count)): raise SystemExit(f"W6 shard index coverage drift: {sorted(shard_indices)}")
+    if len(observed) != EXPECTED_PAGES or len(set(observed)) != EXPECTED_PAGES: raise SystemExit(f"W6 global union is not unique/exhaustive: records={len(observed)} unique={len(set(observed))}")
+    obs = set(observed)
+    if obs != expected: raise SystemExit(f"W6 global union mismatch: missing={len(expected-obs)} extra={len(obs-expected)}")
+    if sizes != Counter({329: 10, 328: 6}): raise SystemExit(f"W6 shard-size topology drift: {sizes}")
+    if len(run_ids) != 1: raise SystemExit(f"W6 shards do not share one workflow run: {sorted(run_ids)}")
+    if len(source_commits) != 1: raise SystemExit(f"W6 shards do not share one source commit: {sorted(source_commits)}")
+    payload = {
+        "schema": SCHEMA, "status": "distributed_computationally_validated", "wave": "W6", "domain": "Geografía/Atlas",
+        "historical_identities": EXPECTED_HISTORICAL, "canonical_processing_objects": EXPECTED_CANONICAL, "shard_count": args.shard_count,
+        "page_records": EXPECTED_PAGES, "unique_page_records": EXPECTED_PAGES, "expected_page_records": EXPECTED_PAGES,
+        "shard_size_distribution": {str(k): v for k, v in sorted(sizes.items())}, "page_partition_complete": True, "page_partition_unique": True,
+        "workflow_run_ids_observed": sorted(run_ids), "source_commits_observed": sorted(source_commits),
+        "same_source_commit_and_workflow_run": True,
+        "archival_complete": False, "text_verified": False, "semantic_ready": False,
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": ["distributed_computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim", "zero_hits != demonstrated_absence"],
+    }
+    walk_no_text(payload); args.output.parent.mkdir(parents=True, exist_ok=True); args.output.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "pages": EXPECTED_PAGES, "shards": args.shard_count, "sizes": dict(sizes), "output": str(args.output)}, sort_keys=True))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Objetivo
Activar la ejecución exhaustiva distribuida de FTRL W6 (Geografía/Atlas) sin reabrir el denominador ya fijado.

## Denominador canónico
- 42 identidades históricas
- 37 objetos canónicos de procesamiento
- 5,258 páginas fuente
- 5 aliases técnicos 2018→2019
- 2 páginas recuperadas criptográficamente por referencia de misma posición
- 0 brechas persistentes de fuente

## Infraestructura incluida
- preflight exhaustivo W6
- normalización de inputs canónicos
- runner determinista distribuido
- 16 shards balanceados: 10×329 + 6×328 páginas
- máximo 8 jobs en paralelo; timeout 330 min
- cifrado de todo handoff restringido antes de upload
- evidencia pública sin texto restringido
- validador de unión global exacta 5,258/5,258
- consolidador privado para el cierre archivístico posterior
- workflow `run-ftrl-w6-distributed.yml`
- run stamp que activa la corrida al fusionarse a `main`

## Gates de promoción
W6 no se considerará cerrada por el mero éxito computacional. Deben mantenerse separadas las condiciones `computationally_validated` y `archival_complete`; `text_verified=false` y `semantic_ready=false` hasta sus gates posteriores.

El merge de este PR está diseñado para disparar la corrida W6 mediante `data/research/ltmd_u1_w6_distributed_run_stamp.json`.