### PR TITLE
SEMB03: exigir holdout privado en evaluación final

### DIFF
--- a/.github/workflows/test-semb03-infrastructure.yml
+++ b/.github/workflows/test-semb03-infrastructure.yml
@@ -7,13 +7,43 @@ on:
       - '.github/workflows/test-semb03-infrastructure.yml'
       - 'scripts/validate_semb03_annotations.py'
       - 'scripts/build_semb03_consensus_draft.py'
+      - 'scripts/prepare_semb03_private_holdout.py'
+      - 'scripts/validate_semb03_holdout_integrity.py'
       - 'scripts/lock_semb03_model.py'
       - 'scripts/evaluate_semb03_locked_validation.py'
       - 'scripts/check_semb03_readiness.py'
       - 'scripts/selftest_semb03_infrastructure.py'
       - 'data/validation/semb03_human_reference_sample.csv'
+      - 'data/validation/semb03_human_reference_annotation_template.csv'
+      - 'data/validation/semb03_holdout_integrity_status.json'
+      - 'data/validation/semb03_private_holdout_commitment.json'
+      - 'data/validation/semb03_model_lock.json'
+      - 'data/validation/semb03_locked_validation_result.json'
       - 'data/validation/semb03_acceptance_criteria.json'
       - 'data/validation/semb03_candidate_grid.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/test-semb03-infrastructure.yml'
+      - 'scripts/validate_semb03_annotations.py'
+      - 'scripts/build_semb03_consensus_draft.py'
+      - 'scripts/prepare_semb03_private_holdout.py'
+      - 'scripts/validate_semb03_holdout_integrity.py'
+      - 'scripts/lock_semb03_model.py'
+      - 'scripts/evaluate_semb03_locked_validation.py'
+      - 'scripts/check_semb03_readiness.py'
+      - 'scripts/selftest_semb03_infrastructure.py'
+      - 'data/validation/semb03_human_reference_sample.csv'
+      - 'data/validation/semb03_human_reference_annotation_template.csv'
+      - 'data/validation/semb03_holdout_integrity_status.json'
+      - 'data/validation/semb03_private_holdout_commitment.json'
+      - 'data/validation/semb03_model_lock.json'
+      - 'data/validation/semb03_locked_validation_result.json'
+      - 'data/validation/semb03_acceptance_criteria.json'
+      - 'data/validation/semb03_candidate_grid.json'
+
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -25,10 +55,14 @@ jobs:
           python3 -m py_compile \
             scripts/validate_semb03_annotations.py \
             scripts/build_semb03_consensus_draft.py \
+            scripts/prepare_semb03_private_holdout.py \
+            scripts/validate_semb03_holdout_integrity.py \
             scripts/lock_semb03_model.py \
             scripts/evaluate_semb03_locked_validation.py \
             scripts/check_semb03_readiness.py \
             scripts/selftest_semb03_infrastructure.py
+      - name: Validate holdout-integrity invariants
+        run: python3 scripts/validate_semb03_holdout_integrity.py
       - name: Run fake-data stage-gate self-test
         run: python3 scripts/selftest_semb03_infrastructure.py
       - name: Run public readiness invariants

--- a/scripts/check_semb03_readiness.py
+++ b/scripts/check_semb03_readiness.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-"""Report SEMB 0.3 readiness without opening human or locked-validation data.
+"""Report SEMB 0.3 readiness without opening private holdout or human labels.
 
