### PR TITLE
fix(w7): query exact HTTP and HTTPS URIs in Common Crawl

### DIFF
--- a/scripts/discover_ltmd_u1_w7_commoncrawl_sources.py
+++ b/scripts/discover_ltmd_u1_w7_commoncrawl_sources.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 """Search a bounded Common Crawl phase for exact W7 withheld-source URIs.
 
-This is a fallback archive probe after Wayback availability errors. Phase 0.2
+This is a fallback archive probe after Wayback availability errors. Phase 0.3
 queries two Common Crawl indexes per year for 2017-2020, centered on the served
-H2014P5FCA reprint (cycle 2017-2018) and the unresolved 2018 viewers. It uses
-only exact institutional URIs; no title search, nearby-key search, or aliases.
+H2014P5FCA reprint (cycle 2017-2018) and the unresolved 2018 viewers. Every
+established institutional path is queried under both exact HTTP and HTTPS URIs,
+because archive indexes treat schemes as distinct URLs. It does not use title
+search, nearby-key search, or aliases.
 """
 from __future__ import annotations
 
@@ -17,13 +19,14 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-VERSION = 'LTMD_U1_W7_COMMONCRAWL_SOURCE_DISCOVERY_0.2'
+VERSION = 'LTMD_U1_W7_COMMONCRAWL_SOURCE_DISCOVERY_0.3'
 COLLINFO = 'https://index.commoncrawl.org/collinfo.json'
 UA = 'LibroTextoMexicanoDigital/U1-W7 exact-uri Common Crawl discovery'
 TIMEOUT = 15
 WORKERS = 10
 PHASE_YEARS = (2017, 2018, 2019, 2020)
 COLLECTIONS_PER_YEAR = 2
+URI_SCHEMES = ('http', 'https')
 OUT = Path('data/catalog/ltmd_u1_w7_commoncrawl_source_discovery.csv')
 REPORT = Path('data/catalog/ltmd_u1_w7_commoncrawl_source_discovery.md')
 
@@ -32,14 +35,14 @@ TARGETS = [
         'target_id': 'H2014P5FCA_page104',
         'target_kind': 'exact_missing_asset',
         'viewer_key': 'H2014P5FCA',
-        'url': 'https://historico.conaliteg.gob.mx/c/H2014P5FCA/104.jpg',
+        'path': 'historico.conaliteg.gob.mx/c/H2014P5FCA/104.jpg',
     },
     *[
         {
             'target_id': f'{key}_viewer',
             'target_kind': 'exact_viewer',
             'viewer_key': key,
-            'url': f'https://historico.conaliteg.gob.mx/{key}.htm',
+            'path': f'historico.conaliteg.gob.mx/{key}.htm',
         }
         for key in ('H2018P3FCA', 'H2018P4FCA', 'H2018P5FCA', 'H2018P6FCA')
     ],
@@ -75,10 +78,17 @@ def select_phase_collections(collections: list[dict]) -> list[dict]:
     return [dedup[key] for key in sorted(dedup)]
 
 
-def query_one(collection: dict, target: dict) -> dict:
+def exact_uri(target: dict, scheme: str) -> str:
+    if scheme not in URI_SCHEMES:
+        raise ValueError(f'unsupported scheme: {scheme}')
+    return f"{scheme}://{target['path']}"
+
+
+def query_one(collection: dict, target: dict, scheme: str) -> dict:
     endpoint = collection.get('cdx-api') or f"https://index.commoncrawl.org/{collection['id']}-index"
+    source_url = exact_uri(target, scheme)
     query_url = endpoint + '?' + urlencode({
-        'url': target['url'],
+        'url': source_url,
         'output': 'json',
         'filter': 'status:200',
     })
