### PR TITLE
Research: preregister Indigenous-language visual validation Stage 1

### DIFF
--- a/docs/LTMD_U1_INDIGENOUS_LANGUAGES_VALIDATION_STAGE1_0_1.md
+++ b/docs/LTMD_U1_INDIGENOUS_LANGUAGES_VALIDATION_STAGE1_0_1.md
@@ -1,0 +1,87 @@
+# LTMD-U1 — validación visual de lenguas indígenas, Stage 1 (0.1)
+
+## Estado y dependencia
+
+Este protocolo continúa `LTMD_U1_INDIGENOUS_LANGUAGES_RERUN_0.2` sin modificar sus reglas de recuperación ni sus resultados. El rerun 0.2 produjo 1,151 páginas candidatas, de las cuales 457 pertenecen a la capa `explicit_general`. Todas permanecen en estado `not_visually_validated`.
+
+La prioridad de Stage 1 es validar visualmente las 457 páginas `explicit_general` contra su activo fuente antes de formular inferencias históricas o promover cualquier registro a `semantic_ready`.
+
+## Principios no negociables
+
+- `ocr_available != text_verified`.
+- `search_hit != historical_claim`.
+- La unidad inicial de revisión es la página fuente, no el hit OCR.
+- No se publica OCR, transcripción extensa, snippet ni imagen fuente.
+- La validación sólo puede cambiar el estado científico después de inspección visual de la página correspondiente.
+- Los resultados 0.2 no se recalibran retrospectivamente a partir de la validación; cualquier cambio futuro del algoritmo de recuperación requiere nueva versión.
+
+## Cola privada de validación
+
+La cola se construye localmente desde el ledger privado `ltmd_u1_indigenous_languages_candidate_ledger_0_2.csv` con:
+
+```bash
+python scripts/prepare_indigenous_validation_sample.py \
+  --candidate-ledger /ruta/privada/ltmd_u1_indigenous_languages_candidate_ledger_0_2.csv \
+  --output-csv /ruta/privada/ltmd_u1_indigenous_languages_validation_queue_0_1.csv \
+  --manifest-json /ruta/privada/ltmd_u1_indigenous_languages_validation_queue_manifest_0_1.json \
+  --expected-explicit 457
+```
+
+El script falla si la cardinalidad de la capa explícita deja de ser 457, si faltan campos requeridos o si un `page_id` duplicado presenta conflicto de identidad/hashes.
+
+La cola resultante contiene únicamente identificadores, metadatos de fuente, hashes, términos de consulta ya derivados y campos vacíos de codificación. No contiene `search_text`, OCR ni fragmentos.
+
+## Doble codificación preregistrada
+
+Antes de observar resultados de validación, Stage 1 fija una selección determinista para acuerdo intercodificador:
+
+- estratificación por `generation`;
+- ranking pseudoaleatorio reproducible mediante SHA-256 de `seed + page_id`;
+- 10% de cada generación, redondeado hacia arriba;
+- mínimo de 2 páginas por generación cuando el estrato lo permita;
+- si un estrato tiene menos de 2 páginas, se selecciona completo.
+
+El conjunto puede reconstruirse exactamente con el mismo ledger y seed. Cambiar tasa, mínimo o seed constituye una nueva versión del protocolo.
+
+## Secuencia de revisión
+
+Cada una de las 457 páginas debe pasar por:
+
+1. comprobación de que `source_asset_url` corresponde al `page_id` y al `canonical_viewer_key` esperados;
+2. comprobación visual de que la página fuente carga y corresponde a la posición declarada;
+3. decisión `verified_true | false_positive | uncertain`;
+4. clasificación con `LTMD_U1_INDIGENOUS_LANGUAGES_CODEBOOK_0_1.md` sólo cuando la evidencia visual lo permite;
+5. registro conservador de `false_positive_cause` cuando proceda;
+6. adjudicación posterior de desacuerdos en las páginas marcadas `double_code_required=1`.
+
+## Causas de falso positivo
+
+Stage 1 admite, como mínimo, las siguientes categorías no expresivas:
+
+- `ocr_error`;
+- `homonym_or_polysemy`;
+- `non_linguistic_named_group`;
+- `context_too_weak`;
+- `source_mismatch`;
+- `other_documented`.
+
+Estas categorías describen la causa de exclusión y no sustituyen la evidencia visual.
+
+## Acuerdo y adjudicación
+
+Las páginas de doble codificación se revisan de forma independiente por dos codificadores. El acuerdo debe estimarse por variable y no como una única cifra agregada cuando las variables sean multietiqueta. Las discrepancias se conservan; la adjudicación produce un estado final separado de Código A y Código B.
+
+No se revisa el codebook durante la primera pasada. Si los desacuerdos muestran definiciones insuficientes, se congela el conjunto inicial, se documentan los problemas y se crea `CODEBOOK_0_2.md`; nunca se sobrescribe 0.1.
+
+## Puerta de salida de Stage 1
+
+Stage 1 sólo se considera completo cuando:
+
+- 457/457 páginas explícitas tienen decisión visual registrada;
+- 0 filas permanecen sin resolver salvo excepciones humanas documentadas;
+- la muestra de doble codificación está completa y adjudicada;
+- existe un manifiesto de hashes de la cola y sus salidas;
+- los falsos positivos están cuantificados por causa y generación;
+- cualquier promoción científica se realiza en un artefacto posterior y versionado, no modificando el rerun 0.2.
+
+Hasta entonces, los conteos 0.2 siguen siendo **resultados de recuperación de candidatos**, no prevalencias históricas validadas.

