### PR TITLE
Product: expose LTMD Analytics read-only HTTP API 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -4,18 +4,24 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'analytics_api/**'
+      - 'requirements-analytics.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
+      - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
     paths:
+      - 'analytics_api/**'
+      - 'requirements-analytics.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
+      - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - '.github/workflows/test-ltmd-analytics.yml'
@@ -31,10 +37,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-      - name: Install test dependencies
-        run: python -m pip install --disable-pip-version-check pytest jsonschema
-      - name: Run Analytics unit tests
-        run: python -m pytest -q tests/test_build_indigenous_analytics_mart.py tests/test_query_indigenous_analytics.py
+      - name: Install Analytics and test dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements-analytics.txt pytest jsonschema
+      - name: Run Analytics unit and HTTP tests
+        run: python -m pytest -q tests/test_build_indigenous_analytics_mart.py tests/test_query_indigenous_analytics.py tests/test_analytics_api.py
       - name: Validate Analytics JSON schema
         run: |
           python - <<'PY'

--- a/analytics_api/__init__.py
+++ b/analytics_api/__init__.py
@@ -1,0 +1,5 @@
+"""Operated HTTP surface for LTMD Analytics.
+
+This package contains product transport code only. Scientific retrieval and aggregation
+logic remains versioned separately and is imported from the repository query engine.
+"""