-Validates core preregistered manifests/blinding and reports the state of every
-pre-human evidence module. It deliberately does not inspect classifier A/B or
-historical comparison outputs as a model-selection signal.
+Validates preregistered manifests, blinding and the 2026-08-27 holdout-integrity
+remediation. It deliberately does not inspect classifier A/B or historical
+comparison outputs as a model-selection signal.
 """
 from __future__ import annotations
-import csv,json,re
+
+import csv
+import json
+import re
 from pathlib import Path
 
 SAMPLE=Path('data/validation/semb03_human_reference_sample.csv')
@@ -14,28 +17,37 @@ TEMPLATE=Path('data/validation/semb03_human_reference_annotation_template.csv')
 REL=Path('data/validation/semb03_reliability_subset.csv')
 CRIT=Path('data/validation/semb03_acceptance_criteria.json')
 GRID=Path('data/validation/semb03_candidate_grid.json')
+INTEGRITY=Path('data/validation/semb03_holdout_integrity_status.json')
+COMMITMENT=Path('data/validation/semb03_private_holdout_commitment.json')
+LOCK=Path('data/validation/semb03_model_lock.json')
 OUT_JSON=Path('data/derived/semb03_readiness_report.json')
 OUT_MD=Path('data/derived/semb03_readiness_report.md')
-VERSION='SEMB03_READINESS_0.3'
+VERSION='SEMB03_READINESS_0.4'
 
-def read_csv(p):
-    with p.open(encoding='utf-8',newline='') as f:return list(csv.DictReader(f))
+
+def read_csv(path):
+    with path.open(encoding='utf-8',newline='') as handle:
+        return list(csv.DictReader(handle))
+
 
 def main():
     checks=[]
     sample=read_csv(SAMPLE);template=read_csv(TEMPLATE);rel=read_csv(REL)
     criteria=json.load(CRIT.open(encoding='utf-8'));grid=json.load(GRID.open(encoding='utf-8'))
+    integrity=json.load(INTEGRITY.open(encoding='utf-8'))
+
     def ck(name,ok,detail):
         checks.append({'check':name,'status':'PASS' if ok else 'FAIL','detail':detail})
-        if not ok:raise AssertionError(f'{name}: {detail}')
+        if not ok:
+            raise AssertionError(f'{name}: {detail}')
 
-    ck('sample_n_480',len(sample)==480,f'n={len(sample)}')
-    ck('sample_unique_ids',len({r['sample_id'] for r in sample})==480,'sample_id unique')
-    ck('sample_unique_fragments',len({r['fragment_id'] for r in sample})==480,'fragment_id unique')
+    ck('legacy_sample_n_480',len(sample)==480,f'n={len(sample)}')
+    ck('legacy_sample_unique_ids',len({r['sample_id'] for r in sample})==480,'sample_id unique')
+    ck('legacy_sample_unique_fragments',len({r['fragment_id'] for r in sample})==480,'fragment_id unique')
     roles={x:sum(r['analysis_role']==x for r in sample) for x in ('development','locked_validation')}
-    ck('roles_320_160',roles=={'development':320,'locked_validation':160},str(roles))
+    ck('legacy_roles_320_160',roles=={'development':320,'locked_validation':160},str(roles))
     gens={g:sum(r['catalog_generation']==g for r in sample) for g in ('1972','1988','1993','2014')}
-    ck('generations_balanced',all(v==120 for v in gens.values()),str(gens))
+    ck('legacy_generations_balanced',all(v==120 for v in gens.values()),str(gens))
     tfields=set(template[0]) if template else set();forbidden={'catalog_generation','analysis_role','fragment_id','page_id','candidate_type','text_sha256'}
     ck('template_blinded_fields',not(tfields&forbidden),f'forbidden_present={sorted(tfields&forbidden)}')
     ck('template_n_480',len(template)==480,f'n={len(template)}')
@@ -47,6 +59,12 @@ def main():
     ck('criteria_frozen',criteria.get('criteria_version')=='SEMB03_ACCEPTANCE_0.1' and criteria.get('frozen_before_human_reference') is True,criteria.get('criteria_version','missing'))
     ck('candidate_grid_frozen',grid.get('candidate_grid_version')=='SEMB03_CANDIDATES_0.1' and grid.get('frozen_before_human_reference') is True,grid.get('candidate_grid_version','missing'))
     ck('development_grouped_by_page',grid.get('development_cv')=={'method':'GroupKFold','n_splits':5,'group':'page_id'},str(grid.get('development_cv')))
+
+    legacy_status=integrity.get('legacy_public_sample',{})
+    replacement=integrity.get('replacement_private_holdout',{})
+    ck('holdout_integrity_version',integrity.get('integrity_version')=='SEMB03_HOLDOUT_INTEGRITY_0.1',integrity.get('integrity_version','missing'))
+    ck('legacy_final_holdout_invalidated',legacy_status.get('final_validation_admissibility')=='invalidated_by_prelock_public_exposure',str(legacy_status.get('final_validation_admissibility')))
+    ck('replacement_holdout_contract',replacement.get('n')==160 and replacement.get('per_generation')==40 and replacement.get('source_pool_must_exclude_all_legacy_480') is True,'160 = 40/generation; legacy 480 excluded')
 
     prehuman={
       'uncertainty_diagnostic':'data/derived/semb02_uncertainty_diagnostic.md',
@@ -65,38 +83,90 @@ def main():
       'research_integrity_manifest':'data/derived/research_integrity_manifest.json',
       'synthetic_gate_candidate':'data/derived/semb03_gate_synthetic_development.json',
       'synthetic_label_head_candidate':'data/derived/semb03_label_heads_synthetic_development.json',
+      'holdout_integrity_status':'data/validation/semb03_holdout_integrity_status.json',
     }
-    prehuman_state={k:Path(v).exists() for k,v in prehuman.items()}
+    prehuman_state={key:Path(value).exists() for key,value in prehuman.items()}
 
     later={
       'human_reference_consensus':'private/semb03_human_reference_consensus.csv',
       'development_result':'data/validation/semb03_development_result.json',
+      'private_holdout_commitment':'data/validation/semb03_private_holdout_commitment.json',
       'model_lock':'data/validation/semb03_model_lock.json',
       'locked_validation_result':'data/validation/semb03_locked_validation_result.json',
       'production_manifest':'data/validation/semb03_production_manifest.json',
     }
-    later_state={k:Path(v).exists() for k,v in later.items()}
+    later_state={key:Path(value).exists() for key,value in later.items()}
+
     stage='WAITING_HUMAN_REFERENCE'
-    if later_state['human_reference_consensus']:stage='HUMAN_REFERENCE_PRESENT'
-    if later_state['development_result']:stage='DEVELOPMENT_COMPLETE'
-    if later_state['model_lock']:stage='MODEL_LOCKED'
-    if later_state['locked_validation_result']:stage='LOCKED_VALIDATION_COMPLETE'
-    if later_state['production_manifest']:stage='PRODUCTION_READY'
+    if later_state['human_reference_consensus']:
+        stage='HUMAN_REFERENCE_PRESENT'
+    if later_state['development_result']:
+        stage='DEVELOPMENT_COMPLETE'
+    if later_state['model_lock']:
+        stage='MODEL_LOCKED'
+    if later_state['locked_validation_result']:
+        stage='LOCKED_VALIDATION_COMPLETE'
+    if later_state['production_manifest']:
+        stage='PRODUCTION_READY'
+
+    commitment_valid=False
+    if COMMITMENT.exists():
+        commitment=json.load(COMMITMENT.open(encoding='utf-8'))
+        commitment_valid=(
+            commitment.get('commitment_version')=='SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1'
+            and commitment.get('holdout_n')==160
+            and commitment.get('per_generation')=={'1972':40,'1988':40,'1993':40,'2014':40}
+            and commitment.get('legacy_sample_excluded') is True
+            and commitment.get('ids_public') is False
+        )
+        ck('private_holdout_commitment_contract',commitment_valid,'160 committed private cases; IDs not public; legacy excluded')
+
+    lock_gate=False
+    if LOCK.exists():
+        lock=json.load(LOCK.open(encoding='utf-8'))
+        lock_gate=(
+            commitment_valid
+            and lock.get('lock_version')=='SEMB03_MODEL_LOCK_0.2'
+            and lock.get('legacy_public_holdout_admissible') is False
+            and lock.get('locked_validation_accessed_before_lock') is False
+            and bool(lock.get('private_holdout_commitment_sha256'))
+        )
+        ck('private_holdout_model_lock_gate',lock_gate,'lock 0.2 bound to replacement private holdout commitment')
+
     complete=sum(prehuman_state.values());total=len(prehuman_state)
-    report={'readiness_version':VERSION,'stage':stage,'infrastructure_checks':checks,'prehuman_modules':prehuman_state,
-            'prehuman_modules_present':complete,'prehuman_modules_total':total,'later_stage_artifacts':later_state,
-            'human_blocker':'A genuine human reference is required before validated model development.' if stage=='WAITING_HUMAN_REFERENCE' else None,
-            'safe_to_open_locked_validation':bool(later_state['model_lock'])}
-    OUT_JSON.parent.mkdir(parents=True,exist_ok=True);json.dump(report,OUT_JSON.open('w',encoding='utf-8'),ensure_ascii=False,indent=2)
+    safe_to_open=bool(lock_gate and not later_state['locked_validation_result'])
+    report={
+      'readiness_version':VERSION,
+      'stage':stage,
+      'infrastructure_checks':checks,
+      'prehuman_modules':prehuman_state,
+      'prehuman_modules_present':complete,
+      'prehuman_modules_total':total,
+      'later_stage_artifacts':later_state,
+      'legacy_public_locked_validation_admissible':False,
+      'final_holdout_protocol':'replacement_private_committed',
+      'private_holdout_commitment_valid':commitment_valid,
+      'human_blocker':'A genuine human reference is required before validated model development.' if stage=='WAITING_HUMAN_REFERENCE' else None,
+      'safe_to_open_locked_validation':safe_to_open,
+    }
+    OUT_JSON.parent.mkdir(parents=True,exist_ok=True)
+    json.dump(report,OUT_JSON.open('w',encoding='utf-8'),ensure_ascii=False,indent=2)
+
     lines=['# Estado de preparación SEMB 0.3','',f'Versión: `{VERSION}`.','',f'**Etapa actual: `{stage}`.**',f'**Módulos prehumanos materializados: {complete}/{total}.**','',
+           '**Holdout final:** reemplazo privado comprometido criptográficamente; los 160 casos públicos históricos no son admisibles como validación final.','',
            'La infraestructura se verifica sin usar salidas A/B ni resultados históricos como función de selección.','', '## Controles estructurales']
-    for c in checks:lines.append(f"- {c['status']} — `{c['check']}`: {c['detail']}")
+    for item in checks:
+        lines.append(f"- {item['status']} — `{item['check']}`: {item['detail']}")
     lines+=['','## Módulos prehumanos']
-    for k,v in prehuman_state.items():lines.append(f"- {'✅' if v else '⬜'} `{k}`")
+    for key,value in prehuman_state.items():
+        lines.append(f"- {'✅' if value else '⬜'} `{key}`")
     lines+=['','## Artefactos de etapas posteriores']
-    for k,v in later_state.items():lines.append(f"- `{k}`: {'presente' if v else 'ausente'}")
-    lines+=['','## Lectura','Si todos los módulos prehumanos están presentes y la etapa continúa en `WAITING_HUMAN_REFERENCE`, el bloqueo restante es epistemológico y deliberado: se necesita referencia humana real para desarrollar un modelo validable. Ningún candidato sintético puede saltar directamente a producción. La validación bloqueada sólo es segura después de existir `model_lock`.']
+    for key,value in later_state.items():
+        lines.append(f"- `{key}`: {'presente' if value else 'ausente'}")
+    lines+=['','## Lectura',
+            'Si todos los módulos prehumanos están presentes y la etapa continúa en `WAITING_HUMAN_REFERENCE`, el bloqueo restante es epistemológico y deliberado: se necesita referencia humana real para desarrollar un modelo validable. Ningún candidato sintético puede saltar directamente a producción. La validación final sólo puede abrirse cuando existe un `SEMB03_MODEL_LOCK_0.2` ligado al compromiso del holdout privado de reemplazo.']
     OUT_MD.write_text('\n'.join(lines)+'\n',encoding='utf-8')
     print(json.dumps(report,ensure_ascii=False))
+
 
 if __name__=='__main__':main()

--- a/scripts/evaluate_semb03_locked_validation.py
+++ b/scripts/evaluate_semb03_locked_validation.py
@@ -1,97 +1,214 @@
 #!/usr/bin/env python3
-"""One-shot evaluation of a locked SEMB 0.3 candidate against human reference.
+"""One-shot evaluation of a locked SEMB 0.3 candidate against a private holdout.
 
-Requires an existing model lock. Uses only sample IDs assigned to locked_validation.
-It writes the validation result but never modifies model configuration. Prediction
-files must expose uncertainty and truncation flags so coverage cannot be ignored.
+The historical 160 rows labelled ``locked_validation`` in the public
+SEMB03_SAMPLE_0.2 are explicitly inadmissible for final validation because their
+identities were published before model lock. Final evaluation therefore requires
+an explicit private holdout manifest whose SHA-256 matches the public commitment
+bound into the model lock.
+
+The script writes aggregate validation metrics only. It never modifies model
+configuration and never writes private sample or fragment identifiers to the
+result JSON.
 """
 from __future__ import annotations