--- a/scripts/prepare_indigenous_validation_sample.py
+++ b/scripts/prepare_indigenous_validation_sample.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""Prepare a deterministic, text-free validation queue for LTMD-U1 Indigenous-language study 0.2.
+
+Version: LTMD_U1_INDIGENOUS_LANGUAGES_VALIDATION_STAGE1_0.1
+
+Input is the private candidate ledger emitted by analyze_indigenous_languages.py.
+Only rows marked explicit_general are admitted. No OCR text or snippets are read or emitted.
+
+The output queue preserves source identity/hash fields required for visual verification and
+marks every row as pending. A deterministic subset is flagged for independent double coding.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+from collections import Counter, defaultdict
+from pathlib import Path
+
+VERSION = "LTMD_U1_INDIGENOUS_LANGUAGES_VALIDATION_STAGE1_0.1"
+
+REQUIRED_FIELDS = {
+    "page_id",
+    "canonical_viewer_key",
+    "generation",
+    "grade_code",
+    "page_index",
+    "viewer_page",
+    "source_asset_url",
+    "source_sha256",
+    "ocr_sha256",
+    "explicit_general",
+    "matched_explicit_terms",
+    "matched_language_groups",
+    "validation_status",
+}
+
+OUTPUT_FIELDS = [
+    "validation_id",
+    "page_id",
+    "canonical_viewer_key",
+    "generation",
+    "grade_code",
+    "page_index",
+    "viewer_page",
+    "source_asset_url",
+    "source_sha256",
+    "ocr_sha256",
+    "query_family",
+    "matched_explicit_terms",
+    "matched_language_groups",
+    "validation_status",
+    "double_code_required",
+    "coder_a_id",
+    "coder_b_id",
+    "reference_type",
+    "named_language",
+    "status_label",
+    "temporality",
+    "speaker_agency",
+    "relation_to_spanish",
+    "territorial_function",
+    "pedagogical_function",
+    "normative_frame",
+    "risk_frame",
+    "evaluative_polarity",
+    "false_positive_cause",
+    "adjudication_status",
+    "validation_date",
+    "notes_nonexpressive",
+]
+
+
+def as_bool(value: str) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def stable_score(seed: str, page_id: str) -> str:
+    return hashlib.sha256(f"{seed}\0{page_id}".encode("utf-8")).hexdigest()
+
+
+def read_candidates(path: Path) -> list[dict]:
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fields = set(reader.fieldnames or [])
+        missing = REQUIRED_FIELDS - fields
+        if missing:
+            raise RuntimeError("candidate ledger missing fields: " + ", ".join(sorted(missing)))
+        rows = [dict(row) for row in reader]
+
+    seen = {}
+    for row in rows:
+        page_id = row["page_id"].strip()
+        if not page_id:
+            raise RuntimeError("candidate ledger contains blank page_id")
+        fingerprint = (
+            row["canonical_viewer_key"],
+            row["source_sha256"],
+            row["ocr_sha256"],
+            row["generation"],
+            row["page_index"],
+            row["viewer_page"],
+        )
+        prior = seen.get(page_id)
+        if prior is not None and prior != fingerprint:
+            raise RuntimeError(f"conflicting duplicate page_id: {page_id}")
+        seen[page_id] = fingerprint
+
+    explicit = [row for row in rows if as_bool(row["explicit_general"])]
+    explicit.sort(key=lambda row: (
+        int(row["generation"]) if str(row["generation"]).isdigit() else str(row["generation"]),
+        row["canonical_viewer_key"],
+        int(row["page_index"] or 0),
+        row["page_id"],
+    ))
+    return explicit
+
+
+def double_code_quota(n: int, rate: float, minimum: int) -> int:
+    if n <= 0:
+        return 0
+    quota = max(minimum, math.ceil(n * rate))
+    return min(n, quota)
+
+
+def select_double_code(rows: list[dict], seed: str, rate: float, minimum: int) -> set[str]:
+    strata = defaultdict(list)
+    for row in rows:
+        strata[str(row["generation"])].append(row)
+
+    selected = set()
+    for generation in sorted(strata, key=lambda value: int(value) if value.isdigit() else value):
+        group = sorted(
+            strata[generation],
+            key=lambda row: (stable_score(seed, row["page_id"]), row["page_id"]),
+        )
+        quota = double_code_quota(len(group), rate, minimum)
+        selected.update(row["page_id"] for row in group[:quota])
+    return selected
+
+
+def build_queue(rows: list[dict], selected: set[str]) -> list[dict]:
+    queue = []
+    for index, row in enumerate(rows, start=1):
+        queue.append({
+            "validation_id": f"ILV02-{index:04d}",
+            "page_id": row["page_id"],
+            "canonical_viewer_key": row["canonical_viewer_key"],
+            "generation": row["generation"],
+            "grade_code": row["grade_code"],
+            "page_index": row["page_index"],
+            "viewer_page": row["viewer_page"],
+            "source_asset_url": row["source_asset_url"],
+            "source_sha256": row["source_sha256"],
+            "ocr_sha256": row["ocr_sha256"],
+            "query_family": "explicit_general_0_2",
+            "matched_explicit_terms": row["matched_explicit_terms"],
+            "matched_language_groups": row["matched_language_groups"],
+            "validation_status": "pending_visual_validation",
+            "double_code_required": "1" if row["page_id"] in selected else "0",
+            "coder_a_id": "",
+            "coder_b_id": "",
+            "reference_type": "",
+            "named_language": "",
+            "status_label": "",
+            "temporality": "",
+            "speaker_agency": "",
+            "relation_to_spanish": "",
+            "territorial_function": "",
+            "pedagogical_function": "",
+            "normative_frame": "",
+            "risk_frame": "",
+            "evaluative_polarity": "",
+            "false_positive_cause": "",
+            "adjudication_status": "pending",
+            "validation_date": "",
+            "notes_nonexpressive": "",
+        })
+    return queue
+
+
+def write_csv(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=OUTPUT_FIELDS)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(candidate_ledger: Path, output_csv: Path, manifest_json: Path,
+        expected_explicit: int | None, double_code_rate: float,
+        double_code_min_per_generation: int, seed: str) -> dict:
+    if not 0 < double_code_rate <= 1:
+        raise RuntimeError("double-code rate must be in (0, 1]")
+    if double_code_min_per_generation < 1:
+        raise RuntimeError("double-code minimum per generation must be >= 1")
+
+    rows = read_candidates(candidate_ledger)
+    if expected_explicit is not None and len(rows) != expected_explicit:
+        raise RuntimeError(
+            f"explicit cardinality mismatch: got {len(rows)}, expected {expected_explicit}"
+        )
+
+    selected = select_double_code(
+        rows, seed=seed, rate=double_code_rate, minimum=double_code_min_per_generation
+    )
+    queue = build_queue(rows, selected)
+    write_csv(output_csv, queue)
+
+    by_generation = Counter(row["generation"] for row in rows)
+    double_by_generation = Counter(
+        row["generation"] for row in rows if row["page_id"] in selected
+    )
+    manifest = {
+        "version": VERSION,
+        "input_candidate_ledger_sha256": sha256_file(candidate_ledger),
+        "explicit_pages": len(rows),
+        "double_coded_pages": len(selected),
+        "selection": {
+            "method": "generation-stratified deterministic SHA-256 ranking",
+            "seed": seed,
+            "rate": double_code_rate,
+            "minimum_per_generation": double_code_min_per_generation,
+            "by_generation": {
+                generation: {
+                    "explicit_pages": by_generation[generation],
+                    "double_coded_pages": double_by_generation[generation],
+                }
+                for generation in sorted(
+                    by_generation, key=lambda value: int(value) if value.isdigit() else value
+                )
+            },
+        },
+        "scientific_state": {
+            "visual_validation_complete": False,
+            "semantic_ready_promotions": 0,
+            "publication_note": (
+                "Queue contains identifiers, source URLs, hashes and coding fields only; "
+                "no OCR text or source-page bytes are emitted."
+            ),
+        },
+        "output": {
+            "filename": output_csv.name,
+            "sha256": sha256_file(output_csv),
+        },
+    }
+    manifest_json.parent.mkdir(parents=True, exist_ok=True)
+    manifest_json.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate-ledger", required=True)
+    parser.add_argument("--output-csv", required=True)
+    parser.add_argument("--manifest-json", required=True)
+    parser.add_argument("--expected-explicit", type=int, default=457)
+    parser.add_argument("--double-code-rate", type=float, default=0.10)
+    parser.add_argument("--double-code-min-per-generation", type=int, default=2)
+    parser.add_argument(
+        "--seed",
+        default="LTMD_U1_INDIGENOUS_LANGUAGES_VALIDATION_STAGE1_0.1",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    candidate = Path(args.candidate_ledger)
+    if not candidate.is_file():
+        raise SystemExit(f"missing candidate ledger: {candidate}")
+    manifest = run(
+        candidate_ledger=candidate,
+        output_csv=Path(args.output_csv),
+        manifest_json=Path(args.manifest_json),
+        expected_explicit=args.expected_explicit,
+        double_code_rate=args.double_code_rate,
+        double_code_min_per_generation=args.double_code_min_per_generation,
+        seed=args.seed,
+    )
+    print(json.dumps(
+        {
+            "explicit_pages": manifest["explicit_pages"],
+            "double_coded_pages": manifest["double_coded_pages"],
+        },
+        sort_keys=True,
+    ))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_indigenous_validation_sample.py
+++ b/scripts/prepare_indigenous_validation_sample.py
@@ -91,6 +91,7 @@ def read_candidates(path: Path) -> list[dict]:
         rows = [dict(row) for row in reader]
 
     seen = {}
+    unique_rows = []
     for row in rows:
         page_id = row["page_id"].strip()
         if not page_id:
@@ -104,11 +105,14 @@ def read_candidates(path: Path) -> list[dict]:
             row["viewer_page"],
         )
         prior = seen.get(page_id)
