### PR TITLE
W7: generar handoffs privados cifrados para cierre archivístico

### DIFF
--- a/.github/workflows/run-ftrl-w7-formacion-civica-etica.yml
+++ b/.github/workflows/run-ftrl-w7-formacion-civica-etica.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ftrl-w7-formacion-civica-etica-${{ github.ref }}
@@ -150,7 +151,84 @@ jobs:
                   for v in x: walk(v)
           walk(data)
           PY
-      - name: Upload text-free computational evidence only
+      - name: Build and encrypt restricted book archive
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          set -euo pipefail
+          DIR="local/ftrl-w7/${VIEWER}"
+          HANDOFF="local/private-handoff-w7-${VIEWER}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w7_${VIEWER}_restricted.tar.gz" \
+            "w7_${VIEWER}_page_ocr.jsonl" \
+            "w7_${VIEWER}_ocr_search.sqlite" \
+            "w7_${VIEWER}_qc_queue.json" \
+            "w7_${VIEWER}_asset_manifest.csv" \
+            "w7_${VIEWER}_run_manifest.json" \
+            "w7_${VIEWER}_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w7-${VIEWER}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w7_${VIEWER}_restricted.tar.gz" \
+            -out "$HANDOFF/w7_${VIEWER}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w7-${VIEWER}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w7-${VIEWER}.pass" \
+            -out "$HANDOFF/w7_${VIEWER}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w7_${VIEWER}_restricted.tar.gz.enc" "$HANDOFF/w7_${VIEWER}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w7_${VIEWER}_restricted.tar.gz" "/tmp/w7-${VIEWER}.pass"
+      - name: Write text-free encrypted handoff manifest
+        env:
+          VIEWER: ${{ matrix.viewer }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          handoff = Path(f'local/private-handoff-w7-{viewer}')
+          evidence = json.loads(Path(f'local/ftrl-w7/{viewer}/w7_{viewer}_evidence.json').read_text(encoding='utf-8'))
+          public_key = Path('security/ltmd_archive_public.pem')
+          public_key_sha256 = hashlib.sha256(public_key.read_bytes()).hexdigest()
+          assert public_key_sha256 == '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'
+          def desc(name):
+              p = handoff / name
+              h = hashlib.sha256()
+              with p.open('rb') as fh:
+                  for chunk in iter(lambda: fh.read(1024*1024), b''): h.update(chunk)
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h.hexdigest()}
+          payload = f'w7_{viewer}_restricted.tar.gz.enc'
+          key = f'w7_{viewer}_passphrase.rsa-oaep.enc'
+          m = {
+              'schema':'LTMD_PRIVATE_FTRL_W7_BOOK_HANDOFF_0.1', 'wave':'W7', 'viewer_key':viewer,
+              'page_records':evidence['page_records'], 'source_commit':os.environ['GH_SHA'],
+              'workflow_run_id':os.environ['GH_RUN_ID'],
+              'encryption':{'payload':'AES-256-CBC + PBKDF2-SHA256, 250000 iterations','key_wrap':'RSA-4096 OAEP SHA-256','public_key_sha256':public_key_sha256},
+              'files':[desc(payload),desc(key),desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded':False,
+              'destination_policy':'private Google Drive; Actions artifact is temporary encrypted handoff only',
+              'archival_complete':False,
+          }
+          (handoff / f'w7_{viewer}_private_handoff_manifest.json').write_text(json.dumps(m, indent=2, sort_keys=True)+'\n', encoding='utf-8')
+          PY
+      - name: Prove plaintext archive is absent
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          HANDOFF="local/private-handoff-w7-${VIEWER}"
+          test ! -f "$HANDOFF/w7_${VIEWER}_restricted.tar.gz"
+          test -f "$HANDOFF/w7_${VIEWER}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w7_${VIEWER}_passphrase.rsa-oaep.enc"
+      - name: Upload encrypted private handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w7-${{ matrix.viewer }}-private-encrypted
+          path: local/private-handoff-w7-${{ matrix.viewer }}/
+          if-no-files-found: error
+          retention-days: 3
+      - name: Upload text-free computational evidence
         uses: actions/upload-artifact@v4
         with:
           name: ltmd-u1-w7-${{ matrix.viewer }}-text-free-evidence
@@ -198,3 +276,20 @@ jobs:
           path: local/ltmd_u1_w7_global_evidence.json
           if-no-files-found: error
           retention-days: 30
+      - name: Report W7 computational validation and private handoff readiness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 64 --repo "$GITHUB_REPOSITORY" --body "FTRL W7 Formación Cívica y Ética — validación computacional exhaustiva COMPLETA en run ${GITHUB_RUN_ID}: 25 objetos canónicos source-admitted, 3,261/3,261 páginas, unión única y exacta; 5 source-retained identities continúan excluidas. SHA fuente, SQLite/FTS5 y QC validados por libro. Productos restringidos únicamente en 25 handoffs cifrados temporales. archival_complete permanece falso hasta consolidación y reverificación privada; text_verified y semantic_ready permanecen falsos."
+
+  report-failure:
+    name: report-w7-failure
+    if: failure() && github.event_name != 'pull_request'
+    needs: [config-gate, precondition, book, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report W7 failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 64 --repo "$GITHUB_REPOSITORY" --body "FTRL W7 Formación Cívica y Ética — corrida ${GITHUB_RUN_ID} NO completó todos sus gates. No se promueve W7 ni se declara archival_complete. Los handoffs exitosos son sólo evidencia diagnóstica y no sustituyen la unión exhaustiva 25/25 y 3,261/3,261."

--- a/data/research/ltmd_u1_w7_ftrl_run_stamp.json
+++ b/data/research/ltmd_u1_w7_ftrl_run_stamp.json
@@ -1,18 +1,21 @@
 {
   "schema": "LTMD_U1_W7_FTRL_RUN_STAMP_0.1",
   "requested_on": "2026-08-28",
-  "attempt": 2,
+  "attempt": 3,
   "wave": "W7",
   "domain": "civica_etica",
   "historical_identities": 30,
   "source_admitted_canonical_objects": 25,
   "withheld_source_identities": 5,
   "admitted_source_pages": 3261,
-  "purpose": "trigger deterministic distributed computational FTRL validation after merge",
-  "retry_reason": "first full run validated 19/25 books; six source-admitted books failed only on transient CONALITEG network timeouts",
+  "purpose": "trigger deterministic distributed W7 rerun with encrypted private archival handoffs after successful 25/25 computational validation",
+  "previous_computational_run_id": "33204203287",
+  "previous_computational_result": "25/25 source-admitted canonical objects and 3261/3261 pages validated; global exact union status ok",
+  "retry_reason": "attempt 2 intentionally uploaded only text-free evidence, so restricted outputs must be reproducibly regenerated and encrypted before temporary Actions handoff",
   "network_retry_policy": "up to 4 attempts for recognized transient network failures with bounded exponential backoff; SHA-256 and non-network failures remain hard gates",
+  "private_handoff_policy": "AES-256-CBC + PBKDF2-SHA256 payload; RSA-4096 OAEP-SHA256 wrapped passphrase; encrypted Actions handoffs retained 3 days; no plaintext restricted archive uploaded",
   "archival_complete": false,
   "text_verified": false,
   "semantic_ready": false,
-  "note": "The five source-retained identities remain excluded without aliases or imputations. This stamp authorizes computational validation only; private archival closure requires separate preservation evidence."
+  "note": "The five source-retained identities remain excluded without aliases or imputations. Attempt 3 authorizes encrypted private handoff generation only; archival_complete still requires independent private Google Drive preservation, redownload checksum verification, private consolidation validation, and a committed closure record."
 }


### PR DESCRIPTION
## Objetivo

Añadir a W7 Formación Cívica y Ética el mismo patrón de handoff privado cifrado ya validado en W9, sin modificar el corpus ni las cinco retenciones activas.

## Estado previo verificado

- run computacional `33204203287` sobre `7a52557ddd2f76d188f995fb52e71baee1c0cbcd`;
- 30 identidades históricas;
- 25 objetos canónicos source-admitted;
- 5 source-retained identities excluidas;
- unión global exacta: **25/25 libros y 3,261/3,261 páginas**;
- `validate-global-w7-union`: success;
- `archival_complete`: permanece false.

## Cambio

Por cada libro admitido, el workflow:

- regenera determinísticamente los derivados restringidos;
- empaqueta JSONL OCR, SQLite/FTS, QC y manifests;
- cifra payload con AES-256-CBC + PBKDF2-SHA256 (250000 iteraciones);
- envuelve la passphrase con RSA-4096 OAEP SHA-256 usando la clave pública canónica;
- elimina el tar plaintext antes de cualquier upload;
- publica sólo un handoff cifrado temporal de 3 días y la evidencia text-free de 30 días;
- mantiene `archival_complete=false` hasta preservación real, redescarga y verificación privada.

El `run_stamp` pasa a attempt 3 exclusivamente para generar estos handoffs después del éxito computacional de attempt 2.

Refs: #64