### PR TITLE
Product: add LTMD-U1 universal corpus index 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -9,10 +9,13 @@ on:
       - 'requirements-analytics.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
+      - 'scripts/build_u1_universal_index.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
+      - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
+      - 'tests/test_build_u1_universal_index.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -22,10 +25,13 @@ on:
       - 'requirements-analytics.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
+      - 'scripts/build_u1_universal_index.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
+      - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
+      - 'tests/test_build_u1_universal_index.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -42,13 +48,23 @@ jobs:
       - name: Install Analytics and test dependencies
         run: python -m pip install --disable-pip-version-check -r requirements-analytics.txt pytest jsonschema
       - name: Run Analytics unit and HTTP tests
-        run: python -m pytest -q tests/test_build_indigenous_analytics_mart.py tests/test_query_indigenous_analytics.py tests/test_analytics_api.py
-      - name: Validate Analytics JSON schema
+        run: >-
+          python -m pytest -q
+          tests/test_build_indigenous_analytics_mart.py
+          tests/test_query_indigenous_analytics.py
+          tests/test_analytics_api.py
+          tests/test_build_u1_universal_index.py
+      - name: Validate Analytics JSON schemas
         run: |
           python - <<'PY'
           import json
           from jsonschema import Draft202012Validator
-          schema = json.load(open('schemas/ltmd_analytics_query_response.schema.json', encoding='utf-8'))
-          Draft202012Validator.check_schema(schema)
-          print('LTMD Analytics query response schema: OK')
+          paths = [
+              'schemas/ltmd_analytics_query_response.schema.json',
+              'schemas/ltmd_u1_universal_index_manifest.schema.json',
+          ]
+          for path in paths:
+              schema = json.load(open(path, encoding='utf-8'))
+              Draft202012Validator.check_schema(schema)
+              print(f'{path}: OK')
           PY