-        if prior is not None and prior != fingerprint:
-            raise RuntimeError(f"conflicting duplicate page_id: {page_id}")
+        if prior is not None:
+            if prior != fingerprint:
+                raise RuntimeError(f"conflicting duplicate page_id: {page_id}")
+            continue
         seen[page_id] = fingerprint
+        unique_rows.append(row)
 
-    explicit = [row for row in rows if as_bool(row["explicit_general"])]
+    explicit = [row for row in unique_rows if as_bool(row["explicit_general"])]
     explicit.sort(key=lambda row: (
         int(row["generation"]) if str(row["generation"]).isdigit() else str(row["generation"]),
         row["canonical_viewer_key"],

--- a/tests/test_prepare_indigenous_validation_sample.py
+++ b/tests/test_prepare_indigenous_validation_sample.py
@@ -1,0 +1,95 @@
+import csv
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "prepare_indigenous_validation_sample.py"
+SPEC = importlib.util.spec_from_file_location("prepare_indigenous_validation_sample", SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_ledger(path: Path, rows: list[dict]) -> None:
+    fieldnames = sorted(mod.REQUIRED_FIELDS)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def candidate(page_id: str, generation: str, explicit: str = "1") -> dict:
+    return {
+        "page_id": page_id,
+        "canonical_viewer_key": f"K-{generation}",
+        "generation": generation,
+        "grade_code": "P5",
+        "page_index": "1",
+        "viewer_page": "2",
+        "source_asset_url": f"https://example.invalid/{page_id}.jpg",
+        "source_sha256": f"source-{page_id}",
+        "ocr_sha256": f"ocr-{page_id}",
+        "explicit_general": explicit,
+        "matched_explicit_terms": "lenguas indigenas",
+        "matched_language_groups": "",
+        "validation_status": "not_visually_validated",
+    }
+
+
+def test_read_candidates_filters_to_explicit(tmp_path):
+    ledger = tmp_path / "candidate.csv"
+    make_ledger(ledger, [candidate("p1", "1993", "1"), candidate("p2", "1993", "0")])
+    rows = mod.read_candidates(ledger)
+    assert [row["page_id"] for row in rows] == ["p1"]
+
+
+def test_double_code_selection_is_deterministic_and_stratified():
+    rows = [candidate(f"a{i}", "1960") for i in range(2)]
+    rows += [candidate(f"b{i}", "1993") for i in range(20)]
+    first = mod.select_double_code(rows, seed="fixed", rate=0.10, minimum=2)
+    second = mod.select_double_code(list(reversed(rows)), seed="fixed", rate=0.10, minimum=2)
+    assert first == second
+    assert len([page_id for page_id in first if page_id.startswith("a")]) == 2
+    assert len([page_id for page_id in first if page_id.startswith("b")]) == 2
+
+
+def test_build_queue_emits_no_text_fields():
+    rows = [candidate("p1", "2014")]
+    queue = mod.build_queue(rows, {"p1"})
+    assert queue[0]["validation_status"] == "pending_visual_validation"
+    assert queue[0]["double_code_required"] == "1"
+    assert "search_text" not in queue[0]
+    assert "ocr_text" not in queue[0]
+    assert "snippet" not in queue[0]
+
+
+def test_run_checks_expected_cardinality(tmp_path):
+    ledger = tmp_path / "candidate.csv"
+    make_ledger(ledger, [candidate("p1", "2014")])
+    try:
+        mod.run(
+            ledger,
+            tmp_path / "queue.csv",
+            tmp_path / "manifest.json",
+            expected_explicit=457,
+            double_code_rate=0.10,
+            double_code_min_per_generation=2,
+            seed="fixed",
+        )
+    except RuntimeError as exc:
+        assert "explicit cardinality mismatch" in str(exc)
+    else:
+        raise AssertionError("expected cardinality mismatch")
+
+
+def test_conflicting_duplicate_page_id_is_rejected(tmp_path):
+    ledger = tmp_path / "candidate.csv"
+    first = candidate("dup", "1993")
+    second = candidate("dup", "1993")
+    second["source_sha256"] = "different"
+    make_ledger(ledger, [first, second])
+    try:
+        mod.read_candidates(ledger)
+    except RuntimeError as exc:
+        assert "conflicting duplicate page_id" in str(exc)
+    else:
+        raise AssertionError("expected duplicate conflict")


### PR DESCRIPTION
## Summary

Prepares the next scientific gate after the Indigenous-language rerun 0.2 without altering the corpus or rerun results.

### Adds
- `scripts/prepare_indigenous_validation_sample.py`: builds a private, text-free queue from the 0.2 candidate ledger and admits only `explicit_general` rows;
- hard gate for the expected 457 explicit pages;
- duplicate identity/hash conflict detection;
- deterministic generation-stratified double-coding selection (10%, minimum 2 per generation where possible) using SHA-256 ranking;
- a manifest with input/output hashes and scientific-state guards;
- synthetic tests for filtering, deterministic selection, privacy, cardinality mismatch and duplicate conflicts;
- a versioned Stage 1 protocol for visual validation and adjudication.

### Scientific safeguards
- no OCR text, snippets, images or source bytes are committed;
- no 0.2 results are recalibrated retrospectively;
- no scientific state is promoted;
- all 457 explicit pages remain candidates until source-page visual validation;
- any future retrieval change requires a new version.

## Next execution step
Run the queue builder locally against the private 1,151-row candidate ledger, visually validate all 457 `explicit_general` pages, complete the deterministic double-coded subset, adjudicate disagreements, and only then create validated historical aggregates.