### PR TITLE
SEMB03: endurecer integridad del holdout final

### DIFF
--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -63,8 +63,6 @@ jobs:
           cff = (root / 'CITATION.cff').read_text(encoding='utf-8')
 
           def cff_scalar(key: str) -> str:
-              # Accept top-level scalars and scalar fields inside YAML sequence items,
-              # e.g. `  - family-names: "Sandoval Gutierrez"`.
               m = re.search(
                   rf'^\s*(?:-\s+)?{re.escape(key)}:\s*(.+?)\s*$',
                   cff,
@@ -143,3 +141,6 @@ jobs:
 
       - name: Validate generated U1 residual reconciliation
         run: python scripts/generate_u1_residual_reconciliation.py --check
+
+      - name: Validate SEMB03 holdout integrity
+        run: python scripts/validate_semb03_holdout_integrity.py

--- a/.github/workflows/sample-semb03-human-reference.yml
+++ b/.github/workflows/sample-semb03-human-reference.yml
@@ -1,47 +1,55 @@
-name: sample-semb03-human-reference
+name: Audit SEMB03 holdout integrity
 
 on:
-  workflow_dispatch:
-  push:
+  pull_request:
+    branches: [main]
     paths:
       - '.github/workflows/sample-semb03-human-reference.yml'
+      - 'scripts/validate_semb03_holdout_integrity.py'
+      - 'scripts/prepare_semb03_private_holdout.py'
+      - 'scripts/lock_semb03_model.py'
       - 'scripts/sample_semb03_human_reference.py'
-      - 'data/derived/fragment_manifest.csv'
+      - 'data/validation/semb03_human_reference_sample.csv'
+      - 'data/validation/semb03_human_reference_annotation_template.csv'
+      - 'data/validation/semb03_holdout_integrity_status.json'
+      - 'data/validation/semb03_acceptance_criteria.json'
+      - 'data/validation/semb03_private_holdout_commitment.json'
+      - 'data/validation/semb03_model_lock.json'
+      - 'data/validation/semb03_locked_validation_result.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/sample-semb03-human-reference.yml'
+      - 'scripts/validate_semb03_holdout_integrity.py'
+      - 'scripts/prepare_semb03_private_holdout.py'
+      - 'scripts/lock_semb03_model.py'
+      - 'scripts/sample_semb03_human_reference.py'
+      - 'data/validation/semb03_human_reference_sample.csv'
+      - 'data/validation/semb03_human_reference_annotation_template.csv'
+      - 'data/validation/semb03_holdout_integrity_status.json'
+      - 'data/validation/semb03_acceptance_criteria.json'
+      - 'data/validation/semb03_private_holdout_commitment.json'
+      - 'data/validation/semb03_model_lock.json'
+      - 'data/validation/semb03_locked_validation_result.json'
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  sample:
+  integrity:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Build deterministic human-reference sample
-        run: python3 scripts/sample_semb03_human_reference.py
-      - name: Verify sample invariants
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate SEMB03 holdout integrity
+        run: python3 scripts/validate_semb03_holdout_integrity.py
+
+      - name: Verify legacy sampler is not a routine generation path
         run: |
-          python3 - <<'PY'
-          import csv
-          from collections import Counter
-          p='data/validation/semb03_human_reference_sample.csv'
-          r=list(csv.DictReader(open(p,encoding='utf-8')))
-          assert len(r)==480
-          assert len({x['fragment_id'] for x in r})==480
-          assert Counter(x['catalog_generation'] for x in r)==Counter({'1972':120,'1988':120,'1993':120,'2014':120})
-          assert Counter(x['analysis_role'] for x in r)==Counter({'development':320,'locked_validation':160})
-          print('verified',len(r))
-          PY
-      - name: Publish sample manifests
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add data/validation/semb03_human_reference_sample.csv \
-                  data/validation/semb03_human_reference_annotation_template.csv
-          if git diff --cached --quiet; then
-            echo 'No sample changes to publish.'
-          else
-            git commit -m 'Publish SEMB 0.3 human reference sample'
-            git push
+          if python3 scripts/sample_semb03_human_reference.py; then
+            echo 'Legacy sampler unexpectedly ran without explicit audit flag.' >&2
+            exit 1
           fi
+          echo 'Legacy public sampler correctly refuses routine execution.'

--- a/data/validation/semb03_holdout_integrity_status.json
+++ b/data/validation/semb03_holdout_integrity_status.json
@@ -1,0 +1,36 @@
+{
+  "integrity_version": "SEMB03_HOLDOUT_INTEGRITY_0.1",
+  "audited_on": "2026-08-27",
+  "legacy_public_sample": {
+    "path": "data/validation/semb03_human_reference_sample.csv",
+    "sample_version": "SEMB03_SAMPLE_0.2",
+    "row_count": 480,
+    "development_rows": 320,
+    "nominal_locked_validation_rows": 160,
+    "current_git_blob_sha": "341493f60779a5fc355235ed0f05aeb576faa96a",
+    "first_public_commit": "ea5a2c2f2da2c245d1ddbedf418732e9f640dfb8",
+    "first_public_at_utc": "2026-08-15T19:38:38Z",
+    "final_validation_admissibility": "invalidated_by_prelock_public_exposure",
+    "permitted_future_role": "development_or_exposed_robustness_audit_only",
+    "public_human_labels_detected": false
+  },
+  "model_lock": {
+    "required_before_final_validation": true,
+    "legacy_subset_may_not_be_rehabilitated_by_retroactive_lock": true,
+    "current_committed_lock_present_at_audit": false
+  },
+  "replacement_private_holdout": {
+    "required": true,
+    "n": 160,
+    "per_generation": 40,
+    "source_pool_must_exclude_all_legacy_480": true,
+    "fragment_ids_must_not_be_committed_before_evaluation": true,
+    "private_storage_prefix": "private/",
+    "public_commitment_path": "data/validation/semb03_private_holdout_commitment.json",
+    "commitment_must_precede_model_lock": true
+  },
+  "semantic_coverage_effect": {
+    "human_reference_labels_created_by_this_audit": 0,
+    "u1_human_semantic_coverage_changed": false
+  }
+}

--- a/docs/SEMB03_HOLDOUT_INTEGRITY_0_1.md
+++ b/docs/SEMB03_HOLDOUT_INTEGRITY_0_1.md
@@ -1,0 +1,40 @@
+# SEMB 0.3 — integridad del holdout y remediación 0.1
+
+Fecha de auditoría: 2026-08-27.
+
+## Hallazgo
+
+La muestra pública `data/validation/semb03_human_reference_sample.csv` contiene 480 fragmentos: 320 marcados `development` y 160 marcados `locked_validation`. Los 160 identificadores nominalmente reservados quedaron visibles en el historial público antes de que existiera el mecanismo de `model lock`.
+
+La primera publicación identificada de una muestra que exponía `fragment_id` y `analysis_role=locked_validation` es el commit `ea5a2c2f2da2c245d1ddbedf418732e9f640dfb8`, fechado 2026-08-15T19:38:38Z. La utilidad de lock irreversible apareció después, en `491b8663688765f2a70d4f9a4a71544f5c474653`, fechado 2026-08-15T19:51:18Z. Al momento de esta auditoría no existe `data/validation/semb03_model_lock.json` en `main`.
+
+No se detectaron etiquetas humanas publicadas en la plantilla de anotación: los campos `annotator_id`, `annotation_round`, `actionable`, `action_labels`, `position_labels`, `annotation_confidence` y `ambiguity_note` permanecen vacíos. La incidencia, por tanto, no es una filtración de respuestas humanas; es una pérdida de independencia del conjunto nominalmente reservado.
+
+## Decisión metodológica
+
+Los 160 casos públicos previamente denominados `locked_validation` quedan **invalidados para cualquier afirmación futura de validación final ciega o verdaderamente held-out**. No se borran del historial y no se reetiquetan retroactivamente para ocultar el incidente. Pueden utilizarse únicamente como material de desarrollo o como auditoría de robustez explícitamente descrita como expuesta.
+
+Un `model lock` creado después de esta exposición no puede rehabilitar esos 160 casos. La validación final de SEMB 0.3 requerirá un nuevo holdout privado de 160 fragmentos, 40 por generación, seleccionado sin consultar salidas semánticas del clasificador y excluyendo las 480 identidades de la muestra pública histórica.
+
+## Nuevo contrato de holdout
+
+El nuevo holdout se genera localmente con `scripts/prepare_semb03_private_holdout.py`. El script usa exclusivamente metadatos del `fragment_manifest.csv`, una semilla criptográfica privada almacenada bajo `private/` y un algoritmo congelado. La ruta `private/` ya está excluida por `.gitignore`.
+
+El manifiesto que contiene `fragment_id` se guarda sólo bajo `private/` y **no debe entrar en Git**. El repositorio público puede recibir únicamente `data/validation/semb03_private_holdout_commitment.json`, que registra tamaño, distribución, versión del algoritmo y SHA-256 del manifiesto privado. Ese hash permite demostrar posteriormente que el conjunto evaluado coincide con el conjunto fijado antes del `model lock` sin revelar sus identidades durante el desarrollo.
+
+El compromiso público debe existir antes de crear `semb03_model_lock.json`. La utilidad de lock se endurece para rechazar: a) un lock sin compromiso privado; b) un compromiso que publique IDs; c) un holdout que no excluya las 480 identidades públicas; d) un lock retroactivo después de un resultado de validación.
+
+## Flujo correcto a partir de esta versión
+
+1. Completar la referencia humana de desarrollo y la fiabilidad intercodificador sin utilizar el futuro holdout privado para ajuste.
+2. Crear fuera de Git la semilla y el manifiesto del nuevo holdout de 160 casos.
+3. Versionar únicamente el compromiso criptográfico público.
+4. Congelar código, configuración, resultado de desarrollo, criterios de aceptación y compromiso mediante `scripts/lock_semb03_model.py`.
+5. Sólo después del lock abrir el manifiesto privado a la evaluación final.
+6. Publicar resultados agregados y, si metodológicamente conviene, revelar el manifiesto únicamente después de cerrada la evaluación.
+
+## Efecto sobre el estado científico
+
+Esta corrección no crea etiquetas humanas ni modifica la cobertura semántica U1. El valor sigue siendo **0/542** hasta que exista referencia humana efectivamente producida, validada e incorporada conforme al protocolo. Tampoco cambia la cobertura técnica 524/542.
+
+La regla conservadora es deliberada: una validación final con un holdout comprometido vale menos que reconocer la exposición y sustituirlo antes de hacer afirmaciones de desempeño.