--- a/docs/LTMD_ANALYTICS_CORPUS_WIDE_CANON_0_1.md
+++ b/docs/LTMD_ANALYTICS_CORPUS_WIDE_CANON_0_1.md
@@ -1,0 +1,123 @@
+# LTMD Analytics — ruta canónica corpus-wide 0.1
+
+Versión: **LTMD_ANALYTICS_CORPUS_WIDE_CANON_0.1**  
+Fecha de decisión: **2026-08-30**
+
+## 1. Decisión
+
+LTMD no pasa todavía de la API temática actual al staging/producto visual como siguiente gran frente. Antes, la infraestructura FTRL-U1 debe convertirse en una capa analítica transversal sobre el universo ya procesado.
+
+El orden canónico es:
+
+`FTRL preservado → Índice Universal U1 → FTS5 corpus-wide → motor Analytics genérico → dimensiones/manifest → léxico y reutilización → verticales → staging → interfaz`
+
+El staging 0.1 ya desarrollado permanece válido como paquete técnico, pero queda subordinado a esta secuencia.
+
+## 2. Universo de referencia
+
+El universo técnico reconstruido y reconciliado para esta fase es:
+
+- 288 bases SQLite privadas;
+- 86,549 páginas únicas;
+- 492 objetos canónicos;
+- 0 conflictos de identidad/hash en la reconstrucción usada por el estudio de lenguas indígenas 0.2.
+
+Estos números son gates de construcción del Índice Universal U1. Una ejecución que no reproduzca las cardinalidades esperadas debe fallar; no se corrige mediante imputación silenciosa.
+
+## 3. Índice Universal LTMD-U1 0.1
+
+`scripts/build_u1_universal_index.py` fusiona las tablas privadas `pages` de FTRL en una sola base SQLite privada con:
+
+- una fila por `page_id` único;
+- identidad de visor y objeto canónico;
+- generación, grado, ola, título y posición;
+- hashes técnicos y métricas OCR disponibles;
+- `search_text` privado;
+- tabla FTS5 `pages_fts` con `unicode61 remove_diacritics 2`;
+- índices B-tree para generación, grado, ola, objeto y hashes;
+- manifiesto JSON text-free con cardinalidades, hashes de insumo, dimensiones y SHA-256 del índice privado.
+
+El archivo SQLite universal **no se publica**. El manifiesto sí puede auditarse públicamente porque no contiene OCR, `page_id`, URL fuente ni rutas privadas.
+
+## 4. Deduplificación y conflicto
+
+La reconciliación conserva la misma frontera usada para reproducir el universo privado 0.2. Un `page_id` repetido puede deduplicarse sólo cuando coincide su fingerprint técnico compuesto por:
+
+- objeto canónico;
+- SHA-256 fuente;
+- SHA-256 OCR;
+- generación;
+- índice de página;
+- página de visor.
+
+Una discrepancia en ese fingerprint es conflicto y bloquea la construcción.
+
+## 5. Búsqueda full-text
+
+FTS5 es una capa de recuperación técnica. En consecuencia:
+
+- una coincidencia es `computational_candidate`;
+- el ranking de búsqueda no constituye relevancia histórica validada;
+- la ausencia de hits no demuestra ausencia histórica;
+- no se publican snippets extensos ni OCR íntegro;
+- filtros y agregados posteriores deben conservar procedencia y estado epistemológico.
+
+## 6. Fases posteriores
+
+### 6.1 Motor Analytics genérico
+
+El motor debe dejar de depender de ledgers temáticos. Consultará el Índice Universal y podrá combinar términos/expresiones con filtros por generación, grado, ola y objeto, calculando páginas y libros únicos.
+
+### 6.2 Dimensiones maestras
+
+Se construirá `Corpus Analytics Manifest` con denominadores técnicamente defendibles. La taxonomía de ola sigue siendo operacional y no se presenta automáticamente como ontología curricular.
+
+### 6.3 Léxico global
+
+Se producirán frecuencias, dispersión, n-gramas y coocurrencias como derivados no sustitutivos. Los rankings deberán controlar longitud y dispersión bibliográfica.
+
+### 6.4 Reutilización y similitud
+
+Analytics deberá distinguir:
+
+- identidad/reutilización exacta demostrada;
+- similitud computacional candidata.
+
+No se convertirá similitud textual en identidad documental.
+
+### 6.5 Verticales
+
+Lenguas indígenas permanece como primer vertical. Después se incorporarán verticales exploratorios sobre interculturalidad, género/familia, ciudadanía/derechos, ambiente, trabajo/economía, ruralidad/migración, nación/identidad, discapacidad/inclusión, territorio y tecnología/ciencia.
+
+## 7. Privacidad y derechos
+
+La separación permanece:
+
+- **privado:** OCR, `search_text`, índice FTS5 completo, rutas internas y materiales fuente;
+- **público:** código, schemas, hashes, cardinalidades, métricas, agregados y derivados no sustitutivos admitidos por la gobernanza del proyecto.
+
+El Índice Universal no convierte el corpus fuente en un producto redistribuible.
+
+## 8. Estado científico
+
+Durante toda esta fase:
+
+- `ocr_available != text_verified`;
+- `search_hit != historical_claim`;
+- `computational_candidate != semantic_ready`;
+- `text_verified = false` salvo evidencia humana específica;
+- `semantic_ready = false` para resultados corpus-wide no validados.
+
+La revisión humana permanece diferida, no eliminada.
+
+## 9. Gate para staging
+
+El staging corpus-wide sólo se activa después de:
+
+1. construir y verificar el Índice Universal real;
+2. comprobar 86,549 páginas / 492 objetos / 0 conflictos;
+3. ejecutar consultas FTS5 corpus-wide sobre el índice privado;
+4. fijar el contrato del motor Analytics genérico;
+5. publicar un manifiesto text-free del corte usado por producto.
+
+Hasta entonces, el paquete de staging existente se conserva como infraestructura disponible, no como siguiente fase principal.