@@ -88,6 +98,8 @@ def query_one(collection: dict, target: dict) -> dict:
         rows = [json.loads(line) for line in raw.splitlines() if line.strip()]
         return {
             'target': target,
+            'scheme': scheme,
+            'source_url': source_url,
             'collection_id': collection['id'],
             'query_url': query_url,
             'probe_state': 'index_ok',
@@ -97,6 +109,8 @@ def query_one(collection: dict, target: dict) -> dict:
     except HTTPError as exc:
         return {
             'target': target,
+            'scheme': scheme,
+            'source_url': source_url,
             'collection_id': collection['id'],
             'query_url': query_url,
             'probe_state': f'index_http_{exc.code}',
@@ -106,6 +120,8 @@ def query_one(collection: dict, target: dict) -> dict:
     except (URLError, TimeoutError, OSError, json.JSONDecodeError) as exc:
         return {
             'target': target,
+            'scheme': scheme,
+            'source_url': source_url,
             'collection_id': collection['id'],
             'query_url': query_url,
             'probe_state': 'index_network_error',
@@ -124,15 +140,16 @@ def main() -> None:
     results = []
     with ThreadPoolExecutor(max_workers=WORKERS) as pool:
         futures = [
-            pool.submit(query_one, collection, target)
+            pool.submit(query_one, collection, target, scheme)
             for collection in collections
             for target in TARGETS
+            for scheme in URI_SCHEMES
         ]
         for future in as_completed(futures):
             result = future.result()
             results.append(result)
             print(
-                result['target']['target_id'], result['collection_id'],
+                result['target']['target_id'], result['scheme'], result['collection_id'],
                 result['probe_state'], 'captures', len(result['rows']), flush=True,
             )
 
@@ -149,6 +166,8 @@ def main() -> None:
                     'target_id': target['target_id'],
                     'target_kind': target['target_kind'],
                     'viewer_key': target['viewer_key'],
+                    'query_scheme': result['scheme'],
+                    'source_url': result['source_url'],
                     'collection_id': result['collection_id'],
                     'probe_state': result['probe_state'],
                     'query_url': result['query_url'],
@@ -168,12 +187,15 @@ def main() -> None:
         states: dict[str, int] = {}
         for result in target_results:
             states[result['probe_state']] = states.get(result['probe_state'], 0) + 1
+        schemes_with_captures = sorted({r['query_scheme'] for r in captures})
         summaries.append({
             **target,
-            'collections_queried': len(target_results),
+            'collections_queried': len(collections),
+            'uri_queries': len(target_results),
             'index_ok': states.get('index_ok', 0),
             'index_errors': len(target_results) - states.get('index_ok', 0),
             'capture_count': len(captures),
+            'schemes_with_captures': ','.join(schemes_with_captures),
             'first_capture': timestamps[0] if timestamps else '',
             'last_capture': timestamps[-1] if timestamps else '',
         })
@@ -181,13 +203,14 @@ def main() -> None:
     OUT.parent.mkdir(parents=True, exist_ok=True)
     fields = [
         'discovery_version', 'observed_utc', 'target_id', 'target_kind',
-        'viewer_key', 'collection_id', 'probe_state', 'query_url', 'timestamp',
-        'url', 'status', 'mime', 'mime_detected', 'digest', 'length', 'offset',
-        'filename',
+        'viewer_key', 'query_scheme', 'source_url', 'collection_id', 'probe_state',
+        'query_url', 'timestamp', 'url', 'status', 'mime', 'mime_detected',
+        'digest', 'length', 'offset', 'filename',
     ]
     with OUT.open('w', encoding='utf-8', newline='') as f:
         writer = csv.DictWriter(f, fieldnames=fields)
-        writer.writeheader(); writer.writerows(records)
+        writer.writeheader()
+        writer.writerows(records)
 
     selected_ids = ', '.join(c['id'] for c in collections)
     lines = [
@@ -199,18 +222,20 @@ def main() -> None:
         '',
         f'Fase temporal: **2017–2020**, hasta **{COLLECTIONS_PER_YEAR}** índices por año.',
         f'Índices seleccionados: `{selected_ids}`.',
+        f'Esquemas exactos consultados por ruta: `{", ".join(URI_SCHEMES)}`.',
         '',
-        'La consulta usa únicamente URIs institucionales exactos. Esta fase está diseñada para descubrimiento rápido alrededor del periodo documental pertinente; cero capturas no equivale a ausencia global en Common Crawl ni en la web histórica.',
+        'La consulta usa únicamente URIs institucionales exactos. HTTP y HTTPS se consultan por separado porque los índices archivísticos los tratan como URLs distintas. Esta ampliación no introduce búsquedas por similitud. Cero capturas no equivale a ausencia global en Common Crawl ni en la web histórica.',
         '',
         '## Resumen',
         '',
-        '| objetivo | colecciones | índice OK | errores | capturas | primera | última |',
-        '|---|---:|---:|---:|---:|---|---|',
+        '| objetivo | colecciones | consultas URI | índice OK | errores | capturas | esquemas con captura | primera | última |',
+        '|---|---:|---:|---:|---:|---:|---|---|---|',
     ]
     for item in summaries:
         lines.append(
-            f"| `{item['target_id']}` | {item['collections_queried']} | {item['index_ok']} | "
-            f"{item['index_errors']} | {item['capture_count']} | `{item['first_capture']}` | `{item['last_capture']}` |"
+            f"| `{item['target_id']}` | {item['collections_queried']} | {item['uri_queries']} | "
+            f"{item['index_ok']} | {item['index_errors']} | {item['capture_count']} | "
+            f"`{item['schemes_with_captures']}` | `{item['first_capture']}` | `{item['last_capture']}` |"
         )
 
     h2014 = next(item for item in summaries if item['target_id'] == 'H2014P5FCA_page104')
@@ -218,7 +243,7 @@ def main() -> None:
         '',
         '## Página 104 de H2014P5FCA',
         '',
-        f"El URI exacto produjo **{h2014['capture_count']}** captura(s) en esta fase, con **{h2014['index_ok']}/{h2014['collections_queried']}** consultas de índice válidas.",
+        f"Las variantes HTTP/HTTPS del URI exacto produjeron **{h2014['capture_count']}** captura(s) en esta fase, con **{h2014['index_ok']}/{h2014['uri_queries']}** consultas de índice válidas.",
         '',
         'Si existen capturas, `filename`, `offset`, `length` y `digest` permiten una recuperación WARC dirigida. No se incorpora ningún byte al corpus en esta etapa.',
         '',


### PR DESCRIPTION
## Problema
El probe W7 de Common Crawl v0.2 consulta únicamente la variante `https://` de cinco rutas institucionales exactas. En un índice archivístico, `http://` y `https://` son URLs distintas; limitar la búsqueda a HTTPS puede producir falsos ceros para material histórico servido originalmente por HTTP.

## Cambio
- eleva el probe a `LTMD_U1_W7_COMMONCRAWL_SOURCE_DISCOVERY_0.3`;
- consulta cada ruta institucional establecida bajo ambos esquemas exactos: HTTP y HTTPS;
- registra `query_scheme` y `source_url` en la evidencia CSV;
- informa consultas por URI y esquemas con captura en el reporte;
- mantiene la ventana acotada 2017–2020 y los mismos índices por año.

## Salvaguardas
- no hay búsqueda por título ni similitud;
- no se consultan claves vecinas como sustitutos;
- no se crean aliases;
- no se incorpora ningún byte al corpus;
- no cambia `ocr_source_admitted` ni los cinco `active_retention` de W7.

Esto amplía únicamente la exhaustividad del descubrimiento archivístico exacto y conserva el comportamiento fail-closed del corpus.

Refs #5