-import argparse,csv,json
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
 from pathlib import Path
 
-MASTER=Path('data/validation/semb03_human_reference_sample.csv')
-CRIT=Path('data/validation/semb03_acceptance_criteria.json')
-LOCK=Path('data/validation/semb03_model_lock.json')
-OUT=Path('data/validation/semb03_locked_validation_result.json')
-VERSION='SEMB03_LOCKED_VALIDATION_0.2'
-ACTIONS=('observe','describe','recall','explain','compare','classify','measure','experiment','investigate','predict','infer','discuss','solve','create','decide','act_on_environment')
-POSITIONS=('receiver','instruction_follower','observer','experimenter','investigator','reasoner','collaborator','decision_maker','community_agent')
-PRED_REQUIRED={'sample_id','actionable','action_labels','position_labels','uncertain','truncation_risk'}
+CRIT_DEFAULT = Path('data/validation/semb03_acceptance_criteria.json')
+COMMITMENT_DEFAULT = Path('data/validation/semb03_private_holdout_commitment.json')
+LOCK_DEFAULT = Path('data/validation/semb03_model_lock.json')
+LEGACY = Path('data/validation/semb03_human_reference_sample.csv')
+OUT_DEFAULT = Path('data/validation/semb03_locked_validation_result.json')
+VERSION = 'SEMB03_LOCKED_VALIDATION_0.3'
+HOLDOUT_VERSION = 'SEMB03_PRIVATE_HOLDOUT_0.1'
+GENERATIONS = ('1972', '1988', '1993', '2014')
+ACTIONS = ('observe','describe','recall','explain','compare','classify','measure','experiment','investigate','predict','infer','discuss','solve','create','decide','act_on_environment')
+POSITIONS = ('receiver','instruction_follower','observer','experimenter','investigator','reasoner','collaborator','decision_maker','community_agent')
+PRED_REQUIRED = {'private_sample_id','actionable','action_labels','position_labels','uncertain','truncation_risk'}
+REF_REQUIRED = {'private_sample_id','actionable','action_labels','position_labels'}
+HOLDOUT_REQUIRED = {'holdout_version','private_sample_id','fragment_id','catalog_generation'}
 