--- a/docs/SEMB03_HOLDOUT_INTEGRITY_SOURCE_BINDING.md
+++ b/docs/SEMB03_HOLDOUT_INTEGRITY_SOURCE_BINDING.md
@@ -1,0 +1,11 @@
+# SEMB 0.3 — nota de enlace criptográfico del holdout
+
+Esta nota complementa `SEMB03_HOLDOUT_INTEGRITY_0_1.md` sin modificar su registro histórico.
+
+El reemplazo privado del holdout debe quedar ligado no sólo al SHA-256 del manifiesto privado, sino también al universo exacto del que se seleccionó. `scripts/prepare_semb03_private_holdout.py` registra en el compromiso público tanto el SHA-256 de `data/derived/fragment_manifest.csv` como su Git blob SHA. Ninguno de estos campos revela los 160 `fragment_id` privados.
+
+`semb03_model_lock.json` sólo puede crearse cuando existe un compromiso válido de 160 casos, 40 por generación, que excluye las 480 identidades de la muestra pública histórica, declara `ids_public=false` y contiene hashes válidos del manifiesto privado y del manifiesto fuente.
+
+El workflow `sample-semb03-human-reference.yml` deja de publicar muestras y funciona como auditoría de sólo lectura. El antiguo generador público exige `--legacy-audit-rebuild`; su única función futura es reproducir el artefacto histórico expuesto, nunca generar una validación final.
+
+Esta remediación no crea referencia humana ni cambia cobertura semántica: U1 permanece en 0/542 hasta que el protocolo humano se ejecute y valide.

