### PR TITLE
W8 Artes: distributed FTRL validation

### DIFF
--- a/.github/workflows/run-ftrl-w8-artes.yml
+++ b/.github/workflows/run-ftrl-w8-artes.yml
@@ -1,0 +1,290 @@
+name: Run FTRL W8 Artes
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'data/research/ltmd_u1_w8_ftrl_run_stamp.json'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/build_ftrl_w8_inputs.py'
+      - 'scripts/run_ftrl_w8_book.py'
+      - 'scripts/validate_ftrl_w8_distributed.py'
+      - '.github/workflows/run-ftrl-w8-artes.yml'
+      - 'data/research/ltmd_u1_w8_ftrl_run_stamp.json'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ftrl-w8-artes-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  config-gate:
+    name: validate-ftrl-w8-config
+    runs-on: ubuntu-latest
+    outputs:
+      viewers: ${{ steps.matrix.outputs.viewers }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile W8 FTRL scripts
+        run: python -m py_compile scripts/build_ftrl_w8_inputs.py scripts/run_ftrl_w8_book.py scripts/validate_ftrl_w8_distributed.py
+      - name: Rebuild normalized W8 inputs without network
+        run: |
+          python scripts/build_ftrl_w8_inputs.py \
+            --asset-output /tmp/w8_asset_manifest.csv \
+            --processing-output /tmp/w8_processing_inventory.csv
+      - name: Validate W8 denominator and derive exact matrix
+        id: matrix
+        shell: bash
+        run: |
+          python - <<'PY'
+          import csv, json, os
+          from collections import Counter
+
+          def read(path):
+              with open(path, encoding='utf-8', newline='') as fh:
+                  return list(csv.DictReader(fh))
+
+          assets = read('/tmp/w8_asset_manifest.csv')
+          proc = read('/tmp/w8_processing_inventory.csv')
+          gate = read('data/catalog/ltmd_u1_w8_artes_source_admissibility.csv')
+          withheld = {'H2018P3EAA','H2018P4EAA','H2018P5EAA','H2018P6EAA'}
+          assert len(gate) == 20
+          assert len(proc) == 16
+          assert len(assets) == 1490
+          assert {r['viewer_key'] for r in gate if r['source_admissible'] == '0'} == withheld
+          assert {r['viewer_key'] for r in gate if r['source_admissible'] == '1'} == {r['viewer_key'] for r in proc}
+          assert not ({r['viewer_key'] for r in assets} & withheld)
+          assert all(r['is_canonical_processing_object'] == '1' for r in proc)
+          assert all(r['technical_identity_covered'] == '1' for r in proc)
+          assert all(r['persistent_internal_source_gaps'] == '0' for r in proc)
+          expected = Counter({r['viewer_key']: int(r['direct_source_jpegs']) for r in proc})
+          observed = Counter(r['viewer_key'] for r in assets)
+          assert observed == expected
+          viewers = [r['viewer_key'] for r in proc]
+          assert len(viewers) == len(set(viewers)) == 16
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+              print('viewers=' + json.dumps(viewers, separators=(',', ':')), file=fh)
+          print('W8 config gate: 20 historical / 16 admitted / 4 withheld / 1490 pages')
+          PY
+
+  precondition:
+    name: require-w7-archival-closure
+    if: github.event_name != 'pull_request'
+    needs: config-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Require canonical W7 archival closure before W8
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          state = json.loads(Path('data/research/ltmd_u1_ftrl_wave_state.json').read_text(encoding='utf-8'))
+          w7 = state['waves']['W7']
+          assert w7['ftrl_status'] == 'validated', w7
+          assert w7['archival_status'] == 'archival_complete', w7
+          evidence = w7.get('archival_closure_evidence')
+          assert evidence == 'data/research/ltmd_u1_w7_archival_closure.json', w7
+          assert Path(evidence).is_file()
+          PY
+
+  book:
+    name: book-${{ matrix.viewer }}
+    if: github.event_name != 'pull_request'
+    needs: [config-gate, precondition]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        viewer: ${{ fromJSON(needs.config-gate.outputs.viewers) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+      - name: Validate private preservation canon
+        run: python scripts/validate_private_corpus_storage_contract.py
+      - name: Execute deterministic W8 book unit
+        run: |
+          python scripts/run_ftrl_w8_book.py \
+            --viewer-key '${{ matrix.viewer }}' \
+            --output-dir local/ftrl-w8
+      - name: Assert public evidence is text-free
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          p = Path(f'local/ftrl-w8/{viewer}/w8_{viewer}_evidence.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W8_BOOK_UNIT_0.1'
+          assert data['status'] == 'validated'
+          forbidden = {'ocr_text_raw','search_text','snippet','text','normalized_text'}
+          def walk(x):
+              if isinstance(x, dict):
+                  assert not (forbidden & set(x)), forbidden & set(x)
+                  for v in x.values(): walk(v)
+              elif isinstance(x, list):
+                  for v in x: walk(v)
+          walk(data)
+          PY
+      - name: Build and encrypt restricted book archive
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          set -euo pipefail
+          DIR="local/ftrl-w8/${VIEWER}"
+          HANDOFF="local/private-handoff-w8-${VIEWER}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w8_${VIEWER}_restricted.tar.gz" \
+            "w8_${VIEWER}_page_ocr.jsonl" \
+            "w8_${VIEWER}_ocr_search.sqlite" \
+            "w8_${VIEWER}_qc_queue.json" \
+            "w8_${VIEWER}_asset_manifest.csv" \
+            "w8_${VIEWER}_run_manifest.json" \
+            "w8_${VIEWER}_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w8-${VIEWER}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w8_${VIEWER}_restricted.tar.gz" \
+            -out "$HANDOFF/w8_${VIEWER}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w8-${VIEWER}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w8-${VIEWER}.pass" \
+            -out "$HANDOFF/w8_${VIEWER}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w8_${VIEWER}_restricted.tar.gz.enc" "$HANDOFF/w8_${VIEWER}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w8_${VIEWER}_restricted.tar.gz" "/tmp/w8-${VIEWER}.pass"
+      - name: Write text-free encrypted handoff manifest
+        env:
+          VIEWER: ${{ matrix.viewer }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          handoff = Path(f'local/private-handoff-w8-{viewer}')
+          evidence = json.loads(Path(f'local/ftrl-w8/{viewer}/w8_{viewer}_evidence.json').read_text(encoding='utf-8'))
+          public_key = Path('security/ltmd_archive_public.pem')
+          public_key_sha256 = hashlib.sha256(public_key.read_bytes()).hexdigest()
+          assert public_key_sha256 == '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'
+          def desc(name):
+              p = handoff / name
+              h = hashlib.sha256()
+              with p.open('rb') as fh:
+                  for chunk in iter(lambda: fh.read(1024*1024), b''): h.update(chunk)
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h.hexdigest()}
+          payload = f'w8_{viewer}_restricted.tar.gz.enc'
+          key = f'w8_{viewer}_passphrase.rsa-oaep.enc'
+          m = {
+              'schema':'LTMD_PRIVATE_FTRL_W8_BOOK_HANDOFF_0.1', 'wave':'W8', 'viewer_key':viewer,
+              'page_records':evidence['page_records'], 'source_commit':os.environ['GH_SHA'],
+              'workflow_run_id':os.environ['GH_RUN_ID'],
+              'encryption':{'payload':'AES-256-CBC + PBKDF2-SHA256, 250000 iterations','key_wrap':'RSA-4096 OAEP SHA-256','public_key_sha256':public_key_sha256},
+              'files':[desc(payload),desc(key),desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded':False,
+              'destination_policy':'private Google Drive; Actions artifact is temporary encrypted handoff only',
+              'archival_complete':False,
+          }
+          (handoff / f'w8_{viewer}_private_handoff_manifest.json').write_text(json.dumps(m, indent=2, sort_keys=True)+'\n', encoding='utf-8')
+          PY
+      - name: Prove plaintext archive is absent
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          HANDOFF="local/private-handoff-w8-${VIEWER}"
+          test ! -f "$HANDOFF/w8_${VIEWER}_restricted.tar.gz"
+          test -f "$HANDOFF/w8_${VIEWER}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w8_${VIEWER}_passphrase.rsa-oaep.enc"
+      - name: Upload encrypted private handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w8-${{ matrix.viewer }}-private-encrypted
+          path: local/private-handoff-w8-${{ matrix.viewer }}/
+          if-no-files-found: error
+          retention-days: 3
+      - name: Upload text-free computational evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w8-${{ matrix.viewer }}-text-free-evidence
+          path: |
+            local/ftrl-w8/${{ matrix.viewer }}/w8_${{ matrix.viewer }}_evidence.json
+            local/ftrl-w8/${{ matrix.viewer }}/w8_${{ matrix.viewer }}_run_manifest.json
+            local/ftrl-w8/${{ matrix.viewer }}/w8_${{ matrix.viewer }}_qc_summary.json
+            local/ftrl-w8/${{ matrix.viewer }}/w8_${{ matrix.viewer }}_asset_manifest.csv
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: validate-global-w8-union
+    if: github.event_name != 'pull_request'
+    needs: book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Download all text-free W8 evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ltmd-u1-w8-*-text-free-evidence
+          path: local/w8-evidence
+          merge-multiple: false
+      - name: Rebuild canonical W8 admitted inputs
+        run: |
+          mkdir -p local/w8-expected
+          python scripts/build_ftrl_w8_inputs.py \
+            --asset-output local/w8-expected/asset_manifest.csv \
+            --processing-output local/w8-expected/processing_inventory.csv
+      - name: Validate exact exhaustive admitted union
+        run: |
+          python scripts/validate_ftrl_w8_distributed.py \
+            --evidence-root local/w8-evidence \
+            --asset-manifest local/w8-expected/asset_manifest.csv \
+            --processing-inventory local/w8-expected/processing_inventory.csv \
+            --output local/ltmd_u1_w8_global_evidence.json
+      - name: Upload global text-free evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w8-global-text-free-evidence
+          path: local/ltmd_u1_w8_global_evidence.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: Report W8 computational validation and private handoff readiness
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 9 --repo "$GITHUB_REPOSITORY" --body "FTRL W8 Artes — validación computacional exhaustiva COMPLETA en run ${GITHUB_RUN_ID}: 16 objetos canónicos source-admitted, 1,490/1,490 páginas, unión única y exacta; 4 source-retained identities continúan excluidas. SHA fuente, SQLite/FTS5 y QC validados por libro. Productos restringidos únicamente en 16 handoffs cifrados temporales. archival_complete permanece falso hasta consolidación y reverificación privada; text_verified y semantic_ready permanecen falsos."
+
+  report-failure:
+    name: report-w8-failure
+    if: failure() && github.event_name != 'pull_request'
+    needs: [config-gate, precondition, book, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report W8 failure
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment 9 --repo "$GITHUB_REPOSITORY" --body "FTRL W8 Artes — corrida ${GITHUB_RUN_ID} NO completó todos sus gates. No se promueve W8 ni se declara archival_complete. Los handoffs exitosos son sólo evidencia diagnóstica y no sustituyen la unión exhaustiva 16/16 y 1,490/1,490."

--- a/data/research/ltmd_u1_w8_ftrl_run_stamp.json
+++ b/data/research/ltmd_u1_w8_ftrl_run_stamp.json
@@ -1,0 +1,23 @@
+{
+  "schema": "LTMD_U1_W8_FTRL_RUN_STAMP_0.1",
+  "requested_on": "2026-08-28",
+  "wave": "W8",
+  "domain": "artes",
+  "attempt": 1,
+  "historical_identities": 20,
+  "source_admitted_canonical_objects": 16,
+  "source_retained_identities": 4,
+  "source_pages": 1490,
+  "purpose": "Trigger deterministic distributed computational FTRL validation and encrypted private handoff generation after merge, gated on canonical W7 archival closure.",
+  "retained_viewer_keys": [
+    "H2018P3EAA",
+    "H2018P4EAA",
+    "H2018P5EAA",
+    "H2018P6EAA"
+  ],
+  "aliases_or_imputations_for_retained_identities": 0,
+  "archival_complete": false,
+  "text_verified": false,
+  "semantic_ready": false,
+  "note": "This stamp does not promote W8. It freezes the source-admitted computational denominator only; archival closure requires persistent private preservation, redownload checksum verification, and private consolidation of all 16 encrypted handoffs."
+}

--- a/scripts/build_ftrl_w8_inputs.py
+++ b/scripts/build_ftrl_w8_inputs.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Normalize versioned W8 Artes topology for generic FTRL.
+
+Only the 16 source-admitted canonical identities enter the computational corpus.
+The four 2018 source-retained identities remain explicit in the canonical gate
+and are never aliased, imputed, or silently absorbed into an admitted viewer.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import Counter
+from pathlib import Path
+
+VERSION = "LTMD_U1_W8_FTRL_INPUTS_0.1"
+EXPECTED_HISTORICAL = 20
+EXPECTED_CANONICAL = 16
+EXPECTED_WITHHELD = 4
+EXPECTED_PAGES = 1490
+WITHHELD = {
+    "H2018P3EAA",
+    "H2018P4EAA",
+    "H2018P5EAA",
+    "H2018P6EAA",
+}
+SHA = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_GATE = Path("data/catalog/ltmd_u1_w8_artes_source_admissibility.csv")
+TOPOLOGY = Path("data/catalog/ltmd_u1_w8_processing_inventory.csv")
+MANIFEST = Path("data/catalog/ltmd_u1_w8_artes_asset_manifest.csv")
+
+
+def read(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def n(row: dict[str, str], key: str) -> int:
+    value = row.get(key, "")
+    if value in {"", None}:
+        raise AssertionError(f"missing {key}: {row}")
+    return int(float(value))
+
+
+def write(path: Path, rows: list[dict[str, object]], fields: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--asset-output", default="local/ftrl/ltmd_u1_w8_asset_manifest.csv")
+    ap.add_argument("--processing-output", default="local/ftrl/ltmd_u1_w8_processing_inventory.csv")
+    args = ap.parse_args()
+
+    gate = read(SOURCE_GATE)
+    topology = read(TOPOLOGY)
+    manifest = read(MANIFEST)
+
+    assert len(gate) == EXPECTED_HISTORICAL
+    assert len(topology) == EXPECTED_HISTORICAL
+    assert len({r["viewer_key"] for r in gate}) == EXPECTED_HISTORICAL
+    assert {r["viewer_key"] for r in topology} == {r["viewer_key"] for r in gate}
+    topo = {r["viewer_key"]: r for r in topology}
+
+    admitted = [r for r in gate if n(r, "source_admissible") == 1]
+    withheld = [r for r in gate if n(r, "source_admissible") == 0]
+    admitted_keys = {r["viewer_key"] for r in admitted}
+    withheld_keys = {r["viewer_key"] for r in withheld}
+
+    assert len(admitted) == EXPECTED_CANONICAL
+    assert len(withheld) == EXPECTED_WITHHELD
+    assert withheld_keys == WITHHELD
+    assert admitted_keys.isdisjoint(WITHHELD)
+
+    for r in admitted:
+        viewer = r["viewer_key"]
+        t = topo[viewer]
+        assert r["source_status"] == "SOURCE_ADMISSIBLE"
+        assert n(r, "direct_asset_ready") == 1
+        assert n(r, "internal_unserved") == 0
+        assert n(r, "probe_errors") == 0
+        assert n(r, "source_jpegs") == n(r, "declared_positions") - 1
+        assert r["alias_state"] == "no_alias"
+        assert t["source_status"] == "SOURCE_ADMISSIBLE"
+        assert t["processing_mode"] == "direct_canonical"
+        assert n(t, "is_canonical_processing_object") == 1
+        assert n(t, "ocr_identity_eligible") == 1
+        assert n(t, "source_page_count") == n(r, "source_jpegs")
+        assert n(t, "declared_positions") == n(r, "declared_positions")
+        assert n(t, "persistent_internal_source_gaps") == 0
+        assert n(t, "probe_errors") == 0
+        assert t["alias_state"] == "no_alias"
+
+    for r in withheld:
+        viewer = r["viewer_key"]
+        t = topo[viewer]
+        assert r["source_status"] == "SOURCE_RETAINED"
+        assert n(r, "source_jpegs") == 0
+        assert n(r, "direct_asset_ready") == 0
+        assert n(r, "internal_unserved") == n(r, "declared_positions")
+        assert n(r, "probe_errors") == 0
+        assert r["alias_state"] == "no_alias"
+        assert t["source_status"] == "SOURCE_RETAINED"
+        assert t["processing_mode"] == "withheld_source"
+        assert n(t, "is_canonical_processing_object") == 0
+        assert n(t, "ocr_identity_eligible") == 0
+        assert n(t, "source_page_count") == 0
+        assert n(t, "persistent_internal_source_gaps") == n(t, "declared_positions")
+        assert t["alias_state"] == "no_alias"
+
+    assert sum(n(r, "source_jpegs") for r in admitted) == EXPECTED_PAGES
+
+    pfields = [
+        "processing_version", "viewer_key", "catalog_generation", "grade_code", "title_core",
+        "processing_mode", "canonical_processing_viewer_key", "technical_identity_covered",
+        "is_canonical_processing_object", "declared_positions", "direct_source_jpegs",
+        "persistent_internal_source_gaps", "source_processing_basis", "interpretive_limit",
+    ]
+    pout: list[dict[str, object]] = []
+    for r in admitted:
+        viewer = r["viewer_key"]
+        pout.append({
+            "processing_version": VERSION,
+            "viewer_key": viewer,
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "processing_mode": "direct_canonical",
+            "canonical_processing_viewer_key": viewer,
+            "technical_identity_covered": 1,
+            "is_canonical_processing_object": 1,
+            "declared_positions": n(r, "declared_positions"),
+            "direct_source_jpegs": n(r, "source_jpegs"),
+            "persistent_internal_source_gaps": 0,
+            "source_processing_basis": f"{r['admissibility_version']}:{r['source_status']}",
+            "interpretive_limit": "technical FTRL only; four retained W8 identities remain outside the corpus; OCR availability does not imply text verification or semantic validation",
+        })
+
+    afields = [
+        "audit_version", "viewer_key", "catalog_generation", "grade_code", "title_core",
+        "viewer_page", "source_image_index", "source_asset_url", "asset_status", "byte_size",
+        "sha256", "processing_mode", "source_provenance",
+    ]
+    aout: list[dict[str, object]] = []
+    seen: set[tuple[str, int]] = set()
+    counts: Counter[str] = Counter()
+    retained_source_rows = 0
+
+    for r in manifest:
+        viewer = r["viewer_key"]
+        if viewer in WITHHELD and r.get("asset_status") == "source_jpeg":
+            retained_source_rows += 1
+        if viewer not in admitted_keys or r.get("asset_status") != "source_jpeg":
+            continue
+
+        index = n(r, "source_image_index")
+        key = (viewer, index)
+        assert key not in seen
+        seen.add(key)
+        assert n(r, "byte_size") > 0
+        assert SHA.fullmatch(r["sha256"])
+        assert r["source_asset_url"].startswith(f"https://historico.conaliteg.gob.mx/c/{viewer}/")
+        assert n(r, "http_status") == 200
+        assert r["probe_state"] == "served_image"
+        assert r["content_type"].lower().startswith("image/")
+        assert not r.get("error")
+
+        counts[viewer] += 1
+        aout.append({
+            "audit_version": VERSION,
+            "viewer_key": viewer,
+            "catalog_generation": n(r, "catalog_generation"),
+            "grade_code": n(r, "grade_code"),
+            "title_core": r["title_core"],
+            "viewer_page": n(r, "viewer_page"),
+            "source_image_index": index,
+            "source_asset_url": r["source_asset_url"],
+            "asset_status": "source_jpeg",
+            "byte_size": n(r, "byte_size"),
+            "sha256": r["sha256"],
+            "processing_mode": "direct_canonical",
+            "source_provenance": f"{r['audit_version']}:historico_conaliteg_direct_jpeg",
+        })
+
+    expected_counts = {r["viewer_key"]: n(r, "source_jpegs") for r in admitted}
+    assert dict(counts) == expected_counts
+    assert len(aout) == len(seen) == EXPECTED_PAGES
+    assert sum(int(r["direct_source_jpegs"]) for r in pout) == EXPECTED_PAGES
+    assert not ({r["viewer_key"] for r in aout} & WITHHELD)
+    assert retained_source_rows == 0
+
+    write(Path(args.processing_output), pout, pfields)
+    write(Path(args.asset_output), aout, afields)
+    print(
+        f"Built W8 FTRL inputs: historical={EXPECTED_HISTORICAL}, "
+        f"canonical={len(pout)}, withheld={len(withheld)}, pages={len(aout)}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_ftrl_w8_book.py
+++ b/scripts/run_ftrl_w8_book.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Run one deterministic LTMD-U1 W8 Artes FTRL book unit.
+
+Restricted OCR/SQLite/QC stay under local/ and must be encrypted before any
+Actions upload. Public evidence is metadata/hash only. Retained W8 identities
+are excluded upstream by the normalized input builder.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+EXPECTED_HISTORICAL = 20
+EXPECTED_CANONICAL = 16
+EXPECTED_WITHHELD = 4
+EXPECTED_TOTAL = 1490
+SCHEMA = "LTMD_FTRL_W8_BOOK_UNIT_0.1"
+NETWORK_RETRY_ATTEMPTS = 4
+NETWORK_RETRY_MARKERS = (
+    "urlerror", "timeouterror", "timed out", "temporary failure",
+    "temporarily unavailable", "connection reset", "remote end closed connection",
+    "http error 429", "http error 500", "http error 502", "http error 503", "http error 504",
+)
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, check=True)
+
+
+def run_network_resilient(command: list[str]) -> None:
+    for attempt in range(1, NETWORK_RETRY_ATTEMPTS + 1):
+        print("+", " ".join(command), flush=True)
+        proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        output = proc.stdout or ""
+        if output:
+            print(output, end="" if output.endswith("\n") else "\n", flush=True)
+        if proc.returncode == 0:
+            return
+        transient = any(marker in output.lower() for marker in NETWORK_RETRY_MARKERS)
+        if not transient or attempt == NETWORK_RETRY_ATTEMPTS:
+            raise subprocess.CalledProcessError(proc.returncode, command, output=output)
+        delay = 5 * (2 ** (attempt - 1))
+        print(f"Transient source-network failure; retrying attempt {attempt + 1}/{NETWORK_RETRY_ATTEMPTS} after {delay}s", flush=True)
+        time.sleep(delay)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    if not rows:
+        raise SystemExit(f"refusing to write empty unit: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows[0]))
+        writer.writeheader(); writer.writerows(rows)
+
+
+def require_environment() -> None:
+    if shutil.which("tesseract") is None:
+        raise SystemExit("Tesseract is required")
+    langs = subprocess.run(["tesseract", "--list-langs"], check=True, capture_output=True, text=True).stdout.splitlines()
+    if "spa" not in {x.strip() for x in langs}:
+        raise SystemExit("Spanish Tesseract language data is required")
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.execute("CREATE VIRTUAL TABLE smoke_fts USING fts5(text)")
+    finally:
+        conn.close()
+
+
+def descriptor(path: Path) -> dict[str, object]:
+    return {"name": path.name, "bytes": path.stat().st_size, "sha256": sha256_file(path)}
+
+
+def jsonl_hashes(path: Path, viewer_key: str) -> tuple[list[str], int]:
+    hashes: list[str] = []
+    count = 0
+    with path.open(encoding="utf-8") as fh:
+        for line_number, line in enumerate(fh, 1):
+            if not line.strip():
+                continue
+            row = json.loads(line)
+            if row.get("wave") != "W8" or row.get("viewer_key") != viewer_key:
+                raise SystemExit(f"foreign W8 record at {path}:{line_number}")
+            hashes.append(page_key_hash(viewer_key, int(row["page_index"])))
+            count += 1
+    return sorted(hashes), count
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--viewer-key", required=True)
+    ap.add_argument("--output-dir", type=Path, default=Path("local/ftrl-w8"))
+    args = ap.parse_args()
+    require_environment()
+
+    viewer = args.viewer_key
+    root = args.output_dir
+    unit = root / viewer
+    unit.mkdir(parents=True, exist_ok=True)
+    full_asset = root / "ltmd_u1_w8_asset_manifest.csv"
+    processing = root / "ltmd_u1_w8_processing_inventory.csv"
+    run([sys.executable, "scripts/build_ftrl_w8_inputs.py", "--asset-output", str(full_asset), "--processing-output", str(processing)])
+
+    proc = read_csv(processing)
+    if len(proc) != EXPECTED_CANONICAL:
+        raise SystemExit("W8 canonical processing denominator drift")
+    canonical = {r["viewer_key"] for r in proc if r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1"}
+    if len(canonical) != EXPECTED_CANONICAL or viewer not in canonical:
+        raise SystemExit(f"viewer is not a W8 source-admitted canonical identity: {viewer}")
+    if any(r["persistent_internal_source_gaps"] != "0" for r in proc):
+        raise SystemExit("W8 admitted processing inventory contains a source gap")
+
+    by = {r["viewer_key"]: r for r in proc}
+    pages_expected = int(by[viewer]["direct_source_jpegs"])
+    assets = read_csv(full_asset)
+    if len(assets) != EXPECTED_TOTAL:
+        raise SystemExit("W8 global source cardinality drift")
+    if len({r["viewer_key"] for r in assets}) != EXPECTED_CANONICAL:
+        raise SystemExit("W8 source-admitted viewer denominator drift")
+    rows = sorted([r for r in assets if r["viewer_key"] == viewer], key=lambda r: int(r["source_image_index"]))
+    if len(rows) != pages_expected:
+        raise SystemExit(f"W8 {viewer} source cardinality drift: {len(rows)} != {pages_expected}")
+
+    expected_hashes = sorted(page_key_hash(viewer, int(r["source_image_index"])) for r in rows)
+    if len(expected_hashes) != len(set(expected_hashes)):
+        raise SystemExit("duplicate expected page key inside W8 book unit")
+
+    prefix = f"w8_{viewer}"
+    unit_asset = unit / f"{prefix}_asset_manifest.csv"
+    jsonl = unit / f"{prefix}_page_ocr.jsonl"
+    db = unit / f"{prefix}_ocr_search.sqlite"
+    run_manifest = unit / f"{prefix}_run_manifest.json"
+    qc_queue = unit / f"{prefix}_qc_queue.json"
+    qc_summary = unit / f"{prefix}_qc_summary.json"
+    evidence = unit / f"{prefix}_evidence.json"
+    write_csv(unit_asset, rows)
+
+    run_network_resilient([sys.executable, "scripts/build_page_ocr_corpus.py", "--asset-manifest", str(unit_asset), "--processing-inventory", str(processing), "--wave", "W8", "--output", str(jsonl), "--cache-dir", str(unit / "assets"), "--resume"])
+    run([sys.executable, "scripts/build_search_index.py", "--input", str(jsonl), "--processing-inventory", str(processing), "--output", str(db)])
+    run([sys.executable, "scripts/validate_ocr_corpus.py", "--input", str(jsonl), "--db", str(db)])
+    run([sys.executable, "scripts/summarize_ftrl_run.py", "--input", str(jsonl), "--db", str(db), "--asset-manifest", str(unit_asset), "--processing-inventory", str(processing), "--label", viewer, "--output", str(run_manifest)])
+    run([sys.executable, "scripts/build_ftrl_qc_queue.py", "--input", str(jsonl), "--queue-output", str(qc_queue), "--summary-output", str(qc_summary)])
+
+    actual_hashes, actual_count = jsonl_hashes(jsonl, viewer)
+    if actual_count != pages_expected or actual_hashes != expected_hashes:
+        raise SystemExit("W8 book page inventory mismatch")
+    rm = json.loads(run_manifest.read_text(encoding="utf-8"))
+    qc = json.loads(qc_summary.read_text(encoding="utf-8"))
+    if rm["status"] != "validated" or rm["database"]["sqlite_integrity"] != "ok":
+        raise SystemExit("W8 book validation failed")
+    if rm["corpus"]["page_records"] != pages_expected or rm["database"]["page_rows"] != pages_expected or rm["database"]["fts_rows"] != pages_expected or qc["page_records"] != pages_expected:
+        raise SystemExit("W8 book cardinality drift")
+
+    payload = {
+        "schema": SCHEMA,
+        "status": "validated",
+        "wave": "W8",
+        "domain": "Artes",
+        "viewer_key": viewer,
+        "page_records": pages_expected,
+        "page_key_hashes": expected_hashes,
+        "source_partition": {
+            "historical_identities": EXPECTED_HISTORICAL,
+            "canonical_processing_objects": EXPECTED_CANONICAL,
+            "withheld_identities": EXPECTED_WITHHELD,
+            "full_admitted_source_pages": EXPECTED_TOTAL,
+            "unit": "one source-admitted canonical viewer/book",
+        },
+        "validation": {
+            "sqlite_integrity": "ok",
+            "sqlite_pages": rm["database"]["page_rows"],
+            "fts_rows": rm["database"]["fts_rows"],
+            "qc_page_records": qc["page_records"],
+        },
+        "restricted_products": [descriptor(jsonl), descriptor(db), descriptor(qc_queue)],
+        "text_free_products": [descriptor(unit_asset), descriptor(run_manifest), descriptor(qc_summary)],
+        "execution": rm.get("execution"),
+        "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "epistemic_guards": [
+            "computationally_validated != archival_complete",
+            "ocr_available != text_verified",
+            "corpus_ready != semantic_ready",
+            "retained_source_identity != alias_candidate",
+            "search_hit != historical_claim",
+            "zero_hits != demonstrated_absence",
+        ],
+    }
+    evidence.write_text(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "viewer_key": viewer, "pages": pages_expected, "evidence": str(evidence)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_ftrl_w8_distributed.py
+++ b/scripts/validate_ftrl_w8_distributed.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Validate exact union of all W8 Artes FTRL source-admitted book evidences."""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+EXPECTED_HISTORICAL = 20
+EXPECTED_CANONICAL = 16
+EXPECTED_WITHHELD = 4
+EXPECTED_TOTAL = 1490
+SCHEMA = "LTMD_FTRL_W8_GLOBAL_EVIDENCE_0.1"
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--evidence-root", type=Path, required=True)
+    ap.add_argument("--asset-manifest", type=Path, required=True)
+    ap.add_argument("--processing-inventory", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    proc = read_csv(args.processing_inventory)
+    assets = read_csv(args.asset_manifest)
+    if len(proc) != EXPECTED_CANONICAL:
+        raise SystemExit(f"expected {EXPECTED_CANONICAL} W8 processing rows, found {len(proc)}")
+    viewers = {r["viewer_key"] for r in proc}
+    if len(viewers) != EXPECTED_CANONICAL:
+        raise SystemExit("duplicate W8 canonical processing identity")
+    if not all(r["technical_identity_covered"] == "1" and r["is_canonical_processing_object"] == "1" and r["persistent_internal_source_gaps"] == "0" for r in proc):
+        raise SystemExit("invalid W8 admitted processing inventory")
+    if len(assets) != EXPECTED_TOTAL:
+        raise SystemExit(f"expected {EXPECTED_TOTAL} W8 source pages, found {len(assets)}")
+    counts = Counter(r["viewer_key"] for r in assets)
+    expected_counts = Counter({r["viewer_key"]: int(r["direct_source_jpegs"]) for r in proc})
+    if counts != expected_counts:
+        raise SystemExit(f"W8 per-viewer page counts drift: {counts} != {expected_counts}")
+
+    expected_hashes = {page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in assets}
+    if len(expected_hashes) != EXPECTED_TOTAL:
+        raise SystemExit("W8 expected page-key hash collision or duplicate")
+
+    evidence_files = sorted(args.evidence_root.rglob("w8_*_evidence.json"))
+    if len(evidence_files) != EXPECTED_CANONICAL:
+        raise SystemExit(f"expected {EXPECTED_CANONICAL} W8 evidence files, found {len(evidence_files)}")
+
+    seen_viewers: set[str] = set()
+    union_hashes: set[str] = set()
+    book_records: dict[str, int] = {}
+    qc_records = sqlite_records = fts_records = 0
+    product_hashes: list[dict[str, object]] = []
+
+    for path in evidence_files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data["schema"] != "LTMD_FTRL_W8_BOOK_UNIT_0.1":
+            raise SystemExit(f"unexpected W8 book evidence schema: {path}")
+        if data["status"] != "validated" or data["wave"] != "W8":
+            raise SystemExit(f"non-validated or foreign W8 evidence: {path}")
+        viewer = data["viewer_key"]
+        if viewer not in viewers or viewer in seen_viewers:
+            raise SystemExit(f"unexpected or duplicate W8 viewer evidence: {viewer}")
+        seen_viewers.add(viewer)
+
+        pages = int(data["page_records"])
+        if pages != expected_counts[viewer]:
+            raise SystemExit(f"W8 evidence page drift for {viewer}: {pages}")
+        hashes = list(data["page_key_hashes"])
+        if len(hashes) != pages or len(set(hashes)) != pages:
+            raise SystemExit(f"duplicate/missing W8 page hashes for {viewer}")
+        if union_hashes & set(hashes):
+            raise SystemExit(f"cross-book W8 page hash overlap for {viewer}")
+        union_hashes.update(hashes)
+
+        partition = data["source_partition"]
+        if int(partition["historical_identities"]) != EXPECTED_HISTORICAL or int(partition["canonical_processing_objects"]) != EXPECTED_CANONICAL or int(partition["withheld_identities"]) != EXPECTED_WITHHELD or int(partition["full_admitted_source_pages"]) != EXPECTED_TOTAL:
+            raise SystemExit(f"W8 source partition drift for {viewer}")
+
+        validation = data["validation"]
+        if validation["sqlite_integrity"] != "ok":
+            raise SystemExit(f"SQLite integrity failure for {viewer}")
+        if int(validation["sqlite_pages"]) != pages or int(validation["fts_rows"]) != pages or int(validation["qc_page_records"]) != pages:
+            raise SystemExit(f"W8 validation cardinality drift for {viewer}")
+        sqlite_records += int(validation["sqlite_pages"])
+        fts_records += int(validation["fts_rows"])
+        qc_records += int(validation["qc_page_records"])
+        book_records[viewer] = pages
+
+        for group in ("restricted_products", "text_free_products"):
+            if len(data[group]) != 3:
+                raise SystemExit(f"unexpected W8 product count for {viewer}: {group}")
+            for item in data[group]:
+                if len(item["sha256"]) != 64 or int(item["bytes"]) <= 0:
+                    raise SystemExit(f"invalid W8 product descriptor for {viewer}")
+                product_hashes.append({"viewer_key": viewer, "class": group, "name": item["name"], "bytes": item["bytes"], "sha256": item["sha256"]})
+
+    if seen_viewers != viewers:
+        raise SystemExit("W8 evidence viewer union is not exhaustive")
+    if union_hashes != expected_hashes or len(union_hashes) != EXPECTED_TOTAL:
+        raise SystemExit("W8 page evidence union is not exact and exhaustive")
+    if sqlite_records != EXPECTED_TOTAL or fts_records != EXPECTED_TOTAL or qc_records != EXPECTED_TOTAL:
+        raise SystemExit("W8 global SQLite/FTS/QC cardinality drift")
+    if len(product_hashes) != EXPECTED_CANONICAL * 6:
+        raise SystemExit("W8 global product descriptor cardinality drift")
+
+    out = {
+        "schema": SCHEMA,
+        "status": "validated",
+        "wave": "W8",
+        "domain": "Artes",
+        "historical_identities": EXPECTED_HISTORICAL,
+        "canonical_processing_objects": EXPECTED_CANONICAL,
+        "withheld_source_identities": EXPECTED_WITHHELD,
+        "source_pages": EXPECTED_TOTAL,
+        "book_page_records": dict(sorted(book_records.items())),
+        "unique_page_key_hashes": len(union_hashes),
+        "sqlite_page_rows": sqlite_records,
+        "fts_rows": fts_records,
+        "qc_page_records": qc_records,
+        "source_gaps_in_admitted_canonical_objects": 0,
+        "aliases_for_withheld_identities": 0,
+        "products": sorted(product_hashes, key=lambda x: (x["viewer_key"], x["class"], x["name"])),
+        "archival_complete": False,
+        "text_verified": False,
+        "semantic_ready": False,
+        "epistemic_guards": [
+            "computationally_validated != archival_complete",
+            "ocr_available != text_verified",
+            "corpus_ready != semantic_ready",
+            "retained_source_identity != alias_candidate",
+            "search_hit != historical_claim",
+            "zero_hits != demonstrated_absence",
+        ],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "books": EXPECTED_CANONICAL, "withheld": EXPECTED_WITHHELD, "pages": EXPECTED_TOTAL, "output": str(args.output)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds the distributed FTRL execution path for W8 Artes using the already-established source-admissibility topology.

- freezes the exact W8 denominator at 20 historical identities;
- admits 16 direct canonical source-backed books totaling 1,490 source pages;
- keeps H2018P3EAA, H2018P4EAA, H2018P5EAA and H2018P6EAA explicitly source-retained;
- creates deterministic per-book OCR/SQLite/FTS/QC execution;
- validates the exact exhaustive union across all 16 admitted books;
- uploads only text-free evidence publicly;
- creates encrypted temporary private handoffs for restricted derivatives;
- requires canonical W7 archival closure before any post-merge W8 execution.

## Scientific safeguards

No retained identity is aliased or imputed. `archival_complete`, `text_verified`, and `semantic_ready` remain false in this PR. Computational validation after merge does not itself imply archival closure or semantic validation.

## Expected post-merge run

16 canonical processing objects / 4 retained identities / 1,490 admitted source pages. Any denominator, page-union, SHA, SQLite/FTS/QC, or preservation-contract drift is a hard failure.