-def labs(s):return {x.strip() for x in (s or '').split(';') if x.strip()}
-def load_rows(p):return list(csv.DictReader(open(p,encoding='utf-8')))
-def load(p):return {r['sample_id']:r for r in load_rows(p)}
-def div(a,b):return a/b if b else None
 
-def flag(v,name):
-    if str(v) not in {'0','1'}:raise SystemExit(f'{name} must be 0/1, got {v!r}')
-    return int(v)
+def labs(value):
+    return {x.strip() for x in (value or '').split(';') if x.strip()}
 
-def binary_metrics(y,yp):
+
+def load_rows(path: Path):
+    with path.open(encoding='utf-8', newline='') as handle:
+        return list(csv.DictReader(handle))
+
+
+def keyed(rows, key):
+    out = {r[key]: r for r in rows}
+    if len(out) != len(rows):
+        raise SystemExit(f'duplicate {key}')
+    return out
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def valid_hex(value, n):
+    return isinstance(value, str) and len(value) == n and all(c in '0123456789abcdef' for c in value.lower())
+
+
+def div(a,b):
+    return a/b if b else None
+
+
+def flag(value, name):
+    if str(value) not in {'0','1'}:
+        raise SystemExit(f'{name} must be 0/1, got {value!r}')
+    return int(value)
+
+
+def binary_metrics(y, yp):
     tp=sum(a==1 and b==1 for a,b in zip(y,yp));tn=sum(a==0 and b==0 for a,b in zip(y,yp));fp=sum(a==0 and b==1 for a,b in zip(y,yp));fn=sum(a==1 and b==0 for a,b in zip(y,yp))
     sens=div(tp,tp+fn);spec=div(tn,tn+fp)
     return {'tp':tp,'tn':tn,'fp':fp,'fn':fn,'sensitivity':sens,'specificity':spec,'balanced_accuracy':None if sens is None or spec is None else (sens+spec)/2}
 
-def multilabel_metrics(rows,field,labels):
+
+def multilabel_metrics(rows, field, labels):
     total_tp=total_fp=total_fn=0; per={}
-    for lab in labels:
+    for label in labels:
         tp=fp=fn=0
-        for h,p in rows:
-            a=lab in labs(h[field]);b=lab in labs(p[field])
+        for human,pred in rows:
+            a=label in labs(human[field]);b=label in labs(pred[field])
             tp+=a and b;fp+=(not a) and b;fn+=a and (not b)
         denom=2*tp+fp+fn;f1=0.0 if denom==0 else 2*tp/denom
         human_pos=tp+fn
-        per[lab]={'tp':tp,'fp':fp,'fn':fn,'human_positives':human_pos,'f1':f1}
+        per[label]={'tp':tp,'fp':fp,'fn':fn,'human_positives':human_pos,'f1':f1}
         total_tp+=tp;total_fp+=fp;total_fn+=fn
     micro=0.0 if 2*total_tp+total_fp+total_fn==0 else 2*total_tp/(2*total_tp+total_fp+total_fn)
     return {'micro_f1':micro,'per_category':per}
 
-def main():
-    ap=argparse.ArgumentParser();ap.add_argument('--predictions',required=True);ap.add_argument('--reference',required=True);args=ap.parse_args()
-    if OUT.exists():raise SystemExit('Locked validation result already exists; refusing a second look')
-    if not LOCK.exists():raise SystemExit('Model must be locked before validation')
-    lock=json.load(LOCK.open(encoding='utf-8'));crit=json.load(CRIT.open(encoding='utf-8'))
-    pred_rows=load_rows(args.predictions)
-    if not pred_rows:raise SystemExit('prediction file empty')
-    missing_cols=PRED_REQUIRED-set(pred_rows[0])
-    if missing_cols:raise SystemExit('prediction file missing required columns: '+','.join(sorted(missing_cols)))
-    master=load(MASTER);pred={r['sample_id']:r for r in pred_rows};ref=load(args.reference)
-    if len(pred)!=len(pred_rows):raise SystemExit('duplicate sample_id in predictions')
-    locked=[sid for sid,r in master.items() if r['analysis_role']=='locked_validation']
-    if len(locked)!=160:raise SystemExit(f'expected 160 locked IDs, found {len(locked)}')
-    missing_pred=[x for x in locked if x not in pred];missing_ref=[x for x in locked if x not in ref]
-    if missing_pred or missing_ref:raise SystemExit(f'incomplete locked data: predictions missing={len(missing_pred)}, reference missing={len(missing_ref)}')
-    extra_locked=set(pred)-set(locked)
-    if extra_locked:raise SystemExit(f'prediction file contains {len(extra_locked)} non-locked sample IDs; refuse mixed evaluation file')
 