--- a/scripts/lock_semb03_model.py
+++ b/scripts/lock_semb03_model.py
@@ -1,53 +1,124 @@
 #!/usr/bin/env python3
-"""Freeze a SEMB 0.3 candidate before locked validation is opened.
+"""Freeze a SEMB 0.3 candidate before private locked validation is opened.
 
 The lock records cryptographic hashes of the development result, configuration,
-executable code and preregistered acceptance criteria. It refuses to overwrite a
-lock or to run after a locked-validation result exists.
+executable code, preregistered acceptance criteria and the public cryptographic
+commitment to the replacement private holdout. It refuses retroactive locks and
+explicitly rejects the legacy public 160-case subset as final validation.
 """
 from __future__ import annotations
-import argparse,hashlib,json,subprocess
-from datetime import datetime,timezone
+
+import argparse
+import hashlib
+import json
+import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 
-OUT=Path('data/validation/semb03_model_lock.json')
-CRIT=Path('data/validation/semb03_acceptance_criteria.json')
-LOCKED_RESULT=Path('data/validation/semb03_locked_validation_result.json')
-VERSION='SEMB03_MODEL_LOCK_0.1'
+OUT = Path("data/validation/semb03_model_lock.json")
+CRIT = Path("data/validation/semb03_acceptance_criteria.json")
+COMMITMENT = Path("data/validation/semb03_private_holdout_commitment.json")
+INTEGRITY = Path("data/validation/semb03_holdout_integrity_status.json")
+LOCKED_RESULT = Path("data/validation/semb03_locked_validation_result.json")
+VERSION = "SEMB03_MODEL_LOCK_0.2"
 
-def sha(p):return hashlib.sha256(Path(p).read_bytes()).hexdigest()
 
-def git_head():
-    try:return subprocess.check_output(['git','rev-parse','HEAD'],text=True).strip()
-    except Exception:return None
+def sha(path: Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
-def main():
-    ap=argparse.ArgumentParser();ap.add_argument('--development-result',required=True);ap.add_argument('--config',required=True);ap.add_argument('--code',nargs='+',required=True);ap.add_argument('--model-name',required=True);ap.add_argument('--model-revision',required=True);args=ap.parse_args()
-    if OUT.exists():raise SystemExit('Model lock already exists; refusing overwrite')
-    if LOCKED_RESULT.exists():raise SystemExit('Locked validation result already exists; cannot create a retroactive lock')
-    dev=Path(args.development_result);cfg=Path(args.config)
-    for p in [dev,cfg,CRIT,*map(Path,args.code)]:
-        if not p.exists():raise SystemExit(f'missing lock input: {p}')
-    d=json.load(dev.open(encoding='utf-8'))
-    if int(d.get('development_n',-1))!=320:raise SystemExit('development_result must document development_n=320')
-    if d.get('locked_validation_accessed') is not False:raise SystemExit('development_result must assert locked_validation_accessed=false')
-    criteria=json.load(CRIT.open(encoding='utf-8'))
-    if criteria.get('criteria_version')!='SEMB03_ACCEPTANCE_0.1':raise SystemExit('unexpected acceptance criteria version')
-    lock={
-      'lock_version':VERSION,
-      'created_utc':datetime.now(timezone.utc).isoformat(),
-      'git_head':git_head(),
-      'model_name':args.model_name,'model_revision':args.model_revision,
-      'development_result':str(dev),'development_result_sha256':sha(dev),
-      'config':str(cfg),'config_sha256':sha(cfg),
-      'code_files':[{'path':str(Path(p)),'sha256':sha(p)} for p in args.code],
-      'acceptance_criteria':str(CRIT),'acceptance_criteria_sha256':sha(CRIT),
-      'acceptance_criteria_version':criteria['criteria_version'],
-      'locked_validation_accessed_before_lock':False,
-      'historical_outputs_used_for_selection':False,
+
+def git_head() -> str | None:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:
+        return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--development-result", required=True)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--code", nargs="+", required=True)
+    parser.add_argument("--model-name", required=True)
+    parser.add_argument("--model-revision", required=True)
+    args = parser.parse_args()
+
+    if OUT.exists():
+        raise SystemExit("Model lock already exists; refusing overwrite")
+    if LOCKED_RESULT.exists():
+        raise SystemExit("Locked validation result already exists; cannot create a retroactive lock")
+    if not COMMITMENT.exists():
+        raise SystemExit(
+            "Missing replacement private holdout commitment; prepare the private 160-case holdout "
+            "and commit only data/validation/semb03_private_holdout_commitment.json before model lock"
+        )
+    if not INTEGRITY.exists():
+        raise SystemExit("Missing holdout-integrity status; refusing un-audited model lock")
+
+    development = Path(args.development_result)
+    config = Path(args.config)
+    code_files = list(map(Path, args.code))
+    for path in [development, config, CRIT, COMMITMENT, INTEGRITY, *code_files]:
+        if not path.exists():
+            raise SystemExit(f"missing lock input: {path}")
+
+    dev = json.loads(development.read_text(encoding="utf-8"))
+    if int(dev.get("development_n", -1)) != 320:
+        raise SystemExit("development_result must document development_n=320")
+    if dev.get("locked_validation_accessed") is not False:
+        raise SystemExit("development_result must assert locked_validation_accessed=false")
+
+    criteria = json.loads(CRIT.read_text(encoding="utf-8"))
+    if criteria.get("criteria_version") != "SEMB03_ACCEPTANCE_0.1":
+        raise SystemExit("unexpected acceptance criteria version")
+
+    integrity = json.loads(INTEGRITY.read_text(encoding="utf-8"))
+    legacy = integrity.get("legacy_public_sample", {})
+    if legacy.get("final_validation_admissibility") != "invalidated_by_prelock_public_exposure":
+        raise SystemExit("integrity status does not invalidate the legacy public holdout")
+
+    commitment = json.loads(COMMITMENT.read_text(encoding="utf-8"))
+    if commitment.get("commitment_version") != "SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1":
+        raise SystemExit("unexpected private holdout commitment version")
+    if commitment.get("holdout_n") != 160:
+        raise SystemExit("private holdout commitment must document holdout_n=160")
+    if commitment.get("per_generation") != {"1972": 40, "1988": 40, "1993": 40, "2014": 40}:
+        raise SystemExit("private holdout commitment must document 40 cases per generation")
+    if commitment.get("legacy_sample_excluded") is not True:
+        raise SystemExit("private holdout must exclude all 480 legacy public identities")
+    if commitment.get("ids_public") is not False:
+        raise SystemExit("private holdout commitment must assert ids_public=false")
+    manifest_digest = str(commitment.get("private_manifest_sha256", ""))
+    if len(manifest_digest) != 64:
+        raise SystemExit("private holdout commitment lacks a valid manifest SHA-256")
+
+    lock = {
+        "lock_version": VERSION,
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "git_head": git_head(),
+        "model_name": args.model_name,
+        "model_revision": args.model_revision,
+        "development_result": str(development),
+        "development_result_sha256": sha(development),
+        "config": str(config),
+        "config_sha256": sha(config),
+        "code_files": [{"path": str(path), "sha256": sha(path)} for path in code_files],
+        "acceptance_criteria": str(CRIT),
+        "acceptance_criteria_sha256": sha(CRIT),
+        "acceptance_criteria_version": criteria["criteria_version"],
+        "holdout_integrity_status": str(INTEGRITY),
+        "holdout_integrity_status_sha256": sha(INTEGRITY),
+        "private_holdout_commitment": str(COMMITMENT),
+        "private_holdout_commitment_sha256": sha(COMMITMENT),
+        "private_holdout_manifest_sha256": manifest_digest,
+        "legacy_public_holdout_admissible": False,
+        "locked_validation_accessed_before_lock": False,
+        "historical_outputs_used_for_selection": False
     }
-    OUT.parent.mkdir(parents=True,exist_ok=True)
-    json.dump(lock,OUT.open('w',encoding='utf-8'),ensure_ascii=False,indent=2)
-    print(json.dumps(lock,ensure_ascii=False,indent=2))
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    OUT.write_text(json.dumps(lock, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(lock, ensure_ascii=False, indent=2))
 
-if __name__=='__main__':main()
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lock_semb03_model.py
+++ b/scripts/lock_semb03_model.py
@@ -27,6 +27,10 @@ def sha(path: Path) -> str:
     return hashlib.sha256(Path(path).read_bytes()).hexdigest()
 
 
+def valid_hex(value: object, n: int) -> bool:
+    return isinstance(value, str) and len(value) == n and all(c in "0123456789abcdef" for c in value.lower())
+
+
 def git_head() -> str | None:
     try:
         return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
@@ -88,9 +92,15 @@ def main() -> None:
         raise SystemExit("private holdout must exclude all 480 legacy public identities")
     if commitment.get("ids_public") is not False:
         raise SystemExit("private holdout commitment must assert ids_public=false")
-    manifest_digest = str(commitment.get("private_manifest_sha256", ""))
-    if len(manifest_digest) != 64:
+    manifest_digest = commitment.get("private_manifest_sha256")
+    source_manifest_digest = commitment.get("source_manifest_sha256")
+    source_manifest_blob = commitment.get("source_manifest_git_blob_sha")
+    if not valid_hex(manifest_digest, 64):
         raise SystemExit("private holdout commitment lacks a valid manifest SHA-256")
+    if not valid_hex(source_manifest_digest, 64):
+        raise SystemExit("private holdout commitment lacks a valid source-manifest SHA-256")
+    if not valid_hex(source_manifest_blob, 40):
+        raise SystemExit("private holdout commitment lacks a valid source-manifest Git blob SHA")
 
     lock = {
         "lock_version": VERSION,
@@ -111,6 +121,8 @@ def main() -> None:
         "private_holdout_commitment": str(COMMITMENT),
         "private_holdout_commitment_sha256": sha(COMMITMENT),
         "private_holdout_manifest_sha256": manifest_digest,
+        "source_fragment_manifest_sha256": source_manifest_digest,
+        "source_fragment_manifest_git_blob_sha": source_manifest_blob,
         "legacy_public_holdout_admissible": False,
         "locked_validation_accessed_before_lock": False,
         "historical_outputs_used_for_selection": False

--- a/scripts/prepare_semb03_private_holdout.py
+++ b/scripts/prepare_semb03_private_holdout.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Prepare a replacement SEMB 0.3 holdout without publishing its identities.
+
+The 160 nominal validation identities in SEMB03_SAMPLE_0.2 were exposed in the
+public Git history before model lock. This utility creates a fresh private
+holdout from manifest metadata only, excluding all 480 legacy sample identities.
+
+Private outputs live under private/ (gitignored). The only public-safe output is
+a cryptographic commitment JSON containing no sample or fragment identifiers.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import hmac
+import json
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "data/derived/fragment_manifest.csv"
+LEGACY = ROOT / "data/validation/semb03_human_reference_sample.csv"
+DEFAULT_SEED = ROOT / "private/semb03/holdout_seed.bin"
+DEFAULT_PRIVATE = ROOT / "private/semb03/holdout_manifest.csv"
+DEFAULT_COMMITMENT = ROOT / "data/validation/semb03_private_holdout_commitment.json"
+VERSION = "SEMB03_PRIVATE_HOLDOUT_0.1"
+GENERATIONS = ("1972", "1988", "1993", "2014")
+RARE = {"activity_candidate", "experiment_candidate", "project_candidate", "assessment_candidate"}
+
+
+def eligible(row: dict[str, str]) -> bool:
+    return row["candidate_type"] != "heading_candidate" and int(row["token_count"]) >= 4
+
+
+def score(seed: bytes, label: str, fragment_id: str) -> bytes:
+    return hmac.new(seed, f"{VERSION}|{label}|{fragment_id}".encode(), hashlib.sha256).digest()
+
+
+def pick(pool: list[dict[str, str]], n: int, seed: bytes, label: str, used: set[str]) -> list[dict[str, str]]:
+    candidates = [r for r in pool if r["fragment_id"] not in used]
+    candidates.sort(key=lambda r: score(seed, label, r["fragment_id"]))
+    if len(candidates) < n:
+        raise SystemExit(f"insufficient eligible pool for {label}: requested {n}, have {len(candidates)}")
+    selected = candidates[:n]
+    used.update(r["fragment_id"] for r in selected)
+    return selected
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def init_seed(path: Path) -> None:
+    if path.exists():
+        raise SystemExit(f"refusing to overwrite existing private seed: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(secrets.token_bytes(32))
+    print(f"created private seed at {path}; do not commit or print its contents")
+
+
+def build(seed_path: Path, private_path: Path, commitment_path: Path) -> None:
+    seed = seed_path.read_bytes()
+    if len(seed) < 32:
+        raise SystemExit("private seed must contain at least 32 bytes")
+
+    rows = list(csv.DictReader(MANIFEST.open(encoding="utf-8")))
+    legacy = list(csv.DictReader(LEGACY.open(encoding="utf-8")))
+    if len(legacy) != 480:
+        raise SystemExit("expected the auditable 480-row legacy public sample")
+    legacy_ids = {r["fragment_id"] for r in legacy}
+    if len(legacy_ids) != 480:
+        raise SystemExit("legacy public sample contains duplicate fragment IDs")
+
+    selected: list[dict[str, str]] = []
+    for generation in GENERATIONS:
+        pool = [
+            r for r in rows
+            if r["catalog_generation"] == generation
+            and r["fragment_id"] not in legacy_ids
+            and eligible(r)
+        ]
+        used: set[str] = set()
+        candidate = []
+        # Preserve broad candidate-type coverage without consulting semantic outputs.
+        candidate += pick([r for r in pool if r["candidate_type"] == "expository_candidate"], 25, seed, f"{generation}:expository", used)
+        candidate += pick([r for r in pool if r["candidate_type"] == "instruction_candidate"], 25, seed, f"{generation}:instruction", used)
+        candidate += pick([r for r in pool if r["candidate_type"] == "question_candidate"], 25, seed, f"{generation}:question", used)
+        candidate += pick([r for r in pool if r["candidate_type"] in RARE], 20, seed, f"{generation}:rare", used)
+        candidate += pick(pool, 25, seed, f"{generation}:remainder", used)
+        # Select 40 privately from the 120 metadata-balanced candidates.
+        candidate.sort(key=lambda r: score(seed, f"{generation}:final40", r["fragment_id"]))
+        chosen = candidate[:40]
+        if len(chosen) != 40 or len({r["fragment_id"] for r in chosen}) != 40:
+            raise SystemExit(f"failed to select 40 unique rows for generation {generation}")
+        selected.extend(chosen)
+
+    ids = {r["fragment_id"] for r in selected}
+    if len(selected) != 160 or len(ids) != 160:
+        raise SystemExit("replacement holdout must contain 160 unique identities")
+    if ids & legacy_ids:
+        raise SystemExit("replacement holdout overlaps legacy public sample")
+
+    private_path.parent.mkdir(parents=True, exist_ok=True)
+    fields = [
+        "holdout_version", "private_sample_id", "fragment_id", "page_id",
+        "catalog_generation", "candidate_type", "token_count", "char_count", "text_sha256",
+    ]
+    with private_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        for row in sorted(selected, key=lambda r: score(seed, "private-order", r["fragment_id"])):
+            opaque = hmac.new(seed, f"opaque|{row['fragment_id']}".encode(), hashlib.sha256).hexdigest()[:20].upper()
+            writer.writerow({
+                "holdout_version": VERSION,
+                "private_sample_id": f"S03H-{opaque}",
+                "fragment_id": row["fragment_id"],
+                "page_id": row["page_id"],
+                "catalog_generation": row["catalog_generation"],
+                "candidate_type": row["candidate_type"],
+                "token_count": row["token_count"],
+                "char_count": row["char_count"],
+                "text_sha256": row["text_sha256"],
+            })
+
+    private_bytes = private_path.read_bytes()
+    counts = {g: sum(1 for r in selected if r["catalog_generation"] == g) for g in GENERATIONS}
+    commitment = {
+        "commitment_version": "SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1",
+        "created_utc": datetime.now(timezone.utc).isoformat(),
+        "selection_algorithm_version": VERSION,
+        "holdout_n": 160,
+        "per_generation": counts,
+        "legacy_sample_excluded": True,
+        "ids_public": False,
+        "private_manifest_sha256": sha256_bytes(private_bytes),
+        "private_manifest_bytes": len(private_bytes),
+        "source_manifest_git_blob_sha": None,
+        "notes": "Commit this JSON only. Keep seed and private manifest outside Git until final evaluation is closed.",
+    }
+    commitment_path.parent.mkdir(parents=True, exist_ok=True)
+    commitment_path.write_text(json.dumps(commitment, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"private holdout: {private_path} (160 IDs, not for Git)")
+    print(f"public-safe commitment: {commitment_path}")
+    print("legacy overlap: 0")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--seed-file", type=Path, default=DEFAULT_SEED)
+    parser.add_argument("--private-output", type=Path, default=DEFAULT_PRIVATE)
+    parser.add_argument("--commitment-output", type=Path, default=DEFAULT_COMMITMENT)
+    parser.add_argument("--init-seed", action="store_true", help="create a new 32-byte private seed and exit")
+    args = parser.parse_args()
+    if args.init_seed:
+        init_seed(args.seed_file)
+        return
+    if not args.seed_file.exists():
+        raise SystemExit(f"missing private seed {args.seed_file}; run once with --init-seed")
+    build(args.seed_file, args.private_output, args.commitment_output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/prepare_semb03_private_holdout.py
+++ b/scripts/prepare_semb03_private_holdout.py
@@ -16,6 +16,7 @@ import hashlib
 import hmac
 import json
 import secrets
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -52,6 +53,19 @@ def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
 
+def git_blob_sha(path: Path) -> str:
+    """Return Git's content-addressed blob SHA for the exact source manifest bytes."""
+    try:
+        value = subprocess.check_output(
+            ["git", "hash-object", str(path)], cwd=ROOT, text=True
+        ).strip().lower()
+    except Exception as exc:
+        raise SystemExit(f"cannot derive Git blob SHA for source manifest: {exc}") from exc
+    if len(value) != 40 or any(c not in "0123456789abcdef" for c in value):
+        raise SystemExit("unexpected Git blob SHA returned for source manifest")
+    return value
+
+
 def init_seed(path: Path) -> None:
     if path.exists():
         raise SystemExit(f"refusing to overwrite existing private seed: {path}")