--- a/analytics_api/app.py
+++ b/analytics_api/app.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Read-only HTTP adapter for LTMD Analytics 0.1.
+
+The service reads the private Indigenous-language candidate ledger from a filesystem path
+provided through `LTMD_INDIGENOUS_LEDGER_PATH`. The private path and ledger contents are never
+returned by the API. Generation-level denominators may be supplied with
+`LTMD_GENERATION_SUMMARY_PATH`; otherwise the repository's public 0.2 generation summary is used.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from threading import RLock
+
+from flask import Flask, jsonify, request
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.query_indigenous_analytics import (  # noqa: E402
+    ALLOWED_GROUP_BY,
+    ANALYTICS_VERSION,
+    ENGINE_VERSION,
+    SOURCE_ANALYSIS_VERSION,
+    load_generation_denominators,
+    load_ledger,
+    query,
+    sha256_file,
+)
+
+DEFAULT_GENERATION_SUMMARY = REPO_ROOT / "data" / "research" / "ltmd_u1_indigenous_languages_generation_summary_0_2.csv"
+MAX_FILTER_VALUES = 20
+MAX_FILTER_VALUE_LENGTH = 120
+MAX_QUERY_LABEL_LENGTH = 240
+
+app = Flask(__name__)
+app.json.ensure_ascii = False
+
+_state_lock = RLock()
+_state = {
+    "ledger_path": None,
+    "ledger_mtime_ns": None,
+    "rows": None,
+    "ledger_sha256": None,
+    "generation_path": None,
+    "generation_mtime_ns": None,
+    "denominators": None,
+}
+
+
+def _configured_paths() -> tuple[Path, Path]:
+    ledger_value = os.environ.get("LTMD_INDIGENOUS_LEDGER_PATH", "").strip()
+    if not ledger_value:
+        raise RuntimeError("LTMD Analytics private ledger is not configured")
+    ledger_path = Path(ledger_value).expanduser()
+    generation_value = os.environ.get("LTMD_GENERATION_SUMMARY_PATH", "").strip()
+    generation_path = Path(generation_value).expanduser() if generation_value else DEFAULT_GENERATION_SUMMARY
+    return ledger_path, generation_path
+
+
+def _load_state() -> tuple[list[dict], dict[str, int], str]:
+    ledger_path, generation_path = _configured_paths()
+    if not ledger_path.is_file():
+        raise RuntimeError("LTMD Analytics private ledger is unavailable")
+    if not generation_path.is_file():
+        raise RuntimeError("LTMD Analytics generation summary is unavailable")
+
+    ledger_mtime = ledger_path.stat().st_mtime_ns
+    generation_mtime = generation_path.stat().st_mtime_ns
+    with _state_lock:
+        ledger_changed = (
+            _state["rows"] is None
+            or _state["ledger_path"] != ledger_path
+            or _state["ledger_mtime_ns"] != ledger_mtime
+        )
+        if ledger_changed:
+            _state["rows"] = load_ledger(ledger_path)
+            _state["ledger_sha256"] = sha256_file(ledger_path)
+            _state["ledger_path"] = ledger_path
+            _state["ledger_mtime_ns"] = ledger_mtime
+
+        generation_changed = (
+            _state["denominators"] is None
+            or _state["generation_path"] != generation_path
+            or _state["generation_mtime_ns"] != generation_mtime
+        )
+        if generation_changed:
+            _state["denominators"] = load_generation_denominators(generation_path)
+            _state["generation_path"] = generation_path
+            _state["generation_mtime_ns"] = generation_mtime
+
+        return _state["rows"], _state["denominators"], _state["ledger_sha256"]
+
+
+def _clean_values(name: str) -> list[str] | None:
+    values = [value.strip() for value in request.args.getlist(name) if value.strip()]
+    if not values:
+        return None
+    if len(values) > MAX_FILTER_VALUES:
+        raise ValueError(f"too many values for {name}; maximum is {MAX_FILTER_VALUES}")
+    if any(len(value) > MAX_FILTER_VALUE_LENGTH for value in values):
+        raise ValueError(f"one or more {name} values exceed {MAX_FILTER_VALUE_LENGTH} characters")
+    return values
+
+
+def _public_error(message: str, status: int):
+    return jsonify({
+        "error": message,
+        "status": status,
+        "service": "LTMD Analytics",
+    }), status
+
+
+@app.get("/health")
+def health():
+    try:
+        rows, denominators, _ = _load_state()
+    except RuntimeError:
+        return jsonify({
+            "status": "degraded",
+            "service": "LTMD Analytics",
+            "analytics_version": ANALYTICS_VERSION,
+            "query_engine_version": ENGINE_VERSION,
+            "private_ledger_configured": bool(os.environ.get("LTMD_INDIGENOUS_LEDGER_PATH", "").strip()),
+        }), 503
+    return jsonify({
+        "status": "ok",
+        "service": "LTMD Analytics",
+        "analytics_version": ANALYTICS_VERSION,
+        "query_engine_version": ENGINE_VERSION,
+        "candidate_rows_loaded": len(rows),
+        "generation_denominators_loaded": len(denominators),
+        "human_validation_complete": False,
+    })
+
+
+@app.get("/v1/meta")
+def metadata():
+    try:
+        rows, denominators, _ = _load_state()
+    except RuntimeError:
+        return _public_error("analytics data unavailable", 503)
+
+    generations = sorted({str(row["generation"]) for row in rows}, key=lambda value: int(value) if value.isdigit() else 10**12)
+    grades = sorted({str(row["grade_code"]) for row in rows})
+    waves = sorted({str(row["wave"]) for row in rows})
+    languages = sorted({
+        language.strip()
+        for row in rows
+        for language in str(row.get("matched_language_groups") or "").split(";")
+        if language.strip()
+    })
+    explicit_terms = sorted({
+        term.strip()
+        for row in rows
+        for term in str(row.get("matched_explicit_terms") or "").split(";")
+        if term.strip()
+    })
+    return jsonify({
+        "service": "LTMD Analytics",
+        "analytics_version": ANALYTICS_VERSION,
+        "query_engine_version": ENGINE_VERSION,
+        "source_analysis_version": SOURCE_ANALYSIS_VERSION,
+        "result_state": "exploratory_signal",
+        "human_validation_complete": False,
+        "candidate_rows": len(rows),
+        "filters": {
+            "generation": generations,
+            "grade_code": grades,
+            "wave": waves,
+            "language_group": languages,
+            "explicit_term": explicit_terms,
+        },
+        "denominator_generations": sorted(denominators, key=lambda value: int(value) if value.isdigit() else 10**12),
+    })
+
+
+@app.get("/v1/indigenous/query")
+def indigenous_query():
+    try:
+        query_label = request.args.get("q", "LTMD Analytics query").strip() or "LTMD Analytics query"
+        if len(query_label) > MAX_QUERY_LABEL_LENGTH:
+            raise ValueError(f"q exceeds {MAX_QUERY_LABEL_LENGTH} characters")
+        group_by = request.args.get("group_by", "").strip() or None
+        if group_by is not None and group_by not in ALLOWED_GROUP_BY:
+            raise ValueError("invalid group_by")
+        filters = {
+            "generation": _clean_values("generation"),
+            "grade_code": _clean_values("grade_code"),
+            "wave": _clean_values("wave"),
+            "language_group": _clean_values("language_group"),
+            "explicit_term": _clean_values("explicit_term"),
+        }
+    except ValueError as exc:
+        return _public_error(str(exc), 400)
+
+    try:
+        rows, denominators, ledger_sha256 = _load_state()
+        response = query(
+            rows,
+            query_label=query_label,
+            filters=filters,
+            denominators=denominators,
+            group_by=group_by,
+            source_ledger_sha256=ledger_sha256,
+        )
+    except RuntimeError:
+        return _public_error("analytics data unavailable", 503)
+
+    return jsonify(response)
+
+
+@app.errorhandler(404)
+def not_found(_error):
+    return _public_error("endpoint not found", 404)
+
+
+@app.errorhandler(405)
+def method_not_allowed(_error):
+    return _public_error("method not allowed; LTMD Analytics 0.1 is read-only", 405)
+
+
+application = app
+
+
+if __name__ == "__main__":
+    app.run(host="127.0.0.1", port=int(os.environ.get("PORT", "8000")), debug=False)