-    usable=[sid for sid in locked if ref[sid].get('actionable') in {'0','1'}]
+def require_columns(rows, required, label):
+    if not rows:
+        raise SystemExit(f'{label} file empty')
+    missing=required-set(rows[0])
+    if missing:
+        raise SystemExit(f'{label} file missing required columns: '+','.join(sorted(missing)))
+
+
+def validate_gate(holdout_path: Path, commitment_path: Path, lock_path: Path):
+    if not holdout_path.exists():
+        raise SystemExit('private holdout manifest is required for final validation')
+    if not commitment_path.exists():
+        raise SystemExit('private holdout commitment is required before final validation')
+    if not lock_path.exists():
+        raise SystemExit('model must be locked before final validation')
+
+    commitment=json.loads(commitment_path.read_text(encoding='utf-8'))
+    lock=json.loads(lock_path.read_text(encoding='utf-8'))
+    if commitment.get('commitment_version')!='SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1':
+        raise SystemExit('unexpected private holdout commitment version')
+    if commitment.get('ids_public') is not False or commitment.get('legacy_sample_excluded') is not True:
+        raise SystemExit('commitment does not establish a private legacy-excluding holdout')
+    if commitment.get('holdout_n')!=160 or commitment.get('per_generation')!={'1972':40,'1988':40,'1993':40,'2014':40}:
+        raise SystemExit('commitment must document 160 cases = 40 per generation')
+
+    manifest_digest=sha256(holdout_path)
+    commitment_digest=sha256(commitment_path)
+    if not valid_hex(commitment.get('private_manifest_sha256'),64) or commitment['private_manifest_sha256']!=manifest_digest:
+        raise SystemExit('private holdout manifest does not match the public commitment')
+    if lock.get('lock_version')!='SEMB03_MODEL_LOCK_0.2':
+        raise SystemExit('final validation requires SEMB03_MODEL_LOCK_0.2')
+    if lock.get('legacy_public_holdout_admissible') is not False:
+        raise SystemExit('model lock does not explicitly reject the legacy public holdout')
+    if lock.get('locked_validation_accessed_before_lock') is not False:
+        raise SystemExit('model lock does not establish pre-access locking')
+    if lock.get('private_holdout_commitment_sha256')!=commitment_digest:
+        raise SystemExit('model lock is not bound to this private holdout commitment')
+    if lock.get('private_holdout_manifest_sha256')!=manifest_digest:
+        raise SystemExit('model lock is not bound to this private holdout manifest')
+    if lock.get('source_fragment_manifest_sha256')!=commitment.get('source_manifest_sha256'):
+        raise SystemExit('model lock/source-manifest SHA mismatch')
+    if lock.get('source_fragment_manifest_git_blob_sha')!=commitment.get('source_manifest_git_blob_sha'):
+        raise SystemExit('model lock/source-manifest Git blob mismatch')
+
+    rows=load_rows(holdout_path)
+    require_columns(rows,HOLDOUT_REQUIRED,'private holdout')
+    if len(rows)!=160:
+        raise SystemExit(f'expected 160 private holdout rows, found {len(rows)}')
+    if any(r['holdout_version']!=HOLDOUT_VERSION for r in rows):
+        raise SystemExit('unexpected private holdout row version')
+    if len({r['private_sample_id'] for r in rows})!=160 or len({r['fragment_id'] for r in rows})!=160:
+        raise SystemExit('private holdout IDs must be unique')
+    counts=Counter(r['catalog_generation'] for r in rows)
+    if counts!=Counter({'1972':40,'1988':40,'1993':40,'2014':40}):
+        raise SystemExit(f'private holdout generation imbalance: {dict(counts)}')
+
+    if LEGACY.exists():
+        legacy_ids={r['fragment_id'] for r in load_rows(LEGACY)}
+        overlap=legacy_ids & {r['fragment_id'] for r in rows}
+        if overlap:
+            raise SystemExit(f'private holdout overlaps {len(overlap)} legacy public fragment IDs')
+    return rows, commitment, lock, manifest_digest, commitment_digest
+
+
+def main():
+    parser=argparse.ArgumentParser()
+    parser.add_argument('--predictions',required=True,type=Path)
+    parser.add_argument('--reference',required=True,type=Path)
+    parser.add_argument('--holdout-manifest',required=True,type=Path,help='private 160-row manifest; never commit before evaluation closes')
+    parser.add_argument('--commitment',type=Path,default=COMMITMENT_DEFAULT)
+    parser.add_argument('--lock',type=Path,default=LOCK_DEFAULT)
+    parser.add_argument('--criteria',type=Path,default=CRIT_DEFAULT)
+    parser.add_argument('--output',type=Path,default=OUT_DEFAULT)
+    args=parser.parse_args()
+
+    if args.output.exists():
+        raise SystemExit('Locked validation result already exists; refusing a second look')
+
+    holdout_rows,commitment,lock,manifest_digest,commitment_digest=validate_gate(args.holdout_manifest,args.commitment,args.lock)
+    criteria=json.loads(args.criteria.read_text(encoding='utf-8'))
+    if criteria.get('criteria_version')!='SEMB03_ACCEPTANCE_0.1':
+        raise SystemExit('unexpected acceptance criteria version')
+
+    pred_rows=load_rows(args.predictions);ref_rows=load_rows(args.reference)
+    require_columns(pred_rows,PRED_REQUIRED,'prediction');require_columns(ref_rows,REF_REQUIRED,'reference')
+    pred=keyed(pred_rows,'private_sample_id');ref=keyed(ref_rows,'private_sample_id');holdout=keyed(holdout_rows,'private_sample_id')
+    expected=set(holdout)
+    if set(pred)!=expected:
+        raise SystemExit(f'prediction IDs must exactly match private holdout: missing={len(expected-set(pred))}, extra={len(set(pred)-expected)}')
+    if set(ref)!=expected:
+        raise SystemExit(f'reference IDs must exactly match private holdout: missing={len(expected-set(ref))}, extra={len(set(ref)-expected)}')
+
+    usable=[sid for sid in expected if ref[sid].get('actionable') in {'0','1'}]
     y=[int(ref[s]['actionable']) for s in usable]
     try:yp=[int(pred[s]['actionable']) for s in usable]