--- a/schemas/ltmd_u1_universal_index_manifest.schema.json
+++ b/schemas/ltmd_u1_universal_index_manifest.schema.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_universal_index_manifest.schema.json",
+  "title": "LTMD-U1 Universal Index 0.1 text-free manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_version", "input", "reconciliation", "dimensions", "index", "scientific_state", "privacy"],
+  "properties": {
+    "manifest_version": {"const": "LTMD_U1_UNIVERSAL_INDEX_0.1"},
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["database_count", "database_hashes", "private_paths_emitted"],
+      "properties": {
+        "database_count": {"type": "integer", "minimum": 1},
+        "database_hashes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["slot", "basename", "sha256"],
+            "properties": {
+              "slot": {"type": "integer", "minimum": 1},
+              "basename": {"type": "string", "minLength": 1},
+              "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+            }
+          }
+        },
+        "private_paths_emitted": {"const": false}
+      }
+    },
+    "reconciliation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["unique_pages", "unique_canonical_objects", "fts_rows", "duplicate_page_ids", "sqlite_integrity_check", "identical_duplicate_rows_deduplicated", "conflicts"],
+      "properties": {
+        "unique_pages": {"type": "integer", "minimum": 1},
+        "unique_canonical_objects": {"type": "integer", "minimum": 1},
+        "fts_rows": {"type": "integer", "minimum": 1},
+        "duplicate_page_ids": {"const": 0},
+        "sqlite_integrity_check": {"const": "ok"},
+        "identical_duplicate_rows_deduplicated": {"type": "integer", "minimum": 0},
+        "conflicts": {"const": 0}
+      }
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["by_generation", "by_wave", "by_grade"],
+      "properties": {
+        "by_generation": {"$ref": "#/$defs/countMap"},
+        "by_wave": {"$ref": "#/$defs/countMap"},
+        "by_grade": {"$ref": "#/$defs/countMap"}
+      }
+    },
+    "index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["format", "fts_table", "tokenizer", "sha256", "private", "contains_search_text", "publish_index_file"],
+      "properties": {
+        "format": {"const": "SQLite3 + FTS5"},
+        "fts_table": {"const": "pages_fts"},
+        "tokenizer": {"const": "unicode61 remove_diacritics 2"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "private": {"const": true},
+        "contains_search_text": {"const": true},
+        "publish_index_file": {"const": false}
+      }
+    },
+    "scientific_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ocr_available", "text_verified", "semantic_ready", "search_result_state", "human_validation_required_for_semantic_ready"],
+      "properties": {
+        "ocr_available": {"const": true},
+        "text_verified": {"const": false},
+        "semantic_ready": {"const": false},
+        "search_result_state": {"const": "computational_candidate"},
+        "human_validation_required_for_semantic_ready": {"const": true}
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ocr_text_in_manifest", "source_urls_in_manifest", "page_ids_in_manifest", "private_storage_paths_in_manifest"],
+      "properties": {
+        "ocr_text_in_manifest": {"const": false},
+        "source_urls_in_manifest": {"const": false},
+        "page_ids_in_manifest": {"const": false},
+        "private_storage_paths_in_manifest": {"const": false}
+      }
+    }
+  },
+  "$defs": {
+    "countMap": {
+      "type": "object",
+      "additionalProperties": {"type": "integer", "minimum": 0}
+    }
+  }
+}

