### PR TITLE
FTRL W4: registrar preservación privada verificada

### DIFF
--- a/data/research/ltmd_u1_ftrl_wave_state.json
+++ b/data/research/ltmd_u1_ftrl_wave_state.json
@@ -1,6 +1,6 @@
 {
   "schema": "LTMD_U1_FTRL_WAVE_STATE_0.1",
-  "effective_date": "2026-08-25",
+  "effective_date": "2026-08-27",
   "note": "Metadata-only operational state. Update only from verified computation and persistent-archive evidence; preservation follows docs/PRESERVATION_CANON_0_2.md. Never infer text or semantic readiness from OCR availability.",
   "waves": {
     "W1": {
@@ -13,15 +13,7 @@
       "archive_destination_logical": "LTMD-U1 — corpus FTRL privado/W1 — Ciencias Naturales/run_32807213503__d07d090__2026-08-24/02_CONSOLIDATED_PRIVATE/LTMD_W1_Ciencias_Naturales_corpus_textual_canonico_v1.zip",
       "archival_closure_evidence": "data/research/ltmd_u1_w1_archival_closure.json"
     },
-    "W2": {
-      "domain": "matematicas",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    },
+    "W2": {"domain": "matematicas", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""},
     "W3": {
       "domain": "espanol_lengua",
       "ftrl_status": "validated",
@@ -34,12 +26,13 @@
     },
     "W4": {
       "domain": "ciencias_sociales",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
+      "ftrl_status": "validated",
+      "ftrl_run_id": "33033136922",
+      "ftrl_commit": "455e0f21434162c4b77a0b5d52269b65512c486d",
+      "archival_status": "in_progress",
+      "preservation_run_id": "private_handoff_preservation_2026-08-27",
+      "archive_destination_logical": "LTMD-U1 — corpus FTRL privado/W4 — Ciencias Sociales/run_33033136922__455e0f2__2026-08-26",
+      "preservation_checkpoint_evidence": "data/research/ltmd_u1_w4_preservation_checkpoint.json"
     },
     "W5": {
       "domain": "historia",
@@ -61,50 +54,10 @@
       "archive_destination_logical": "LTMD-U1 — corpus FTRL privado/W6 — Geografía y Atlas/run_32908105382__ae785d8__2026-08-25/02_CONSOLIDATED_PRIVATE",
       "archival_closure_evidence": "data/research/ltmd_u1_w6_archival_closure.json"
     },
-    "W7": {
-      "domain": "civica_etica",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    },
-    "W8": {
-      "domain": "artes",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    },
-    "W9": {
-      "domain": "educacion_fisica",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    },
-    "W10": {
-      "domain": "integrados_multiarea",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    },
-    "W11": {
-      "domain": "otros_no_clasificados",
-      "ftrl_status": "pending",
-      "ftrl_run_id": "",
-      "ftrl_commit": "",
-      "archival_status": "not_started",
-      "preservation_run_id": "",
-      "archive_destination_logical": ""
-    }
+    "W7": {"domain": "civica_etica", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""},
+    "W8": {"domain": "artes", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""},
+    "W9": {"domain": "educacion_fisica", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""},
+    "W10": {"domain": "integrados_multiarea", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""},
+    "W11": {"domain": "otros_no_clasificados", "ftrl_status": "pending", "ftrl_run_id": "", "ftrl_commit": "", "archival_status": "not_started", "preservation_run_id": "", "archive_destination_logical": ""}
   }
 }