-    except Exception:raise SystemExit('predicted actionable must be 0/1')
+    except Exception as exc:raise SystemExit('predicted actionable must be 0/1') from exc
     if any(x not in {0,1} for x in yp):raise SystemExit('predicted actionable must be 0/1')
     actionable=binary_metrics(y,yp)
     pairs=[(ref[s],pred[s]) for s in usable]
     act=multilabel_metrics(pairs,'action_labels',ACTIONS);pos=multilabel_metrics(pairs,'position_labels',POSITIONS)
-    ca=crit['locked_validation']
-    def macro_block(m,conf):
-        vals=[v['f1'] for v in m['per_category'].values() if v['human_positives']>=conf['macro_min_human_positives']]
-        m['macro_f1']=sum(vals)/len(vals) if vals else None
-        floors=[(k,v) for k,v in m['per_category'].items() if v['human_positives']>=conf['category_floor_min_human_positives'] and v['f1']<conf['category_f1_floor']]
-        m['category_floor_failures']=[k for k,_ in floors]
+    ca=criteria['locked_validation']
+
+    def macro_block(metrics,conf):
+        vals=[v['f1'] for v in metrics['per_category'].values() if v['human_positives']>=conf['macro_min_human_positives']]
+        metrics['macro_f1']=sum(vals)/len(vals) if vals else None
+        floors=[(k,v) for k,v in metrics['per_category'].items() if v['human_positives']>=conf['category_floor_min_human_positives'] and v['f1']<conf['category_f1_floor']]
+        metrics['category_floor_failures']=[k for k,_ in floors]
     macro_block(act,ca['actions']);macro_block(pos,ca['positions'])
 
-    uncertain={sid:flag(pred[sid]['uncertain'],f'{sid}.uncertain') for sid in locked}
-    trunc={sid:flag(pred[sid]['truncation_risk'],f'{sid}.truncation_risk') for sid in locked}
-    certain_rate=sum(1-uncertain[s] for s in locked)/len(locked)
+    uncertain={sid:flag(pred[sid]['uncertain'],f'{sid}.uncertain') for sid in expected}
+    trunc={sid:flag(pred[sid]['truncation_risk'],f'{sid}.truncation_risk') for sid in expected}
+    certain_rate=sum(1-uncertain[s] for s in expected)/len(expected)
     by_generation={}
-    for g in ('1972','1988','1993','2014'):
-        ids=[s for s in locked if master[s]['catalog_generation']==g]
-        if not ids:raise SystemExit(f'no locked cases for generation {g}')
+    for generation in GENERATIONS:
+        ids=[sid for sid,row in holdout.items() if row['catalog_generation']==generation]
         rate=sum(uncertain[s] for s in ids)/len(ids)
-        by_generation[g]={'n':len(ids),'uncertain_n':sum(uncertain[s] for s in ids),'uncertain_rate':rate,'certain_rate':1-rate,'truncation_risk_n':sum(trunc[s] for s in ids)}
+        by_generation[generation]={'n':len(ids),'uncertain_n':sum(uncertain[s] for s in ids),'uncertain_rate':rate,'certain_rate':1-rate,'truncation_risk_n':sum(trunc[s] for s in ids)}
     rates=[x['uncertain_rate'] for x in by_generation.values()]
-    uncertainty_gap_pp=100*(max(rates)-min(rates))
-    total_trunc=sum(trunc.values())
+    uncertainty_gap_pp=100*(max(rates)-min(rates));total_trunc=sum(trunc.values())
     coverage={'certain_output_rate':certain_rate,'uncertain_rate':1-certain_rate,'by_generation':by_generation,'max_generation_uncertainty_gap_pp':uncertainty_gap_pp,'truncation_risk_n':total_trunc}
 
     checks={
@@ -108,8 +225,24 @@ def main():
       'generation_uncertainty_gap':uncertainty_gap_pp<=ca['coverage']['max_generation_uncertainty_gap_pp'],
       'no_silent_truncation':(total_trunc==0) if ca['coverage']['silent_truncation_allowed'] is False else True,
     }
-    result={'validation_version':VERSION,'model_lock_version':lock.get('lock_version'),'model_lock_git_head':lock.get('git_head'),'criteria_version':crit['criteria_version'],'locked_n':160,'usable_nonambiguous_n':len(usable),'actionable':actionable,'actions':act,'positions':pos,'coverage':coverage,'checks':checks,'passed':all(checks.values()),'model_modified_after_opening_validation':False}
-    OUT.parent.mkdir(parents=True,exist_ok=True);json.dump(result,OUT.open('w',encoding='utf-8'),ensure_ascii=False,indent=2)
+    result={
+      'validation_version':VERSION,
+      'model_lock_version':lock.get('lock_version'),
+      'model_lock_git_head':lock.get('git_head'),
+      'criteria_version':criteria['criteria_version'],
+      'holdout_protocol':'replacement_private_committed',
+      'private_manifest_sha256':manifest_digest,
+      'holdout_commitment_sha256':commitment_digest,
+      'locked_n':160,
+      'usable_nonambiguous_n':len(usable),
+      'actionable':actionable,'actions':act,'positions':pos,'coverage':coverage,
+      'checks':checks,'passed':all(checks.values()),
+      'legacy_public_holdout_used':False,
+      'model_modified_after_opening_validation':False,
+    }
+    args.output.parent.mkdir(parents=True,exist_ok=True)
+    args.output.write_text(json.dumps(result,ensure_ascii=False,indent=2)+'\n',encoding='utf-8')
     print(json.dumps(result,ensure_ascii=False,indent=2))