--- a/scripts/build_u1_universal_index.py
+++ b/scripts/build_u1_universal_index.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Build the private corpus-wide LTMD-U1 universal SQLite/FTS5 index.
+
+Version: LTMD_U1_UNIVERSAL_INDEX_0.1
+
+The builder reconciles page-level FTRL SQLite databases into one private search index.
+It may read OCR-derived search text and source URLs, but those values remain inside the
+private SQLite output. The companion manifest is text-free and suitable for public audit.
+
+Scientific boundary:
+    ocr_available != text_verified
+    search_hit != historical_claim
+    computational_candidate != semantic_ready
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sqlite3
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+EXPECTED_U1_PAGES = 86549
+EXPECTED_U1_OBJECTS = 492
+
+CORE_COLUMNS = (
+    "page_id",
+    "viewer_key",
+    "canonical_viewer_key",
+    "wave",
+    "catalog_generation",
+    "grade_code",
+    "title_core",
+    "page_index",
+    "viewer_page",
+    "source_asset_url",
+    "source_sha256",
+    "ocr_sha256",
+    "ocr_confidence_mean",
+    "search_text",
+)
+
+OPTIONAL_COLUMNS = (
+    "source_byte_size",
+    "ocr_engine",
+    "ocr_engine_version",
+    "ocr_language",
+    "ocr_psm",
+    "search_text_sha256",
+    "ocr_char_count",
+    "ocr_word_count",
+    "generated_at",
+)
+
+PRIVATE_OUTPUT_COLUMNS = CORE_COLUMNS + OPTIONAL_COLUMNS
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def collect_db_paths(explicit: Iterable[str], directories: Iterable[str], pattern: str) -> list[Path]:
+    paths: set[Path] = set()
+    for value in explicit:
+        path = Path(value).expanduser().resolve()
+        if not path.is_file():
+            raise RuntimeError(f"input SQLite does not exist: {path}")
+        paths.add(path)
+    for value in directories:
+        root = Path(value).expanduser().resolve()
+        if not root.is_dir():
+            raise RuntimeError(f"input directory does not exist: {root}")
+        for path in root.rglob(pattern):
+            if path.is_file():
+                paths.add(path.resolve())
+    result = sorted(paths, key=lambda path: str(path))
+    if not result:
+        raise RuntimeError("no input SQLite databases were found")
+    return result
+
+
+def quote_identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def table_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in connection.execute(f"PRAGMA table_info({quote_identifier(table)})")}
+
+
+def page_fingerprint(row: dict) -> tuple:
+    return (
+        row.get("canonical_viewer_key"),
+        row.get("source_sha256"),
+        row.get("ocr_sha256"),
+        str(row.get("catalog_generation")),
+        str(row.get("page_index")),
+        str(row.get("viewer_page")),
+    )
+
+
+def iter_source_pages(db_paths: list[Path]):
+    """Yield one canonical row per unique page_id and fail on conflicting duplicates."""
+    seen: dict[str, tuple] = {}
+    duplicate_rows = 0
+    for db_path in db_paths:
+        connection = sqlite3.connect(str(db_path))
+        connection.row_factory = sqlite3.Row
+        try:
+            columns = table_columns(connection, "pages")
+            missing = set(CORE_COLUMNS) - columns
+            if missing:
+                raise RuntimeError(
+                    f"{db_path.name}: pages table missing required columns: " + ", ".join(sorted(missing))
+                )
+            selected = [name for name in PRIVATE_OUTPUT_COLUMNS if name in columns]
+            sql = "SELECT " + ", ".join(quote_identifier(name) for name in selected) + " FROM pages ORDER BY page_id"
+            for source_row in connection.execute(sql):
+                row = {name: source_row[name] if name in source_row.keys() else None for name in PRIVATE_OUTPUT_COLUMNS}
+                page_id = str(row.get("page_id") or "").strip()
+                if not page_id:
+                    raise RuntimeError(f"{db_path.name}: blank page_id")
+                fingerprint = page_fingerprint(row)
+                previous = seen.get(page_id)
+                if previous is not None:
+                    if previous != fingerprint:
+                        raise RuntimeError(f"conflicting duplicate page_id: {page_id} in {db_path.name}")
+                    duplicate_rows += 1
+                    continue
+                seen[page_id] = fingerprint
+                yield row
+        finally:
+            connection.close()
+    iter_source_pages.duplicate_rows = duplicate_rows
+
+
+iter_source_pages.duplicate_rows = 0
+
+
+def initialize_index(connection: sqlite3.Connection) -> None:
+    connection.executescript(
+        """
+        PRAGMA foreign_keys=ON;
+        PRAGMA journal_mode=DELETE;
+        PRAGMA synchronous=NORMAL;
+
+        CREATE TABLE index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+
+        CREATE TABLE pages (
+            id INTEGER PRIMARY KEY,
+            page_id TEXT NOT NULL UNIQUE,
+            viewer_key TEXT NOT NULL,
+            canonical_viewer_key TEXT NOT NULL,
+            wave TEXT,
+            catalog_generation INTEGER,
+            grade_code INTEGER,
+            title_core TEXT,
+            page_index INTEGER,
+            viewer_page INTEGER,
+            source_asset_url TEXT,
+            source_sha256 TEXT,
+            source_byte_size INTEGER,
+            ocr_engine TEXT,
+            ocr_engine_version TEXT,
+            ocr_language TEXT,
+            ocr_psm INTEGER,
+            ocr_sha256 TEXT,
+            search_text TEXT NOT NULL,
+            search_text_sha256 TEXT,
+            ocr_confidence_mean REAL,
+            ocr_char_count INTEGER,
+            ocr_word_count INTEGER,
+            generated_at TEXT
+        );
+
+        CREATE INDEX pages_generation_idx ON pages(catalog_generation);
+        CREATE INDEX pages_grade_idx ON pages(grade_code);
+        CREATE INDEX pages_wave_idx ON pages(wave);
+        CREATE INDEX pages_object_idx ON pages(canonical_viewer_key);
+        CREATE INDEX pages_source_sha_idx ON pages(source_sha256);
+        CREATE INDEX pages_ocr_sha_idx ON pages(ocr_sha256);
+
+        CREATE VIRTUAL TABLE pages_fts USING fts5(
+            search_text,
+            content='pages',
+            content_rowid='id',
+            tokenize='unicode61 remove_diacritics 2'
+        );
+        """
+    )
+
+
+def insert_page(connection: sqlite3.Connection, row: dict) -> None:
+    values = [row.get(name) for name in PRIVATE_OUTPUT_COLUMNS]
+    search_index = PRIVATE_OUTPUT_COLUMNS.index("search_text")
+    values[search_index] = values[search_index] or ""
+    sql = (
+        "INSERT INTO pages (" + ", ".join(quote_identifier(name) for name in PRIVATE_OUTPUT_COLUMNS) + ") "
+        + "VALUES (" + ", ".join("?" for _ in PRIVATE_OUTPUT_COLUMNS) + ")"
+    )
+    connection.execute(sql, values)
+
+
+def verify_index(connection: sqlite3.Connection, expected_pages: int | None, expected_objects: int | None) -> dict:
+    page_count = connection.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+    object_count = connection.execute("SELECT COUNT(DISTINCT canonical_viewer_key) FROM pages").fetchone()[0]
+    fts_count = connection.execute("SELECT COUNT(*) FROM pages_fts").fetchone()[0]
+    if page_count != fts_count:
+        raise RuntimeError(f"FTS cardinality mismatch: pages={page_count}, pages_fts={fts_count}")
+    if expected_pages is not None and page_count != expected_pages:
+        raise RuntimeError(f"page cardinality mismatch: got {page_count}, expected {expected_pages}")
+    if expected_objects is not None and object_count != expected_objects:
+        raise RuntimeError(f"object cardinality mismatch: got {object_count}, expected {expected_objects}")
+
+    duplicate_page_ids = connection.execute(
+        "SELECT COUNT(*) FROM (SELECT page_id FROM pages GROUP BY page_id HAVING COUNT(*) > 1)"
+    ).fetchone()[0]
+    if duplicate_page_ids:
+        raise RuntimeError(f"universal index contains duplicate page_id values: {duplicate_page_ids}")
+
+    integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+    if integrity != "ok":
+        raise RuntimeError(f"SQLite integrity_check failed: {integrity}")
+
+    return {
+        "unique_pages": page_count,
+        "unique_canonical_objects": object_count,
+        "fts_rows": fts_count,
+        "duplicate_page_ids": duplicate_page_ids,
+        "sqlite_integrity_check": integrity,
+    }
+
+
+def summarize_dimensions(connection: sqlite3.Connection) -> dict:
+    def counter(query: str) -> dict[str, int]:
+        return {str(key): int(value) for key, value in connection.execute(query)}
+
+    return {
+        "by_generation": counter(
+            "SELECT catalog_generation, COUNT(*) FROM pages GROUP BY catalog_generation ORDER BY catalog_generation"
+        ),
+        "by_wave": counter("SELECT wave, COUNT(*) FROM pages GROUP BY wave ORDER BY wave"),
+        "by_grade": counter("SELECT grade_code, COUNT(*) FROM pages GROUP BY grade_code ORDER BY grade_code"),
+    }
+
+
+def write_meta(connection: sqlite3.Connection, values: dict[str, object]) -> None:
+    connection.executemany(
+        "INSERT OR REPLACE INTO index_meta(key, value) VALUES (?, ?)",
+        [(key, json.dumps(value, ensure_ascii=False, sort_keys=True)) for key, value in sorted(values.items())],
+    )
+
+
+def build_index(
+    db_paths: list[Path],
+    output_path: Path,
+    manifest_path: Path,
+    expected_pages: int | None,
+    expected_objects: int | None,
+) -> dict:
+    output_path = output_path.expanduser().resolve()
+    manifest_path = manifest_path.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    if output_path.exists():
+        output_path.unlink()
+
+    input_hashes = [
+        {"slot": index + 1, "basename": path.name, "sha256": sha256_file(path)}
+        for index, path in enumerate(db_paths)
+    ]
+
+    connection = sqlite3.connect(str(output_path))
+    try:
+        initialize_index(connection)
+        connection.execute("BEGIN")
+        page_counter = Counter()
+        objects: set[str] = set()
+        inserted = 0
+        for row in iter_source_pages(db_paths):
+            insert_page(connection, row)
+            inserted += 1
+            page_counter[str(row.get("wave"))] += 1
+            objects.add(str(row.get("canonical_viewer_key")))
+        connection.commit()
+
+        connection.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
+        connection.commit()
+
+        verification = verify_index(connection, expected_pages, expected_objects)
+        dimensions = summarize_dimensions(connection)
+        write_meta(
+            connection,
+            {
+                "builder_version": VERSION,
+                "unique_pages": verification["unique_pages"],
+                "unique_canonical_objects": verification["unique_canonical_objects"],
+                "text_verified": False,
+                "semantic_ready": False,
+                "private_index": True,
+            },
+        )
+        connection.commit()
+        connection.execute("VACUUM")
+    finally:
+        connection.close()
+
+    index_sha256 = sha256_file(output_path)
+    manifest = {
+        "manifest_version": VERSION,
+        "input": {
+            "database_count": len(db_paths),
+            "database_hashes": input_hashes,
+            "private_paths_emitted": False,
+        },
+        "reconciliation": {
+            **verification,
+            "identical_duplicate_rows_deduplicated": int(iter_source_pages.duplicate_rows),
+            "conflicts": 0,
+        },
+        "dimensions": dimensions,
+        "index": {
+            "format": "SQLite3 + FTS5",
+            "fts_table": "pages_fts",
+            "tokenizer": "unicode61 remove_diacritics 2",
+            "sha256": index_sha256,
+            "private": True,
+            "contains_search_text": True,
+            "publish_index_file": False,
+        },
+        "scientific_state": {
+            "ocr_available": True,
+            "text_verified": False,
+            "semantic_ready": False,
+            "search_result_state": "computational_candidate",
+            "human_validation_required_for_semantic_ready": True,
+        },
+        "privacy": {
+            "ocr_text_in_manifest": False,
+            "source_urls_in_manifest": False,
+            "page_ids_in_manifest": False,
+            "private_storage_paths_in_manifest": False,
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return manifest
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", action="append", default=[], help="Explicit input SQLite; repeatable")
+    parser.add_argument("--db-dir", action="append", default=[], help="Directory searched recursively; repeatable")
+    parser.add_argument("--glob", default="*.sqlite", help="Filename glob used under --db-dir")
+    parser.add_argument("--output", required=True, help="Private universal SQLite output")
+    parser.add_argument("--manifest", required=True, help="Text-free JSON manifest output")
+    parser.add_argument("--expected-pages", type=int, default=EXPECTED_U1_PAGES)
+    parser.add_argument("--expected-objects", type=int, default=EXPECTED_U1_OBJECTS)
+    parser.add_argument(
+        "--no-u1-cardinality-gate",
+        action="store_true",
+        help="Disable 86,549/492 gates for synthetic tests or non-U1 development only",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    db_paths = collect_db_paths(args.db, args.db_dir, args.glob)
+    expected_pages = None if args.no_u1_cardinality_gate else args.expected_pages
+    expected_objects = None if args.no_u1_cardinality_gate else args.expected_objects
+    manifest = build_index(
+        db_paths,
+        Path(args.output),
+        Path(args.manifest),
+        expected_pages,
+        expected_objects,
+    )
+    print(json.dumps({
+        "builder_version": VERSION,
+        "database_count": manifest["input"]["database_count"],
+        "unique_pages": manifest["reconciliation"]["unique_pages"],
+        "unique_canonical_objects": manifest["reconciliation"]["unique_canonical_objects"],
+        "index_sha256": manifest["index"]["sha256"],
+    }, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_u1_universal_index.py
+++ b/tests/test_build_u1_universal_index.py
@@ -1,0 +1,183 @@
+import hashlib
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "build_u1_universal_index.py"
+SPEC = importlib.util.spec_from_file_location("build_u1_universal_index", SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_source_db(path: Path, rows: list[dict]):
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE pages (
+                page_id TEXT,
+                viewer_key TEXT,
+                canonical_viewer_key TEXT,
+                wave TEXT,
+                catalog_generation INTEGER,
+                grade_code INTEGER,
+                title_core TEXT,
+                page_index INTEGER,
+                viewer_page INTEGER,
+                source_asset_url TEXT,
+                source_sha256 TEXT,
+                source_byte_size INTEGER,
+                ocr_engine TEXT,
+                ocr_engine_version TEXT,
+                ocr_language TEXT,
+                ocr_psm INTEGER,
+                ocr_sha256 TEXT,
+                search_text TEXT,
+                search_text_sha256 TEXT,
+                ocr_confidence_mean REAL,
+                ocr_char_count INTEGER,
+                ocr_word_count INTEGER,
+                generated_at TEXT
+            )
+            """
+        )
+        for row in rows:
+            values = {
+                "viewer_key": row.get("canonical_viewer_key"),
+                "source_asset_url": "https://example.invalid/source.jpg",
+                "source_byte_size": 100,
+                "ocr_engine": "test",
+                "ocr_engine_version": "1",
+                "ocr_language": "spa",
+                "ocr_psm": 3,
+                "search_text_sha256": hashlib.sha256(row["search_text"].encode()).hexdigest(),
+                "ocr_confidence_mean": 90.0,
+                "ocr_char_count": len(row["search_text"]),
+                "ocr_word_count": len(row["search_text"].split()),
+                "generated_at": "2026-08-30T00:00:00Z",
+                **row,
+            }
+            fields = list(values)
+            connection.execute(
+                "INSERT INTO pages (" + ",".join(fields) + ") VALUES (" + ",".join("?" for _ in fields) + ")",
+                [values[field] for field in fields],
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def row(page_id, book, generation, grade, wave, text, page_index=1):
+    return {
+        "page_id": page_id,
+        "canonical_viewer_key": book,
+        "wave": wave,
+        "catalog_generation": generation,
+        "grade_code": grade,
+        "title_core": f"Book {book}",
+        "page_index": page_index,
+        "viewer_page": page_index,
+        "source_sha256": hashlib.sha256((page_id + "source").encode()).hexdigest(),
+        "ocr_sha256": hashlib.sha256((page_id + "ocr").encode()).hexdigest(),
+        "search_text": text,
+    }
+
+
+def test_build_reconciles_duplicate_and_builds_fts(tmp_path):
+    db1 = tmp_path / "a.sqlite"
+    db2 = tmp_path / "b.sqlite"
+    p1 = row("p1", "B1", 1993, 5, "W3", "La lengua rarámuri aparece aquí")
+    p2 = row("p2", "B2", 2014, 6, "W7", "Diversidad lingüística de México")
+    make_source_db(db1, [p1, p2])
+    make_source_db(db2, [p1])
+
+    output = tmp_path / "universal.sqlite"
+    manifest_path = tmp_path / "manifest.json"
+    manifest = mod.build_index([db1, db2], output, manifest_path, expected_pages=2, expected_objects=2)
+
+    assert manifest["reconciliation"]["unique_pages"] == 2
+    assert manifest["reconciliation"]["unique_canonical_objects"] == 2
+    assert manifest["reconciliation"]["identical_duplicate_rows_deduplicated"] == 1
+    assert manifest["reconciliation"]["conflicts"] == 0
+    assert manifest["index"]["private"] is True
+    assert manifest["scientific_state"]["semantic_ready"] is False
+
+    connection = sqlite3.connect(output)
+    try:
+        hit = connection.execute(
+            "SELECT p.page_id FROM pages_fts f JOIN pages p ON p.id=f.rowid WHERE pages_fts MATCH ?",
+            ("raramuri",),
+        ).fetchall()
+        assert hit == [("p1",)]
+    finally:
+        connection.close()
+
+
+def test_conflicting_duplicate_page_id_fails(tmp_path):
+    db1 = tmp_path / "a.sqlite"
+    db2 = tmp_path / "b.sqlite"
+    p1 = row("dup", "B1", 1993, 5, "W3", "texto")
+    p2 = dict(p1)
+    p2["source_sha256"] = hashlib.sha256(b"different").hexdigest()
+    make_source_db(db1, [p1])
+    make_source_db(db2, [p2])
+
+    try:
+        list(mod.iter_source_pages([db1, db2]))
+    except RuntimeError as exc:
+        assert "conflicting duplicate page_id" in str(exc)
+    else:
+        raise AssertionError("expected conflict gate")
+
+
+def test_manifest_is_text_free_and_path_free(tmp_path):
+    db = tmp_path / "private_wave.sqlite"
+    make_source_db(db, [row("p1", "B1", 1993, 5, "W3", "secreto rarámuri")])
+    output = tmp_path / "private_universal.sqlite"
+    manifest_path = tmp_path / "manifest.json"
+    mod.build_index([db], output, manifest_path, expected_pages=1, expected_objects=1)
+
+    payload = manifest_path.read_text(encoding="utf-8")
+    saved = json.loads(payload)
+    assert "secreto" not in payload
+    assert "example.invalid" not in payload
+    assert str(tmp_path) not in payload
+    assert "p1" not in payload
+    assert saved["privacy"]["ocr_text_in_manifest"] is False
+    assert saved["privacy"]["page_ids_in_manifest"] is False
+    assert saved["input"]["private_paths_emitted"] is False
+
+
+def test_u1_cardinality_gate_rejects_wrong_counts(tmp_path):
+    db = tmp_path / "a.sqlite"
+    make_source_db(db, [row("p1", "B1", 1993, 5, "W3", "texto")])
+    output = tmp_path / "universal.sqlite"
+    manifest_path = tmp_path / "manifest.json"
+
+    try:
+        mod.build_index([db], output, manifest_path, expected_pages=86549, expected_objects=492)
+    except RuntimeError as exc:
+        assert "page cardinality mismatch" in str(exc)
+    else:
+        raise AssertionError("expected U1 page cardinality gate")
+
+
+def test_missing_core_column_is_rejected(tmp_path):
+    db = tmp_path / "bad.sqlite"
+    connection = sqlite3.connect(db)
+    try:
+        connection.execute("CREATE TABLE pages(page_id TEXT)")
+        connection.execute("INSERT INTO pages(page_id) VALUES ('p1')")
+        connection.commit()
+    finally:
+        connection.close()
+
+    try:
+        list(mod.iter_source_pages([db]))
+    except RuntimeError as exc:
+        assert "missing required columns" in str(exc)
+        assert "search_text" in str(exc)
+    else:
+        raise AssertionError("expected schema gate")


### PR DESCRIPTION
## Summary

Canonizes the corpus-wide route before staging and adds the first reproducible **LTMD-U1 Universal Index 0.1** builder.

### Builder
- reconciles private FTRL `pages` tables from multiple SQLite inputs;
- defaults to the canonical U1 gates: **86,549 unique pages / 492 canonical objects**;
- deduplicates repeated `page_id` only when the proven technical fingerprint matches;
- fails on conflicting duplicate identities;
- creates one private SQLite database with B-tree dimensions and FTS5 `pages_fts`;
- uses `unicode61 remove_diacritics 2` for accent-insensitive retrieval;
- keeps OCR-derived `search_text`, page IDs, source URLs and private paths out of the public manifest.

### Scientific/privacy contract
- the universal SQLite output is private and must not be committed;
- its JSON manifest is text-free and records cardinalities, dimensions, input hashes and the private index SHA-256;
- `ocr_available != text_verified`;
- FTS hits remain `computational_candidate`;
- `semantic_ready=false` until applicable human validation exists.

### Route change
`docs/LTMD_ANALYTICS_CORPUS_WIDE_CANON_0_1.md` makes the new sequence explicit:

`FTRL → universal index → corpus-wide FTS5 → generic Analytics → dimensions/lexicon/reuse → verticals → staging → UI`

### Tests/CI
Adds synthetic gates for exact reconciliation, conflict rejection, FTS5 retrieval, manifest privacy and U1 cardinality enforcement, plus JSON Schema validation.

## Next
After this builder is green, reconstruct the preserved 288 private FTRL SQLite databases, materialize the real universal index, verify the 86,549/492/0-conflict gates, preserve the private index in Drive, and publish only its text-free manifest.