### PR TITLE
W7: retry transient CONALITEG network failures

### DIFF
--- a/data/research/ltmd_u1_w7_ftrl_run_stamp.json
+++ b/data/research/ltmd_u1_w7_ftrl_run_stamp.json
@@ -1,6 +1,7 @@
 {
   "schema": "LTMD_U1_W7_FTRL_RUN_STAMP_0.1",
   "requested_on": "2026-08-28",
+  "attempt": 2,
   "wave": "W7",
   "domain": "civica_etica",
   "historical_identities": 30,
@@ -8,6 +9,8 @@
   "withheld_source_identities": 5,
   "admitted_source_pages": 3261,
   "purpose": "trigger deterministic distributed computational FTRL validation after merge",
+  "retry_reason": "first full run validated 19/25 books; six source-admitted books failed only on transient CONALITEG network timeouts",
+  "network_retry_policy": "up to 4 attempts for recognized transient network failures with bounded exponential backoff; SHA-256 and non-network failures remain hard gates",
   "archival_complete": false,
   "text_verified": false,
   "semantic_ready": false,

--- a/scripts/run_ftrl_w7_book.py
+++ b/scripts/run_ftrl_w7_book.py
@@ -15,6 +15,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -23,11 +24,56 @@ EXPECTED_CANONICAL = 25
 EXPECTED_WITHHELD = 5
 EXPECTED_TOTAL = 3261
 SCHEMA = "LTMD_FTRL_W7_BOOK_UNIT_0.1"
+NETWORK_RETRY_ATTEMPTS = 4
+NETWORK_RETRY_MARKERS = (
+    "urlerror",
+    "timeouterror",
+    "timed out",
+    "temporary failure",
+    "temporarily unavailable",
+    "connection reset",
+    "remote end closed connection",
+    "http error 429",
+    "http error 500",
+    "http error 502",
+    "http error 503",
+    "http error 504",
+)
 
 
 def run(command: list[str]) -> None:
     print("+", " ".join(command), flush=True)
     subprocess.run(command, check=True)
+
+
+def run_network_resilient(command: list[str]) -> None:
+    """Retry only transient network failures; integrity failures stay hard."""
+    for attempt in range(1, NETWORK_RETRY_ATTEMPTS + 1):
+        print("+", " ".join(command), flush=True)
+        proc = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        output = proc.stdout or ""
+        if output:
+            print(output, end="" if output.endswith("\n") else "\n", flush=True)
+        if proc.returncode == 0:
+            return
+
+        lowered = output.lower()
+        transient = any(marker in lowered for marker in NETWORK_RETRY_MARKERS)
+        if not transient or attempt == NETWORK_RETRY_ATTEMPTS:
+            raise subprocess.CalledProcessError(proc.returncode, command, output=output)
+
+        delay = 5 * (2 ** (attempt - 1))
+        print(
+            f"Transient source-network failure; retrying attempt "
+            f"{attempt + 1}/{NETWORK_RETRY_ATTEMPTS} after {delay}s",
+            flush=True,
+        )
+        time.sleep(delay)
 
 
 def sha256_file(path: Path) -> str:
@@ -157,7 +203,7 @@ def main() -> None:
     evidence = unit / f"{prefix}_evidence.json"
     write_csv(unit_asset, rows)
 
-    run([
+    run_network_resilient([
         sys.executable,
         "scripts/build_page_ocr_corpus.py",
         "--asset-manifest",


### PR DESCRIPTION
## Context
The first full W7 run (`33201694589`) validated 19/25 source-admitted books. Six book jobs failed in the OCR source-download step because `historico.conaliteg.gob.mx` timed out after 60 seconds. No source-cardinality, SHA-256, OCR-integrity, SQLite/FTS, or retained-identity invariant failed.

Failed viewers: `H2008P1CI250`, `H2008P1CI251`, `H2008P2CI257`, `H2008P2CI258`, `H2008P3CI264`, `H2008P6CI286`.

## Change
- Add W7-specific bounded retries around page-corpus construction.
- Retry only recognized transient network failures (timeouts, connection resets, 429/5xx transport failures).
- Preserve SHA-256 and all non-network failures as hard gates; they are not converted into success.
- Use bounded exponential backoff (5s, 10s, 20s; at most 4 attempts).
- Update the W7 run stamp to attempt 2 and record why the rerun is required.

## Scientific/archival boundary
- No page is dropped.
- No source identity is aliased or imputed.
- The five retained W7 identities remain excluded.
- `archival_complete`, `text_verified`, and `semantic_ready` remain false.
- Public artifacts remain text-free only.

Continues #64.