### PR TITLE
FTRL W9: activar Educación Física sobre topología SHA verificada

### DIFF
--- a/.github/workflows/run-ftrl-w9-educacion-fisica.yml
+++ b/.github/workflows/run-ftrl-w9-educacion-fisica.yml
@@ -1,0 +1,265 @@
+name: Run FTRL W9 Educacion Fisica
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w9_ftrl_run_stamp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/build_ftrl_w9_inputs.py'
+      - 'scripts/run_ftrl_w9_book.py'
+      - 'scripts/validate_ftrl_w9_distributed.py'
+      - '.github/workflows/run-ftrl-w9-educacion-fisica.yml'
+      - 'data/research/ltmd_u1_w9_ftrl_run_stamp.json'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ftrl-w9-educacion-fisica-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  config-gate:
+    name: validate-ftrl-w9-config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile W9 FTRL scripts
+        run: python -m py_compile scripts/build_ftrl_w9_inputs.py scripts/run_ftrl_w9_book.py scripts/validate_ftrl_w9_distributed.py
+      - name: Rebuild normalized W9 inputs without network
+        run: |
+          python scripts/build_ftrl_w9_inputs.py \
+            --asset-output /tmp/w9_asset_manifest.csv \
+            --processing-output /tmp/w9_processing_inventory.csv
+          python - <<'PY'
+          import csv
+          from collections import Counter
+          def read(p):
+              with open(p, encoding='utf-8', newline='') as fh: return list(csv.DictReader(fh))
+          a = read('/tmp/w9_asset_manifest.csv'); p = read('/tmp/w9_processing_inventory.csv')
+          assert len(p) == 4
+          assert len(a) == 448
+          assert Counter(r['viewer_key'] for r in a) == Counter({'H2008P1ED252':114,'H2008P2ED260':106,'H2008P5ED280':114,'H2008P6ED287':114})
+          assert all(r['is_canonical_processing_object'] == '1' for r in p)
+          assert all(r['technical_identity_covered'] == '1' for r in p)
+          assert all(r['persistent_internal_source_gaps'] == '0' for r in p)
+          print('W9 config gate: 4 books / 448 pages')
+          PY
+
+  precondition:
+    name: require-w4-archival-closure
+    if: github.event_name != 'pull_request'
+    needs: config-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require canonical W4 archival closure before W9
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          state = json.loads(Path('data/research/ltmd_u1_ftrl_wave_state.json').read_text(encoding='utf-8'))
+          w4 = state['waves']['W4']
+          assert w4['ftrl_status'] == 'validated', w4
+          assert w4['archival_status'] == 'archival_complete', w4
+          evidence = w4.get('archival_closure_evidence')
+          assert evidence == 'data/research/ltmd_u1_w4_archival_closure.json', w4
+          assert Path(evidence).is_file()
+          PY
+
+  book:
+    name: book-${{ matrix.viewer }}
+    if: github.event_name != 'pull_request'
+    needs: [config-gate, precondition]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        viewer: [H2008P1ED252, H2008P2ED260, H2008P5ED280, H2008P6ED287]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+      - name: Validate private preservation canon
+        run: python scripts/validate_private_corpus_storage_contract.py
+      - name: Execute deterministic W9 book unit
+        run: |
+          python scripts/run_ftrl_w9_book.py \
+            --viewer-key '${{ matrix.viewer }}' \
+            --output-dir local/ftrl-w9
+      - name: Assert public evidence is text-free
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          p = Path(f'local/ftrl-w9/{viewer}/w9_{viewer}_evidence.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W9_BOOK_UNIT_0.1'
+          assert data['status'] == 'validated'
+          forbidden = {'ocr_text_raw','search_text','snippet','text','normalized_text'}
+          def walk(x):
+              if isinstance(x, dict):
+                  assert not (forbidden & set(x)), forbidden & set(x)
+                  for v in x.values(): walk(v)
+              elif isinstance(x, list):
+                  for v in x: walk(v)
+          walk(data)
+          PY
+      - name: Build and encrypt restricted book archive
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          set -euo pipefail
+          DIR="local/ftrl-w9/${VIEWER}"
+          HANDOFF="local/private-handoff-w9-${VIEWER}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w9_${VIEWER}_restricted.tar.gz" \
+            "w9_${VIEWER}_page_ocr.jsonl" \
+            "w9_${VIEWER}_ocr_search.sqlite" \
+            "w9_${VIEWER}_qc_queue.json" \
+            "w9_${VIEWER}_asset_manifest.csv" \
+            "w9_${VIEWER}_run_manifest.json" \
+            "w9_${VIEWER}_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w9-${VIEWER}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w9_${VIEWER}_restricted.tar.gz" \
+            -out "$HANDOFF/w9_${VIEWER}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w9-${VIEWER}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w9-${VIEWER}.pass" \
+            -out "$HANDOFF/w9_${VIEWER}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w9_${VIEWER}_restricted.tar.gz.enc" "$HANDOFF/w9_${VIEWER}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w9_${VIEWER}_restricted.tar.gz" "/tmp/w9-${VIEWER}.pass"
+      - name: Write text-free encrypted handoff manifest
+        env:
+          VIEWER: ${{ matrix.viewer }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          handoff = Path(f'local/private-handoff-w9-{viewer}')
+          evidence = json.loads(Path(f'local/ftrl-w9/{viewer}/w9_{viewer}_evidence.json').read_text(encoding='utf-8'))
+          def desc(name):
+              p = handoff / name
+              h = hashlib.sha256()
+              with p.open('rb') as fh:
+                  for chunk in iter(lambda: fh.read(1024*1024), b''): h.update(chunk)
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h.hexdigest()}
+          payload = f'w9_{viewer}_restricted.tar.gz.enc'
+          key = f'w9_{viewer}_passphrase.rsa-oaep.enc'
+          m = {
+              'schema':'LTMD_PRIVATE_FTRL_W9_BOOK_HANDOFF_0.1', 'wave':'W9', 'viewer_key':viewer,
+              'page_records':evidence['page_records'], 'source_commit':os.environ['GH_SHA'],
+              'workflow_run_id':os.environ['GH_RUN_ID'],
+              'encryption':{'payload':'AES-256-CBC + PBKDF2-SHA256, 250000 iterations','key_wrap':'RSA-4096 OAEP SHA-256','public_key_sha256':'78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'},
+              'files':[desc(payload),desc(key),desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded':False,
+              'destination_policy':'private Google Drive; Actions artifact is temporary encrypted handoff only',
+              'archival_complete':False,
+          }
+          (handoff / f'w9_{viewer}_private_handoff_manifest.json').write_text(json.dumps(m, indent=2, sort_keys=True)+'\n', encoding='utf-8')
+          PY
+      - name: Prove plaintext archive is absent
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          HANDOFF="local/private-handoff-w9-${VIEWER}"
+          test ! -f "$HANDOFF/w9_${VIEWER}_restricted.tar.gz"
+          test -f "$HANDOFF/w9_${VIEWER}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w9_${VIEWER}_passphrase.rsa-oaep.enc"
+      - name: Upload encrypted private handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w9-${{ matrix.viewer }}-private-encrypted
+          path: local/private-handoff-w9-${{ matrix.viewer }}/
+          if-no-files-found: error
+          retention-days: 3
+      - name: Upload text-free computational evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w9-${{ matrix.viewer }}-text-free-evidence
+          path: |
+            local/ftrl-w9/${{ matrix.viewer }}/w9_${{ matrix.viewer }}_evidence.json
+            local/ftrl-w9/${{ matrix.viewer }}/w9_${{ matrix.viewer }}_run_manifest.json
+            local/ftrl-w9/${{ matrix.viewer }}/w9_${{ matrix.viewer }}_qc_summary.json
+            local/ftrl-w9/${{ matrix.viewer }}/w9_${{ matrix.viewer }}_asset_manifest.csv
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: validate-global-w9-union
+    if: github.event_name != 'pull_request'
+    needs: book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Download all text-free W9 evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ltmd-u1-w9-*-text-free-evidence
+          path: local/w9-evidence
+          merge-multiple: false
+      - name: Rebuild canonical W9 inputs
+        run: |
+          mkdir -p local/w9-expected
+          python scripts/build_ftrl_w9_inputs.py \
+            --asset-output local/w9-expected/asset_manifest.csv \
+            --processing-output local/w9-expected/processing_inventory.csv
+      - name: Validate exact exhaustive union
+        run: |
+          python scripts/validate_ftrl_w9_distributed.py \
+            --evidence-root local/w9-evidence \
+            --asset-manifest local/w9-expected/asset_manifest.csv \
+            --processing-inventory local/w9-expected/processing_inventory.csv \
+            --output local/ltmd_u1_w9_global_evidence.json
+      - name: Upload global text-free evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w9-global-text-free-evidence
+          path: local/ltmd_u1_w9_global_evidence.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Report W9 computational validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 64 --repo "$GITHUB_REPOSITORY" --body "FTRL W9 Educación Física — validación computacional exhaustiva COMPLETA en run ${GITHUB_RUN_ID}: 4 libros/objetos canónicos, 448/448 páginas, unión única y exacta; SHA fuente, SQLite/FTS5 y QC validados por libro. Productos restringidos únicamente en handoffs cifrados. archival_complete permanece falso hasta consolidación y reverificación privada; text_verified y semantic_ready permanecen falsos."
+
+  report-failure:
+    name: report-w9-failure
+    if: failure() && github.event_name != 'pull_request'
+    needs: [config-gate, precondition, book, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report W9 failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 64 --repo "$GITHUB_REPOSITORY" --body "FTRL W9 Educación Física — corrida ${GITHUB_RUN_ID} NO completó todos sus gates. No se promueve W9 ni se declara archival_complete. Los handoffs exitosos son sólo evidencia diagnóstica y no sustituyen la unión exhaustiva 448/448."

--- a/data/research/ltmd_u1_w9_ftrl_run_stamp.json
+++ b/data/research/ltmd_u1_w9_ftrl_run_stamp.json
@@ -1,0 +1,31 @@
+{
+  "schema": "LTMD_U1_W9_FTRL_RUN_STAMP_0.1",
+  "wave": "W9",
+  "domain": "educacion_fisica",
+  "effective_date": "2026-08-27",
+  "mode": "four_canonical_books_parallel",
+  "historical_identities": 4,
+  "canonical_processing_objects": 4,
+  "canonical_source_pages": 448,
+  "expected_pages_by_viewer": {
+    "H2008P1ED252": 114,
+    "H2008P2ED260": 106,
+    "H2008P5ED280": 114,
+    "H2008P6ED287": 114
+  },
+  "source_topology_commit": "95c3ede9b2cb5079f552854eade521fe9b040777",
+  "prior_ocr_metrics_commit": "0255e915170fd5c38b00716b2b30837c7dec0571",
+  "prior_technical_closure": "docs/LTMD_U1_W9_COMPLETION.md",
+  "precondition": "W4 validated and archival_complete",
+  "purpose": "Regenerate restricted page-level FTRL under the current OCR/FTS/QC contract from the already versioned SHA-256 source topology. Prior OCR metrics are continuity evidence only because full historical OCR text was not persisted.",
+  "archival_complete_on_activation": false,
+  "text_verified": false,
+  "semantic_ready": false,
+  "epistemic_guards": [
+    "technical_closure != archival_complete",
+    "ocr_available != text_verified",
+    "corpus_ready != semantic_ready",
+    "search_hit != historical_claim",
+    "zero_hits != demonstrated_absence"
+  ]
+}

--- a/scripts/build_ftrl_w9_inputs.py
+++ b/scripts/build_ftrl_w9_inputs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Normalize versioned W9 Educación Física topology for generic FTRL."""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import Counter
+from pathlib import Path
+
+VERSION = "LTMD_U1_W9_FTRL_INPUTS_0.1"
+EXPECTED = {
+    "H2008P1ED252": 114,
+    "H2008P2ED260": 106,
+    "H2008P5ED280": 114,
+    "H2008P6ED287": 114,
+}
+EXPECTED_HISTORICAL = 4
+EXPECTED_CANONICAL = 4
+EXPECTED_PAGES = sum(EXPECTED.values())
+SHA = re.compile(r"^[0-9a-f]{64}$")
+PROCESSING = Path("data/catalog/ltmd_u1_w9_processing_inventory.csv")
+MANIFEST = Path("data/catalog/ltmd_u1_w9_canonical_page_manifest.csv")
+
+
+def read(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def n(row: dict[str, str], key: str) -> int:
+    value = row.get(key, "")
+    if value in {"", None}:
+        raise AssertionError(f"missing {key}: {row}")
+    return int(float(value))
+
+
+def write(path: Path, rows: list[dict[str, object]], fields: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--asset-output", default="local/ftrl/ltmd_u1_w9_asset_manifest.csv")
+    ap.add_argument("--processing-output", default="local/ftrl/ltmd_u1_w9_processing_inventory.csv")
+    args = ap.parse_args()
+
+    processing = read(PROCESSING)
+    manifest = read(MANIFEST)
+    assert len(processing) == EXPECTED_HISTORICAL
+    by = {r["viewer_key"]: r for r in processing}
+    assert set(by) == set(EXPECTED)
+    assert len(by) == EXPECTED_HISTORICAL
+    assert all(r["source_status"] == "SOURCE_ADMISSIBLE" for r in processing)
+    assert all(r["processing_mode"] == "direct_canonical" for r in processing)
+    assert all(n(r, "ocr_identity_eligible") == 1 for r in processing)
+    assert all(n(r, "is_canonical_processing_object") == 1 for r in processing)
+    assert all(n(r, "persistent_internal_source_gaps") == 0 for r in processing)
+    assert all(n(r, "probe_errors") == 0 for r in processing)
+    assert all(r["semantic_state"] == "WAITING_HUMAN_REFERENCE" for r in processing)
+    assert all(r["alias_state"] == "no_alias" for r in processing)
+
+    for viewer, pages in EXPECTED.items():
+        r = by[viewer]
+        assert n(r, "source_page_count") == pages
+        assert n(r, "declared_positions") == pages + 1
+
+    pfields = [
+        "processing_version", "viewer_key", "catalog_generation", "grade_code", "title_core",
+        "processing_mode", "canonical_processing_viewer_key", "technical_identity_covered",
+        "is_canonical_processing_object", "declared_positions", "direct_source_jpegs",
+        "persistent_internal_source_gaps", "source_processing_basis", "interpretive_limit",
+    ]
+    pout: list[dict[str, object]] = []
+    for r in processing:
+        viewer = r["viewer_key"]
+        pout.append({
+            "processing_version": VERSION,
+            "viewer_key": viewer,
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "processing_mode": "direct_canonical",
+            "canonical_processing_viewer_key": viewer,
+            "technical_identity_covered": 1,
+            "is_canonical_processing_object": 1,
+            "declared_positions": n(r, "declared_positions"),
+            "direct_source_jpegs": n(r, "source_page_count"),
+            "persistent_internal_source_gaps": 0,
+            "source_processing_basis": f"{r['topology_version']}:official_source_sha256_topology",
+            "interpretive_limit": "technical FTRL only; OCR availability does not imply text verification or semantic validation",
+        })
+
+    assert len(manifest) == EXPECTED_PAGES
+    assert set(r["viewer_key"] for r in manifest) == set(EXPECTED)
+    afields = [
+        "audit_version", "viewer_key", "catalog_generation", "grade_code", "title_core",
+        "viewer_page", "source_image_index", "source_asset_url", "asset_status", "byte_size",
+        "sha256", "processing_mode", "source_provenance",
+    ]
+    aout: list[dict[str, object]] = []
+    seen: set[tuple[str, int]] = set()
+    counts: Counter[str] = Counter()
+    for r in manifest:
+        viewer = r["viewer_key"]
+        index = n(r, "source_image_index")
+        key = (viewer, index)
+        assert key not in seen
+        seen.add(key)
+        assert viewer in EXPECTED
+        assert r["processing_mode"] == "direct_canonical"
+        assert r["asset_status"] == "source_jpeg"
+        assert n(r, "byte_size") > 0
+        assert SHA.fullmatch(r["sha256"])
+        assert r["source_asset_url"].startswith(f"https://historico.conaliteg.gob.mx/c/{viewer}/")
+        counts[viewer] += 1
+        aout.append({
+            "audit_version": VERSION,
+            "viewer_key": viewer,
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "viewer_page": n(r, "viewer_page"),
+            "source_image_index": index,
+            "source_asset_url": r["source_asset_url"],
+            "asset_status": "source_jpeg",
+            "byte_size": n(r, "byte_size"),
+            "sha256": r["sha256"],
+            "processing_mode": "direct_canonical",
+            "source_provenance": r["source_provenance"],
+        })
+    assert dict(counts) == EXPECTED
+    assert len(aout) == len(seen) == EXPECTED_PAGES
+    assert sum(int(r["direct_source_jpegs"]) for r in pout) == EXPECTED_PAGES
+
+    write(Path(args.processing_output), pout, pfields)
+    write(Path(args.asset_output), aout, afields)
+    print(f"Built W9 FTRL inputs: historical={len(pout)}, canonical={EXPECTED_CANONICAL}, pages={len(aout)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w9_book.py
+++ b/scripts/run_ftrl_w9_book.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Run one deterministic LTMD-U1 W9 FTRL book unit.
+
+Restricted OCR/SQLite/QC stay under local/ and must be encrypted before any
+Actions upload. Public evidence is metadata/hash only.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED = {
+    "H2008P1ED252": 114,
+    "H2008P2ED260": 106,
+    "H2008P5ED280": 114,
+    "H2008P6ED287": 114,
+}
+EXPECTED_TOTAL = sum(EXPECTED.values())
+SCHEMA = "LTMD_FTRL_W9_BOOK_UNIT_0.1"
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows:
+        raise SystemExit(f"refusing to write empty unit: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None:
+        raise SystemExit("Tesseract is required")
+    langs = subprocess.run(["tesseract", "--list-langs"], check=True, capture_output=True, text=True).stdout.splitlines()
+    if "spa" not in {x.strip() for x in langs}:
+        raise SystemExit("Spanish Tesseract language data is required")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    finally:
+        conn.close()
+
+
+def descriptor(path: Path) -> dict[str, object]:
+    return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+
+def jsonl_hashes(path: Path, viewer_key: str) -> tuple[list[str], int]:
+    hashes: list[str] = []
+    count = 0
+    with path.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if row.get("wave") != "W9" or row.get("viewer_key") != viewer_key:
+                raise SystemExit(f"foreign W9 record at {path}:{line_number}")
+            hashes.append(page_key_hash(viewer_key, int(row["page_index"])))
+            count += 1
+    return sorted(hashes), count
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--viewer-key", required=True, choices=sorted(EXPECTED))
+    ap.add_argument("--output-dir", type=Path, default=Path("local/ftrl-w9"))
+    args = ap.parse_args()
+    require_environment()
+
+    viewer = args.viewer_key
+    pages_expected = EXPECTED[viewer]
+    root = args.output_dir
+    unit = root / viewer
+    unit.mkdir(parents=True, exist_ok=True)
+    full_asset = root / "ltmd_u1_w9_asset_manifest.csv"
+    processing = root / "ltmd_u1_w9_processing_inventory.csv"
+    run([sys.executable, "scripts/build_ftrl_w9_inputs.py", "--asset-output", str(full_asset), "--processing-output", str(processing)])
+
+    proc = read_csv(processing)
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if set(canonical) != set(EXPECTED):
+        raise SystemExit("W9 processing denominator drift")
+    rows = sorted([r for r in read_csv(full_asset) if r["viewer_key"] == viewer], key=lambda r: int(r["source_image_index"]))
+    if len(rows) != pages_expected:
+        raise SystemExit(f"W9 {viewer} source cardinality drift: {len(rows)} != {pages_expected}")
+    if len(read_csv(full_asset)) != EXPECTED_TOTAL:
+        raise SystemExit("W9 global source cardinality drift")
+    expected_hashes = sorted(page_key_hash(viewer, int(r["source_image_index"])) for r in rows)
+    if len(expected_hashes) != len(set(expected_hashes)):
+        raise SystemExit("duplicate expected page key inside W9 book unit")
+
+    prefix = f"w9_{viewer}"
+    unit_asset = unit / f"{prefix}_asset_manifest.csv"
+    jsonl = unit / f"{prefix}_page_ocr.jsonl"
+    db = unit / f"{prefix}_ocr_search.sqlite"
+    run_manifest = unit / f"{prefix}_run_manifest.json"
+    qc_queue = unit / f"{prefix}_qc_queue.json"
+    qc_summary = unit / f"{prefix}_qc_summary.json"
+    evidence = unit / f"{prefix}_evidence.json"
+    write_csv(unit_asset, rows)
+
+    run([sys.executable, "scripts/build_page_ocr_corpus.py", "--asset-manifest", str(unit_asset), "--processing-inventory", str(processing), "--wave", "W9", "--output", str(jsonl), "--cache-dir", str(unit / "assets"), "--resume"])
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(processing), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(unit_asset), "--processing-inventory", str(processing), "--label", viewer, "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+
+    actual_hashes, actual_count = jsonl_hashes(jsonl, viewer)
+    if actual_count != pages_expected or actual_hashes != expected_hashes:
+        raise SystemExit("W9 book page inventory mismatch")
+    rm = json.loads(run_manifest.read_text(encoding="utf-8"))
+    qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["database"]["sqlite_integrity"] != "ok":
+        raise SystemExit("W9 book validation failed")
+    if rm["corpus"]["page_records"] != pages_expected or rm["database"]["page_rows"] != pages_expected or rm["database"]["fts_rows"] != pages_expected or qc["page_records"] != pages_expected:
+        raise SystemExit("W9 book cardinality drift")
+
+    payload = {
+        "schema": SCHEMA,
+        "status": "validated",
+        "wave": "W9",
+        "domain": "Educación Física",
+        "viewer_key": viewer,
+        "page_records": pages_expected,
+        "page_key_hashes": expected_hashes,
+        "source_partition": {"full_source_pages": EXPECTED_TOTAL, "unit": "one canonical viewer/book"},
+        "validation": {"sqlite_integrity": "ok", "sqlite_pages": rm["database"]["page_rows"], "fts_rows": rm["database"]["fts_rows"], "qc_page_records": qc["page_records"]},
+        "restricted_products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue)],
+        "text_free_products": [descriptor(unit_asset), descriptor(run_manifest), descriptor(qc_summary)],
+        "execution": rm.get("execution"),
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": ["computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim", "zero_hits != demonstrated_absence"],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "viewer_key": viewer, "pages": pages_expected, "evidence": str(evidence)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_ftrl_w9_distributed.py
+++ b/scripts/validate_ftrl_w9_distributed.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Validate exact union of the four W9 FTRL book-unit evidences."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+EXPECTED = {
+    "H2008P1ED252": 114,
+    "H2008P2ED260": 106,
+    "H2008P5ED280": 114,
+    "H2008P6ED287": 114,
+}
+EXPECTED_TOTAL = sum(EXPECTED.values())
+SCHEMA = "LTMD_FTRL_W9_GLOBAL_EVIDENCE_0.1"
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--evidence-root", type=Path, required=True)
+    ap.add_argument("--asset-manifest", type=Path, required=True)
+    ap.add_argument("--processing-inventory", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    proc = read_csv(args.processing_inventory)
+    assets = read_csv(args.asset_manifest)
+    assert len(proc) == 4
+    assert {r["viewer_key"] for r in proc} == set(EXPECTED)
+    assert all(r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1" for r in proc)
+    assert len(assets) == EXPECTED_TOTAL
+    counts = Counter(r["viewer_key"] for r in assets)
+    assert dict(counts) == EXPECTED
+
+    expected_hashes = {
+        page_key_hash(r["viewer_key"], int(r["source_image_index"]))
+        for r in assets
+    }
+    assert len(expected_hashes) == EXPECTED_TOTAL
+
+    evidence_files = sorted(args.evidence_root.rglob("w9_*_evidence.json"))
+    if len(evidence_files) != 4:
+        raise SystemExit(f"expected 4 W9 evidence files, found {len(evidence_files)}")
+
+    seen_viewers: set[str] = set()
+    union_hashes: set[str] = set()
+    book_records: dict[str, int] = {}
+    qc_records = 0
+    sqlite_records = 0
+    fts_records = 0
+    product_hashes: list[dict[str, object]] = []
+
+    for path in evidence_files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["schema"] == "LTMD_FTRL_W9_BOOK_UNIT_0.1"
+        assert data["status"] == "validated"
+        assert data["wave"] == "W9"
+        viewer = data["viewer_key"]
+        assert viewer in EXPECTED and viewer not in seen_viewers
+        seen_viewers.add(viewer)
+        pages = int(data["page_records"])
+        assert pages == EXPECTED[viewer]
+        hashes = list(data["page_key_hashes"])
+        assert len(hashes) == pages == len(set(hashes))
+        assert not (union_hashes & set(hashes))
+        union_hashes.update(hashes)
+        validation = data["validation"]
+        assert validation["sqlite_integrity"] == "ok"
+        assert int(validation["sqlite_pages"]) == pages
+        assert int(validation["fts_rows"]) == pages
+        assert int(validation["qc_page_records"]) == pages
+        sqlite_records += int(validation["sqlite_pages"])
+        fts_records += int(validation["fts_rows"])
+        qc_records += int(validation["qc_page_records"])
+        book_records[viewer] = pages
+        for group in ("restricted_products", "text_free_products"):
+            for item in data[group]:
+                assert len(item["sha256"]) == 64 and int(item["bytes"]) > 0
+                product_hashes.append({"viewer_key": viewer, "class": group, "name": item["name"], "bytes": item["bytes"], "sha256": item["sha256"]})
+
+    assert seen_viewers == set(EXPECTED)
+    assert union_hashes == expected_hashes
+    assert len(union_hashes) == EXPECTED_TOTAL
+    assert sqlite_records == fts_records == qc_records == EXPECTED_TOTAL
+
+    out = {
+        "schema": SCHEMA,
+        "status": "validated",
+        "wave": "W9",
+        "domain": "Educación Física",
+        "historical_identities": 4,
+        "canonical_processing_objects": 4,
+        "source_pages": EXPECTED_TOTAL,
+        "book_page_records": dict(sorted(book_records.items())),
+        "unique_page_key_hashes": len(union_hashes),
+        "sqlite_page_rows": sqlite_records,
+        "fts_rows": fts_records,
+        "qc_page_records": qc_records,
+        "source_gaps": 0,
+        "aliases": 0,
+        "products": sorted(product_hashes, key=lambda x: (x["viewer_key"], x["class"], x["name"])),
+        "archival_complete": False,
+        "text_verified": False,
+        "semantic_ready": False,
+        "epistemic_guards": ["computationally_validated != archival_complete", "ocr_available != text_verified", "corpus_ready != semantic_ready", "search_hit != historical_claim", "zero_hits != demonstrated_absence"],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "books": 4, "pages": EXPECTED_TOTAL, "output": str(args.output)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Objetivo

Activar FTRL exhaustivo para W9 Educación Física reutilizando la topología fuente ya versionada y verificada, sin redescubrimiento documental ni cambios en cobertura U1.

## Base documental/técnica reutilizada

- 4 identidades históricas / 4 objetos canónicos.
- 448 páginas fuente canónicas: 114 / 106 / 114 / 114.
- topología cerrada: commit `95c3ede9b2cb5079f552854eade521fe9b040777`.
- OCR técnico histórico: commit `0255e915170fd5c38b00716b2b30837c7dec0571`.
- cierre técnico previo: `docs/LTMD_U1_W9_COMPLETION.md`.

El OCR histórico íntegro no fue persistido; por ello NO se promueve directamente a FTRL. Se reutilizan identidad, topología, URLs y SHA-256 fuente, y se regenera el corpus restringido bajo el contrato FTRL actual.

## Implementación

- normalizador W9 → contrato genérico FTRL;
- ejecución paralela por libro (4 unidades naturales, no 8 shards artificiales);
- SHA-256 de assets obligatorio antes de OCR;
- JSONL OCR + SQLite/FTS5 + QC restringidos;
- cifrado AES-256-CBC/PBKDF2 y key-wrap RSA-OAEP antes de subir handoffs;
- evidencia pública text-free;
- validador global exige unión exacta 448/448 sin duplicados;
- W4 `archival_complete` es precondición;
- stamp de activación dispara la corrida sólo al llegar a `main`.

## Invariantes

- cobertura U1 permanece 524/542;
- W9 técnico continúa 4/4;
- `archival_complete=false` hasta persistencia privada + redescarga + SHA;
- `text_verified=false`;
- `semantic_ready=false`;
- sin aliases ni imputaciones nuevas.

Refs: #64