--- a/analytics_api/passenger_wsgi.py
+++ b/analytics_api/passenger_wsgi.py
@@ -1,0 +1,16 @@
+"""cPanel/Passenger WSGI entry point for LTMD Analytics.
+
+Configure the cPanel Python application to use this file as its startup entry point.
+Private data paths must be supplied through environment variables and must not live under
+public_html or inside the Git repository.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from analytics_api.app import application  # noqa: E402,F401

--- a/docs/LTMD_ANALYTICS_HTTP_API_0_1.md
+++ b/docs/LTMD_ANALYTICS_HTTP_API_0_1.md
@@ -1,0 +1,118 @@
+# LTMD Analytics HTTP API 0.1
+
+Versión de transporte: **LTMD Analytics HTTP 0.1**  
+Motor de consulta: `LTMD_ANALYTICS_QUERY_ENGINE_0.1`
+
+## Propósito
+
+Esta capa expone por HTTP el motor exacto de consulta de LTMD Analytics sin convertir el ledger privado en un recurso descargable. La API es **read-only** y devuelve únicamente agregados, filtros, metadatos de versión, procedencia criptográfica y advertencias epistemológicas.
+
+## Endpoints P0
+
+### `GET /health`
+
+Comprueba que el servicio está activo y que los insumos privados están disponibles. No revela rutas de filesystem.
+
+### `GET /v1/meta`
+
+Devuelve versiones, estado científico y vocabularios de filtros disponibles para el vertical de lenguas indígenas.
+
+### `GET /v1/indigenous/query`
+
+Parámetros repetibles:
+
+- `generation`
+- `grade_code`
+- `wave`
+- `language_group`
+- `explicit_term`
+
+Parámetros simples:
+
+- `q`: etiqueta descriptiva de consulta;
+- `group_by`: `generation | grade_code | wave | language_group | explicit_term`.
+
+Ejemplo local:
+
+```bash
+curl --get 'http://127.0.0.1:8000/v1/indigenous/query' \
+  --data-urlencode 'q=rarámuri por generación' \
+  --data-urlencode 'language_group=Tarahumara / rarámuri' \
+  --data-urlencode 'group_by=generation'
+```
+
+La respuesta no contiene `page_id`, URL de fuente, OCR, snippets ni hashes de página/OCR.
+
+## Configuración privada
+
+Variables de entorno:
+
+```text
+LTMD_INDIGENOUS_LEDGER_PATH=/ruta/privada/ltmd_u1_indigenous_languages_candidate_ledger_0_2.csv
+LTMD_GENERATION_SUMMARY_PATH=/ruta/al/ltmd_u1_indigenous_languages_generation_summary_0_2.csv
+```
+
+`LTMD_GENERATION_SUMMARY_PATH` es opcional: si no se define, se utiliza la tabla pública versionada del repositorio.
+
+El ledger privado **no debe**:
+
+- guardarse dentro del repositorio;
+- colocarse bajo `public_html`;
+- aparecer en logs o respuestas HTTP;
+- enviarse al navegador;
+- copiarse a artefactos públicos de CI.
+
+## Ejecución local
+
+```bash
+python -m pip install -r requirements-analytics.txt
+export LTMD_INDIGENOUS_LEDGER_PATH=/ruta/privada/ledger.csv
+flask --app analytics_api.app run --host 127.0.0.1 --port 8000
+```
+
+## cPanel / Passenger
+
+El repositorio incluye `analytics_api/passenger_wsgi.py` como punto de entrada WSGI.
+
+Configuración conceptual:
+
+1. crear una aplicación Python separada para LTMD Analytics;
+2. mantener su directorio de aplicación fuera de `public_html` cuando sea posible;
+3. instalar `requirements-analytics.txt` en el entorno virtual de esa aplicación;
+4. configurar el startup WSGI con `analytics_api/passenger_wsgi.py`;
+5. definir `LTMD_INDIGENOUS_LEDGER_PATH` apuntando al ledger privado fuera del árbol público;
+6. reiniciar la aplicación;
+7. verificar `/health`, `/v1/meta` y una consulta acotada;
+8. sólo después conectar una interfaz web.
+
+No se fija todavía un dominio ni un origen CORS. Esa decisión corresponde al despliegue de la interfaz institucional y no debe anticiparse en código.
+
+## Denominadores
+
+Las tasas `pages_per_1000` se calculan únicamente cuando existe un denominador compatible. La versión 0.1 dispone de denominadores por **generación**. Si una consulta filtra por grado u ola, la API devuelve `pages_per_1000=null` y una advertencia, en lugar de dividir entre un universo que ya no corresponde al filtro.
+
+## Estado epistemológico
+
+Toda respuesta de consulta 0.1 utiliza:
+
+```text
+result_state = exploratory_signal
+human_validation_complete = false
+```
+
+La existencia de una API no cambia el estado científico de la evidencia. `search_hit != historical_claim` y `computational_candidate != semantic_ready` siguen siendo reglas obligatorias.
+
+## Límites P0
+
+La API 0.1 no incluye:
+
+- autenticación o cuentas;
+- escritura o anotación;
+- descarga del ledger;
+- OCR;
+- fragmentos fuente;
+- IA generativa para interpretar resultados;
+- CORS abierto;
+- rate limiting distribuido.
+
+Autenticación, cuotas y CORS deben introducirse antes de una exposición pública amplia o de funciones comerciales que requieran control de acceso.

--- a/requirements-analytics.txt
+++ b/requirements-analytics.txt
@@ -1,0 +1,4 @@
+# Runtime dependency for the operated LTMD Analytics HTTP layer.
+# Kept separate from requirements-release.txt so the frozen scientific release environment
+# does not silently acquire product-only dependencies.
+Flask==3.1.2

--- a/requirements-analytics.txt
+++ b/requirements-analytics.txt
@@ -1,4 +1,4 @@
 # Runtime dependency for the operated LTMD Analytics HTTP layer.
 # Kept separate from requirements-release.txt so the frozen scientific release environment
 # does not silently acquire product-only dependencies.
-Flask==3.1.2
+Flask==3.1.3

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,0 +1,128 @@
+import csv
+
+from analytics_api import app as api
+
+
+def write_csv(path, fieldnames, rows):
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def candidate(page_id, book, generation, grade, wave, explicit="0", named="0", languages="", terms=""):
+    return {
+        "page_id": page_id,
+        "canonical_viewer_key": book,
+        "wave": wave,
+        "generation": generation,
+        "grade_code": grade,
+        "explicit_general": explicit,
+        "named_language_contextual": named,
+        "matched_explicit_terms": terms,
+        "matched_language_groups": languages,
+        "validation_status": "not_visually_validated",
+    }
+
+
+def reset_state():
+    for key in list(api._state):
+        api._state[key] = None
+
+
+def configure(monkeypatch, tmp_path):
+    ledger = tmp_path / "ledger.csv"
+    rows = [
+        candidate("p1", "B1", "1993", "5", "W3", "1", "1", "Náhuatl", "lenguas indigenas"),
+        candidate("p2", "B1", "1993", "5", "W3", "0", "1", "Náhuatl;Otomí", ""),
+        candidate("p3", "B2", "2014", "6", "W7", "1", "0", "", "lengua indigena"),
+    ]
+    write_csv(ledger, list(rows[0]), rows)
+    generation = tmp_path / "generation.csv"
+    write_csv(generation, ["generation", "total_pages"], [
+        {"generation": "1993", "total_pages": "1000"},
+        {"generation": "2014", "total_pages": "2000"},
+    ])
+    monkeypatch.setenv("LTMD_INDIGENOUS_LEDGER_PATH", str(ledger))
+    monkeypatch.setenv("LTMD_GENERATION_SUMMARY_PATH", str(generation))
+    reset_state()
+    return ledger
+
+
+def test_health_is_safe_and_configured(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    client = api.app.test_client()
+    response = client.get("/health")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    assert payload["candidate_rows_loaded"] == 3
+    assert payload["human_validation_complete"] is False
+    rendered = repr(payload)
+    assert str(tmp_path) not in rendered
+    assert "ledger.csv" not in rendered
+
+
+def test_meta_exposes_filter_vocabulary_not_private_rows(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    client = api.app.test_client()
+    response = client.get("/v1/meta")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["filters"]["generation"] == ["1993", "2014"]
+    assert "Náhuatl" in payload["filters"]["language_group"]
+    assert payload["candidate_rows"] == 3
+    assert "page_id" not in repr(payload)
+
+
+def test_query_endpoint_uses_exact_unique_counts(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    client = api.app.test_client()
+    response = client.get(
+        "/v1/indigenous/query",
+        query_string=[
+            ("q", "náhuatl 1993"),
+            ("generation", "1993"),
+            ("language_group", "Náhuatl"),
+            ("group_by", "generation"),
+        ],
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["metrics"]["candidate_pages"] == 2
+    assert payload["metrics"]["candidate_books"] == 1
+    assert payload["metrics"]["pages_per_1000"] == 2.0
+    assert payload["breakdown"][0]["value"] == "1993"
+    assert payload["result_state"] == "exploratory_signal"
+    assert payload["provenance"]["human_validation_complete"] is False
+    assert "p1" not in repr(payload)
+    assert "p2" not in repr(payload)
+
+
+def test_invalid_group_by_is_rejected(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    client = api.app.test_client()
+    response = client.get("/v1/indigenous/query?group_by=page_id")
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid group_by"
+
+
+def test_service_is_read_only(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    client = api.app.test_client()
+    response = client.post("/v1/indigenous/query")
+    assert response.status_code == 405
+    assert "read-only" in response.get_json()["error"]
+
+
+def test_unconfigured_health_does_not_leak_path(monkeypatch):
+    monkeypatch.delenv("LTMD_INDIGENOUS_LEDGER_PATH", raising=False)
+    monkeypatch.delenv("LTMD_GENERATION_SUMMARY_PATH", raising=False)
+    reset_state()
+    client = api.app.test_client()
+    response = client.get("/health")
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload["status"] == "degraded"
+    assert payload["private_ledger_configured"] is False
+    assert "path" not in repr(payload).lower()


### PR DESCRIPTION
## Summary

Adds a deployable, read-only Flask/WSGI HTTP layer for LTMD Analytics 0.1.

### Endpoints
- `GET /health`
- `GET /v1/meta`
- `GET /v1/indigenous/query`

### Private-data boundary
The candidate ledger is injected through `LTMD_INDIGENOUS_LEDGER_PATH` and is never stored in Git or returned over HTTP. The service does not expose page IDs, source URLs, OCR, snippets, page/OCR hashes, or filesystem paths.

### Deployment
- isolated `requirements-analytics.txt` so product dependencies do not modify the frozen scientific release environment;
- Flask 3.1.3;
- cPanel/Passenger WSGI entry point;
- deployment documentation with private ledger outside `public_html`;
- no CORS origin is pre-authorized before the institutional UI exists.

### Safety/methodology
- read-only methods only;
- parameter length/count bounds;
- generation-level denominators are used only when compatible with active filters;
- responses remain `exploratory_signal` with `human_validation_complete=false`;
- internal configuration failures return generic 503 responses without paths.

### Tests
Extends the dedicated Analytics CI to cover the HTTP layer, including health, meta, exact query counts, invalid grouping, read-only enforcement, and private-path leakage checks.

## Next
Deploy in a private/staging cPanel Python application, verify endpoints with the preserved private ledger, then build the institutional UI against this API.