--- a/data/research/ltmd_u1_w4_preservation_checkpoint.json
+++ b/data/research/ltmd_u1_w4_preservation_checkpoint.json
@@ -1,0 +1,45 @@
+{
+  "schema": "LTMD_FTRL_PRESERVATION_CHECKPOINT_0.1",
+  "wave": "W4",
+  "domain": "Ciencias Sociales",
+  "effective_date": "2026-08-27",
+  "archival_complete": false,
+  "ftrl": {
+    "status": "validated",
+    "run_id": "33033136922",
+    "commit": "455e0f21434162c4b77a0b5d52269b65512c486d",
+    "historical_identities": 14,
+    "canonical_processing_objects": 14,
+    "distributed_shards": 8,
+    "page_records": 2414,
+    "global_exact_union": true,
+    "page_partition_complete": true,
+    "page_partition_unique": true,
+    "sqlite_fts_qc_validated_per_shard": true
+  },
+  "persistent_archive": {
+    "provider": "google_drive",
+    "destination_shared": false,
+    "logical_destination": "LTMD-U1 — corpus FTRL privado/W4 — Ciencias Sociales/run_33033136922__455e0f2__2026-08-26",
+    "encrypted_handoffs_preserved": true,
+    "encrypted_handoffs_unique": 8,
+    "redownload_checksum_verification_complete": true,
+    "private_consolidation_validated": false,
+    "restricted_plaintext_publicly_exposed": false,
+    "redundant_session_copies_removed": 8
+  },
+  "handoffs": [
+    {"shard": 0, "actions_artifact_id": 9631053623, "drive_filename": "w4-shard-00-private-encrypted.zip", "sha256": "87caa0985d84702820dbf5e9c4e7ee2e824308b0418fd99f3e8bba5083254bb9"},
+    {"shard": 1, "actions_artifact_id": 9631078587, "drive_filename": "w4-shard-01-private-encrypted.zip", "sha256": "1be071f469a52f9937297d30728cef374081dd55c53d46c92cae19d988061210"},
+    {"shard": 2, "actions_artifact_id": 9631090692, "drive_filename": "w4-shard-02-private-encrypted.zip", "sha256": "077e11378e75942bb5ed539eca3e8d0f15550f7ee5570eec3d6bc3c243ac0c69"},
+    {"shard": 3, "actions_artifact_id": 9631101111, "drive_filename": "w4-shard-03-private-encrypted.zip", "sha256": "41961cdedc95f05df35fb19e0ce8d8ed0fef5ecdaae8ff5370e21b476ad78031"},
+    {"shard": 4, "actions_artifact_id": 9631075115, "drive_filename": "w4-shard-04-private-encrypted.zip", "sha256": "bb42ed6c32e79ef022cb6cb6183a0a5c073e231996a0d6b7c97702df39198d87"},
+    {"shard": 5, "actions_artifact_id": 9631072252, "drive_filename": "w4-shard-05-private-encrypted.zip", "sha256": "f2bb26f553192988ceed3d58794d81584854b46afaabc23fec890603f4be6afd"},
+    {"shard": 6, "actions_artifact_id": 9631096398, "drive_filename": "w4-shard-06-private-encrypted.zip", "sha256": "c2ca23908a1b655ca3e64f53e2324b6b68b17596e2b59cb04706feab1d49ac9f"},
+    {"shard": 7, "actions_artifact_id": 9631074779, "drive_filename": "w4-shard-07-private-encrypted.zip", "sha256": "1ddd98e61da8fba91be06bd1f70940924dd784a6f239731587ae548cbe841645"}
+  ],
+  "next_gate": "Consolidate the eight verified encrypted handoffs into one canonical private W4 corpus representation, preserve its manifest/checksums, redownload and verify it, then and only then set archival_complete=true.",
+  "interpretive_limit": "Computational validation and persistent encrypted preservation do not imply archival closure, text verification, semantic readiness, or historical interpretation.",
+  "text_verified": false,
+  "semantic_ready": false
+}


### PR DESCRIPTION
## Qué cambia

- Promueve W4 Ciencias Sociales a `ftrl_status=validated` con run `33033136922` y commit `455e0f21434162c4b77a0b5d52269b65512c486d`.
- Conserva el cierre archivístico abierto (`archival_status=in_progress`).
- Añade `data/research/ltmd_u1_w4_preservation_checkpoint.json` con 8/8 handoffs cifrados, sus digests SHA-256 y la evidencia de redescarga/verificación desde Google Drive privado.
- Registra que las copias redundantes creadas durante la verificación fueron retiradas.

## Invariantes

- W4: 14 identidades históricas, 14 objetos canónicos, 2,414 páginas, 8 shards, unión exacta.
- `archival_complete=false`: todavía falta consolidación privada canónica.
- `text_verified=false`.
- `semantic_ready=false`.
- No se publica OCR, SQLite, snippets ni texto restringido.

Refs #64.