@@ -65,6 +79,7 @@ def build(seed_path: Path, private_path: Path, commitment_path: Path) -> None:
     if len(seed) < 32:
         raise SystemExit("private seed must contain at least 32 bytes")
 
+    manifest_bytes = MANIFEST.read_bytes()
     rows = list(csv.DictReader(MANIFEST.open(encoding="utf-8")))
     legacy = list(csv.DictReader(LEGACY.open(encoding="utf-8")))
     if len(legacy) != 480:
@@ -136,7 +151,8 @@ def build(seed_path: Path, private_path: Path, commitment_path: Path) -> None:
         "ids_public": False,
         "private_manifest_sha256": sha256_bytes(private_bytes),
         "private_manifest_bytes": len(private_bytes),
-        "source_manifest_git_blob_sha": None,
+        "source_manifest_sha256": sha256_bytes(manifest_bytes),
+        "source_manifest_git_blob_sha": git_blob_sha(MANIFEST),
         "notes": "Commit this JSON only. Keep seed and private manifest outside Git until final evaluation is closed.",
     }
     commitment_path.parent.mkdir(parents=True, exist_ok=True)
@@ -144,6 +160,7 @@ def build(seed_path: Path, private_path: Path, commitment_path: Path) -> None:
     print(f"private holdout: {private_path} (160 IDs, not for Git)")
     print(f"public-safe commitment: {commitment_path}")
     print("legacy overlap: 0")