+
 
 if __name__=='__main__':main()

--- a/scripts/selftest_semb03_infrastructure.py
+++ b/scripts/selftest_semb03_infrastructure.py
@@ -1,11 +1,18 @@
 #!/usr/bin/env python3
-"""Lightweight self-tests for SEMB 0.3 infrastructure using fake temporary data.
+"""Self-tests for SEMB 0.3 stage gates using temporary fake data only.
 
-No fake annotation is persisted or treated as scientific reference. The tests
-exercise schema validation and static stage-gate invariants only.
+No fake annotation, private holdout, commitment, lock, prediction, reference, or
+validation result is persisted as scientific evidence. The tests exercise schema
+validation and the final one-shot private-holdout gate end to end.
 """
 from __future__ import annotations
-import csv,json,subprocess,sys,tempfile
+
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 MASTER=Path('data/validation/semb03_human_reference_sample.csv')
@@ -14,13 +21,25 @@ GRID=Path('data/validation/semb03_candidate_grid.json')
 LOCK_SCRIPT=Path('scripts/lock_semb03_model.py')
 VAL_SCRIPT=Path('scripts/evaluate_semb03_locked_validation.py')
 ANN_SCRIPT=Path('scripts/validate_semb03_annotations.py')
-VERSION='SEMB03_SELFTEST_0.1'
+VERSION='SEMB03_SELFTEST_0.2'
+GENERATIONS=('1972','1988','1993','2014')
+
 
 def run(cmd,expect=0):
     cp=subprocess.run(cmd,text=True,capture_output=True)
     if cp.returncode!=expect:
         raise AssertionError(f'expected rc={expect}, got {cp.returncode}\nSTDOUT={cp.stdout}\nSTDERR={cp.stderr}')
     return cp
+
+
+def sha(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def write_csv(path,fields,rows):
+    with Path(path).open('w',encoding='utf-8',newline='') as handle:
+        writer=csv.DictWriter(handle,fieldnames=fields);writer.writeheader();writer.writerows(rows)
+
 
 def main():
     master=list(csv.DictReader(MASTER.open(encoding='utf-8')));assert len(master)==480
@@ -31,28 +50,97 @@ def main():
     assert crit['locked_validation']['coverage']['certain_output_rate_min']==0.70
     assert crit['locked_validation']['coverage']['max_generation_uncertainty_gap_pp']==20.0
 
-    # Validate two deliberately fake but schema-correct annotations in temp only.
+    # Validate two deliberately fake but schema-correct development annotations in temp only.
     ids=[master[0]['sample_id'],master[1]['sample_id']]
     fields=['sample_id','annotator_id','annotation_round','actionable','action_labels','position_labels','annotation_confidence','ambiguity_note']
-    with tempfile.TemporaryDirectory(prefix='ltmd-selftest-') as td:
-        good=Path(td)/'good.csv';bad=Path(td)/'bad.csv'
-        with good.open('w',encoding='utf-8',newline='') as f:
-            w=csv.DictWriter(f,fieldnames=fields);w.writeheader();
-            w.writerow({'sample_id':ids[0],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'1','action_labels':'observe','position_labels':'observer','annotation_confidence':'3','ambiguity_note':''})
-            w.writerow({'sample_id':ids[1],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'0','action_labels':'','position_labels':'receiver','annotation_confidence':'2','ambiguity_note':''})
+    with tempfile.TemporaryDirectory(prefix='ltmd-selftest-') as td_name:
+        td=Path(td_name)
+        good=td/'good.csv';bad=td/'bad.csv'
+        write_csv(good,fields,[
+            {'sample_id':ids[0],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'1','action_labels':'observe','position_labels':'observer','annotation_confidence':'3','ambiguity_note':''},
+            {'sample_id':ids[1],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'0','action_labels':'','position_labels':'receiver','annotation_confidence':'2','ambiguity_note':''},
+        ])
         run([sys.executable,str(ANN_SCRIPT),str(good)],0)
-        with bad.open('w',encoding='utf-8',newline='') as f:
-            w=csv.DictWriter(f,fieldnames=fields);w.writeheader();
-            w.writerow({'sample_id':ids[0],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'0','action_labels':'observe','position_labels':'receiver','annotation_confidence':'3','ambiguity_note':''})
+        write_csv(bad,fields,[
+            {'sample_id':ids[0],'annotator_id':'FAKE_TEST','annotation_round':'0','actionable':'0','action_labels':'observe','position_labels':'receiver','annotation_confidence':'3','ambiguity_note':''},
+        ])
         cp=subprocess.run([sys.executable,str(ANN_SCRIPT),str(bad)],text=True,capture_output=True)
         assert cp.returncode!=0 and 'actionable=0 requires empty action_labels' in (cp.stdout+cp.stderr)
 
-    lock_text=LOCK_SCRIPT.read_text(encoding='utf-8');val_text=VAL_SCRIPT.read_text(encoding='utf-8')
-    assert 'refusing overwrite' in lock_text and 'locked_validation_accessed' in lock_text
-    assert 'refusing a second look' in val_text
-    assert "'uncertain'" in val_text and "'truncation_risk'" in val_text
-    assert 'generation_uncertainty_gap' in val_text and 'certain_output_rate' in val_text
+        # Build a completely fake private holdout and cryptographic gate in temp only.
+        holdout=td/'holdout.csv';pred=td/'predictions.csv';ref=td/'reference.csv'
+        commitment=td/'commitment.json';lock=td/'lock.json';result=td/'result.json'
+        holdout_rows=[];pred_rows=[];ref_rows=[]
+        counter=0
+        for generation in GENERATIONS:
+            for j in range(40):
+                sid=f'FAKE-H-{counter:03d}'
+                fid=f'FAKE-FRAGMENT-{generation}-{j:03d}'
+                holdout_rows.append({'holdout_version':'SEMB03_PRIVATE_HOLDOUT_0.1','private_sample_id':sid,'fragment_id':fid,'catalog_generation':generation})
+                actionable='1' if counter%2==0 else '0'
+                actions='observe' if actionable=='1' else ''
+                position='observer' if actionable=='1' else 'receiver'
+                pred_rows.append({'private_sample_id':sid,'actionable':actionable,'action_labels':actions,'position_labels':position,'uncertain':'0','truncation_risk':'0'})
+                ref_rows.append({'private_sample_id':sid,'actionable':actionable,'action_labels':actions,'position_labels':position})
+                counter+=1
+        write_csv(holdout,['holdout_version','private_sample_id','fragment_id','catalog_generation'],holdout_rows)
+        write_csv(pred,['private_sample_id','actionable','action_labels','position_labels','uncertain','truncation_risk'],pred_rows)
+        write_csv(ref,['private_sample_id','actionable','action_labels','position_labels'],ref_rows)
+        manifest_sha=sha(holdout)
+        commitment_obj={
+            'commitment_version':'SEMB03_PRIVATE_HOLDOUT_COMMITMENT_0.1',
+            'holdout_n':160,
+            'per_generation':{'1972':40,'1988':40,'1993':40,'2014':40},
+            'legacy_sample_excluded':True,
+            'ids_public':False,
+            'private_manifest_sha256':manifest_sha,
+            'source_manifest_sha256':'a'*64,
+            'source_manifest_git_blob_sha':'b'*40,
+        }
+        commitment.write_text(json.dumps(commitment_obj,sort_keys=True)+'\n',encoding='utf-8')
+        lock_obj={
+            'lock_version':'SEMB03_MODEL_LOCK_0.2',
+            'git_head':'FAKE',
+            'private_holdout_commitment_sha256':sha(commitment),
+            'private_holdout_manifest_sha256':manifest_sha,
+            'source_fragment_manifest_sha256':'a'*64,
+            'source_fragment_manifest_git_blob_sha':'b'*40,
+            'legacy_public_holdout_admissible':False,
+            'locked_validation_accessed_before_lock':False,
+        }
+        lock.write_text(json.dumps(lock_obj,sort_keys=True)+'\n',encoding='utf-8')
+        run([
+            sys.executable,str(VAL_SCRIPT),
+            '--predictions',str(pred),'--reference',str(ref),'--holdout-manifest',str(holdout),
+            '--commitment',str(commitment),'--lock',str(lock),'--output',str(result),
+        ],0)
+        evaluated=json.loads(result.read_text(encoding='utf-8'))
+        assert evaluated['passed'] is True
+        assert evaluated['locked_n']==160
+        assert evaluated['holdout_protocol']=='replacement_private_committed'
+        assert evaluated['legacy_public_holdout_used'] is False
+        rendered=result.read_text(encoding='utf-8')
+        assert 'private_sample_id' not in rendered and 'fragment_id' not in rendered
+        second=subprocess.run([
+            sys.executable,str(VAL_SCRIPT),
+            '--predictions',str(pred),'--reference',str(ref),'--holdout-manifest',str(holdout),
+            '--commitment',str(commitment),'--lock',str(lock),'--output',str(result),
+        ],text=True,capture_output=True)
+        assert second.returncode!=0 and 'refusing a second look' in (second.stdout+second.stderr)
 
-    print(json.dumps({'selftest_version':VERSION,'passed':True,'fake_annotations_persisted':False,'master_n':len(master)},ensure_ascii=False))
+    lock_text=LOCK_SCRIPT.read_text(encoding='utf-8');val_text=VAL_SCRIPT.read_text(encoding='utf-8')
+    assert 'legacy_public_holdout_admissible' in lock_text
+    assert 'private_holdout_commitment_sha256' in lock_text
+    assert 'private holdout manifest does not match the public commitment' in val_text
+    assert 'legacy public fragment IDs' in val_text
+
+    print(json.dumps({
+        'selftest_version':VERSION,
+        'passed':True,
+        'fake_artifacts_persisted':False,
+        'legacy_master_n':len(master),
+        'private_holdout_gate_tested_n':160,
+    },ensure_ascii=False))
+
 
 if __name__=='__main__':main()


### PR DESCRIPTION
## Propósito

Cierra una ruta residual que todavía permitía evaluar SEMB 0.3 contra los 160 IDs públicos históricos. Después de la remediación de integridad, la evaluación final debe usar exclusivamente el holdout privado de reemplazo comprometido antes del model lock.

## Cambios

- `evaluate_semb03_locked_validation.py` pasa a `SEMB03_LOCKED_VALIDATION_0.3`;
- exige `--holdout-manifest` privado explícito;
- verifica 160 casos únicos, 40 por generación y cero solapamiento con las 480 identidades públicas históricas;
- verifica SHA-256 del manifiesto privado contra el compromiso público;
- verifica que el compromiso esté ligado criptográficamente a `SEMB03_MODEL_LOCK_0.2`;
- rechaza locks que no invaliden el holdout legado o que no acrediten pre-access locking;
- exige que predicciones y referencia coincidan exactamente con los 160 IDs privados;
- el resultado público contiene sólo métricas agregadas y hashes, nunca IDs privados;
- `selftest_semb03_infrastructure.py` construye 160 casos falsos temporales, compromiso y lock falsos, ejecuta una evaluación completa y comprueba el rechazo de una segunda mirada;
- `check_semb03_readiness.py` pasa a 0.4 y sólo marca segura la apertura de validación cuando existe el gate privado completo;
- el workflow de infraestructura se amplía a PR, compila y prueba toda esta cadena.

## Invariantes

- ningún dato falso del self-test se persiste;
- ningún ID del holdout privado se publica;
- los 160 casos públicos antiguos continúan inadmisibles como validación final;
- la cobertura semántica humana permanece 0/542;
- no cambia la cobertura técnica U1.