+    print(f"source manifest blob: {commitment['source_manifest_git_blob_sha']}")
 
 
 def main() -> None:

--- a/scripts/sample_semb03_human_reference.py
+++ b/scripts/sample_semb03_human_reference.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
-"""Create the preregistered SEMB 0.3 human-reference sample from FRAGSEG metadata only.
+"""Rebuild the legacy public SEMB 0.3 human-reference sample for audit only.
 
-Scientific invariant: this script must never read semantic classifier outputs or
+The SEMB03_SAMPLE_0.2 split was published before model lock, so its 160 rows
+labelled ``locked_validation`` are no longer admissible as a blind final holdout.
+This script is retained only to reproduce that historical artifact. It must not
+be used to create a final validation set. For the replacement holdout use
+``scripts/prepare_semb03_private_holdout.py``.
+
+Scientific invariant: this script never reads semantic classifier outputs or
 historical comparison files. Selection is deterministic from manifest metadata
-and fragment_id hashes. Annotator-facing IDs are opaque: they disclose neither
-generation nor development/validation role.
+and fragment_id hashes.
 """
 from __future__ import annotations
 
+import argparse
 import csv
 import hashlib
 from pathlib import Path
@@ -39,11 +45,10 @@ def pick(rows,n,salt,used):
 
 
 def opaque_sample_id(fragment_id):
-    # 16 hex chars are ample for 480 deterministic IDs and reveal no generation.
     return 'S03-'+h(fragment_id,VERSION+':opaque')[:16].upper()
 
 
-def main():
+def rebuild_legacy_artifact():
     rows=list(csv.DictReader(MANIFEST.open(encoding='utf-8')))
     assert len(rows)==9594
     sample=[]
@@ -78,8 +83,6 @@ def main():
     with OUT.open('w',encoding='utf-8',newline='') as f:
         w=csv.DictWriter(f,fieldnames=fields);w.writeheader();w.writerows(sample)
 
-    # Annotator-facing template deliberately omits generation, page, candidate type,
-    # token/character counts and development/validation role.
     afields=['sample_id','annotator_id','annotation_round','actionable','action_labels',
              'position_labels','annotation_confidence','ambiguity_note']
     with ANNOT.open('w',encoding='utf-8',newline='') as f:
@@ -88,7 +91,24 @@ def main():
             w.writerow({'sample_id':r['sample_id'],'annotator_id':'','annotation_round':'',
                         'actionable':'','action_labels':'','position_labels':'',
                         'annotation_confidence':'','ambiguity_note':''})
-    print('sample',len(sample),'development',sum(r['analysis_role']=='development' for r in sample),
-          'locked_validation',sum(r['analysis_role']=='locked_validation' for r in sample))
+    print('legacy audit sample rebuilt:',len(sample),'development',sum(r['analysis_role']=='development' for r in sample),
+          'nominal_locked_validation_exposed',sum(r['analysis_role']=='locked_validation' for r in sample))
+
+
+def main():
+    parser=argparse.ArgumentParser()
+    parser.add_argument(
+        '--legacy-audit-rebuild', action='store_true',
+        help='explicitly reproduce the already-public historical 480-row artifact; never creates a valid final holdout',
+    )
+    args=parser.parse_args()
+    if not args.legacy_audit_rebuild:
+        raise SystemExit(
+            'Refusing routine public sample generation: SEMB03_SAMPLE_0.2 contains an exposed nominal holdout. '
+            'Use scripts/prepare_semb03_private_holdout.py for future final validation, or pass '
+            '--legacy-audit-rebuild only to reproduce the historical artifact.'
+        )
+    rebuild_legacy_artifact()
+
 
 if __name__=='__main__': main()

--- a/scripts/validate_semb03_holdout_integrity.py
+++ b/scripts/validate_semb03_holdout_integrity.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate SEMB 0.3 holdout-integrity invariants.
+
+This validator makes the 2026-08-27 remediation machine-readable. It does not
+create labels, open a private holdout, or alter scientific coverage.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS = ROOT / "data/validation/semb03_holdout_integrity_status.json"
+SAMPLE = ROOT / "data/validation/semb03_human_reference_sample.csv"
+ANNOT = ROOT / "data/validation/semb03_human_reference_annotation_template.csv"
+COMMITMENT = ROOT / "data/validation/semb03_private_holdout_commitment.json"
+LOCK = ROOT / "data/validation/semb03_model_lock.json"
+LOCKED_RESULT = ROOT / "data/validation/semb03_locked_validation_result.json"
+
+
+def fail(msg: str) -> None:
+    raise SystemExit(f"SEMB03 holdout integrity: FAIL — {msg}")
+
+
+def main() -> None:
+    if not STATUS.exists():
+        fail("missing integrity status")
+    status = json.loads(STATUS.read_text(encoding="utf-8"))
+    if status.get("integrity_version") != "SEMB03_HOLDOUT_INTEGRITY_0.1":
+        fail("unexpected integrity status version")
+
+    legacy = status["legacy_public_sample"]
+    replacement = status["replacement_private_holdout"]
+    if legacy.get("final_validation_admissibility") != "invalidated_by_prelock_public_exposure":
+        fail("legacy public holdout must remain invalid for final validation")
+    if legacy.get("nominal_locked_validation_rows") != 160:
+        fail("legacy status must document 160 exposed nominal validation rows")
+    if replacement.get("n") != 160 or replacement.get("per_generation") != 40:
+        fail("replacement holdout must be fixed at 160 = 40 per generation")
+    if replacement.get("source_pool_must_exclude_all_legacy_480") is not True:
+        fail("replacement must exclude all 480 legacy public sample identities")
+    if replacement.get("fragment_ids_must_not_be_committed_before_evaluation") is not True:
+        fail("replacement IDs must remain outside Git before evaluation")
+
+    rows = list(csv.DictReader(SAMPLE.open(encoding="utf-8")))
+    if len(rows) != 480 or len({r["fragment_id"] for r in rows}) != 480:
+        fail("legacy public sample must remain an auditable 480-row unique historical artifact")
+    counts = Counter(r["analysis_role"] for r in rows)
+    if counts != Counter({"development": 320, "locked_validation": 160}):
+        fail(f"unexpected legacy role counts: {dict(counts)}")
+
+    ann = list(csv.DictReader(ANNOT.open(encoding="utf-8")))
+    if len(ann) != 480:
+        fail("legacy annotation template must retain 480 rows for historical auditability")
+    human_fields = [
+        "annotator_id", "annotation_round", "actionable", "action_labels",
+        "position_labels", "annotation_confidence", "ambiguity_note",
+    ]
+    leaked = [
+        (i + 2, field)
+        for i, row in enumerate(ann)
+        for field in human_fields
+        if (row.get(field) or "").strip()
+    ]
+    if leaked:
+        fail(f"public human annotation values detected, first={leaked[0]}")
+
+    if LOCKED_RESULT.exists() and not LOCK.exists():
+        fail("locked validation result exists without a prior model lock")
+
+    if COMMITMENT.exists():
+        commitment = json.loads(COMMITMENT.read_text(encoding="utf-8"))
+        allowed_keys = {
+            "commitment_version", "created_utc", "selection_algorithm_version",
+            "holdout_n", "per_generation", "legacy_sample_excluded",
+            "ids_public", "private_manifest_sha256", "private_manifest_bytes",
+            "source_manifest_git_blob_sha", "notes",
+        }
+        extra = set(commitment) - allowed_keys
+        if extra:
+            fail(f"public commitment contains unsupported fields: {sorted(extra)}")
+        if commitment.get("holdout_n") != 160:
+            fail("private holdout commitment must document holdout_n=160")
+        pg = commitment.get("per_generation")
+        if pg != {"1972": 40, "1988": 40, "1993": 40, "2014": 40}:
+            fail("private holdout commitment must document 40 cases per generation")
+        if commitment.get("legacy_sample_excluded") is not True:
+            fail("commitment must assert exclusion of all 480 legacy identities")
+        if commitment.get("ids_public") is not False:
+            fail("commitment must assert ids_public=false")
+        digest = commitment.get("private_manifest_sha256", "")
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest.lower()):
+            fail("invalid private manifest SHA-256 commitment")
+
+    if LOCK.exists():
+        if not COMMITMENT.exists():
+            fail("model lock exists without private holdout commitment")
+        lock = json.loads(LOCK.read_text(encoding="utf-8"))
+        if "private_holdout_commitment_sha256" not in lock:
+            fail("model lock does not bind the private holdout commitment")
+        if lock.get("legacy_public_holdout_admissible") is not False:
+            fail("model lock must explicitly reject the legacy public holdout")
+
+    print("SEMB03 holdout integrity: OK")
+    print("legacy nominal holdout: exposed / inadmissible for final validation")
+    print("public human labels detected: 0")
+    print("replacement private holdout commitment:", "present" if COMMITMENT.exists() else "pending")
+    print("model lock:", "present" if LOCK.exists() else "pending")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_semb03_holdout_integrity.py
+++ b/scripts/validate_semb03_holdout_integrity.py
@@ -24,6 +24,12 @@ def fail(msg: str) -> None:
     raise SystemExit(f"SEMB03 holdout integrity: FAIL — {msg}")
 
 
+def valid_hex(value: object, n: int) -> bool:
+    if not isinstance(value, str) or len(value) != n:
+        return False
+    return all(c in "0123456789abcdef" for c in value.lower())
+
+
 def main() -> None:
     if not STATUS.exists():
         fail("missing integrity status")
@@ -76,11 +82,13 @@ def main() -> None:
             "commitment_version", "created_utc", "selection_algorithm_version",
             "holdout_n", "per_generation", "legacy_sample_excluded",
             "ids_public", "private_manifest_sha256", "private_manifest_bytes",
-            "source_manifest_git_blob_sha", "notes",
+            "source_manifest_sha256", "source_manifest_git_blob_sha", "notes",
         }
         extra = set(commitment) - allowed_keys
         if extra:
             fail(f"public commitment contains unsupported fields: {sorted(extra)}")
+        if commitment.get("commitment_version") != "SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1":
+            fail("unexpected private holdout commitment version")
         if commitment.get("holdout_n") != 160:
             fail("private holdout commitment must document holdout_n=160")
         pg = commitment.get("per_generation")
@@ -90,9 +98,14 @@ def main() -> None:
             fail("commitment must assert exclusion of all 480 legacy identities")
         if commitment.get("ids_public") is not False:
             fail("commitment must assert ids_public=false")
-        digest = commitment.get("private_manifest_sha256", "")
-        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest.lower()):
+        if not valid_hex(commitment.get("private_manifest_sha256"), 64):
             fail("invalid private manifest SHA-256 commitment")
+        if not isinstance(commitment.get("private_manifest_bytes"), int) or commitment["private_manifest_bytes"] <= 0:
+            fail("private manifest byte count must be a positive integer")
+        if not valid_hex(commitment.get("source_manifest_sha256"), 64):
+            fail("invalid source manifest SHA-256")
+        if not valid_hex(commitment.get("source_manifest_git_blob_sha"), 40):
+            fail("invalid source manifest Git blob SHA")
 
     if LOCK.exists():
         if not COMMITMENT.exists():


### PR DESCRIPTION
## Propósito

Corrige una vulnerabilidad metodológica detectada en SEMB 0.3: las 160 identidades nominalmente `locked_validation` de `SEMB03_SAMPLE_0.2` quedaron expuestas públicamente antes de existir un `model lock`, por lo que no deben usarse como holdout final ciego.

## Cambios

- documenta el incidente sin borrar ni reescribir el historial;
- conserva los 160 casos expuestos sólo como desarrollo/auditoría de robustez;
- añade `scripts/prepare_semb03_private_holdout.py` para seleccionar 160 casos nuevos (40 por generación), excluyendo las 480 identidades públicas;
- mantiene semilla e IDs nuevos bajo `private/` y permite publicar sólo un compromiso criptográfico sin identidades;
- liga el compromiso al SHA-256 y Git blob SHA del `fragment_manifest.csv` exacto usado como universo de selección;
- endurece `scripts/lock_semb03_model.py` a 0.2 para exigir el compromiso privado antes del lock y rechazar un lock retroactivo;
- convierte `scripts/sample_semb03_human_reference.py` en reconstrucción histórica sólo con `--legacy-audit-rebuild`;
- reemplaza el workflow de publicación automática por una auditoría read-only;
- añade `scripts/validate_semb03_holdout_integrity.py` al workflow específico y a `Scientific release preflight`.

## Invariantes

- no se crean etiquetas humanas;
- cobertura semántica U1 permanece 0/542;
- cobertura técnica U1 permanece 524/542;
- los 160 casos públicos antiguos no se rehabilitan como holdout final;
- cualquier futuro holdout final debe ser privado hasta después del model lock y quedar comprometido criptográficamente sin publicar IDs.