### PR TITLE
Product: canonize and materialize LTMD-U1 Universal Index 0.1

### DIFF
--- a/data/research/ltmd_u1_universal_index_materialization_0_1.json
+++ b/data/research/ltmd_u1_universal_index_materialization_0_1.json
@@ -1,0 +1,87 @@
+{
+  "builder_version": "LTMD_U1_UNIVERSAL_INDEX_0.1",
+  "dimensions": {
+    "by_generation": {
+      "1960": 3536,
+      "1966": 6680,
+      "1972": 7020,
+      "1982": 3292,
+      "1988": 5274,
+      "1993": 21708,
+      "2008": 6538,
+      "2011": 7611,
+      "2014": 13752,
+      "2018": 2744,
+      "2019": 8394
+    },
+    "by_grade": {
+      "1": 10459,
+      "2": 10814,
+      "3": 20333,
+      "4": 13059,
+      "5": 12710,
+      "6": 19174
+    },
+    "by_wave": {
+      "W1": 6516,
+      "W10": 11937,
+      "W11": 19862,
+      "W2": 11945,
+      "W3": 20765,
+      "W4": 2414,
+      "W5": 2653,
+      "W6": 5258,
+      "W7": 3261,
+      "W8": 1490,
+      "W9": 448
+    }
+  },
+  "index": {
+    "bytes": 209022976,
+    "canonical_row_order": "page_id_ascending",
+    "format": "SQLite3 + FTS5",
+    "fts_table": "pages_fts",
+    "private": true,
+    "publish_index_file": false,
+    "sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2",
+    "tokenizer": "unicode61 remove_diacritics 2"
+  },
+  "input": {
+    "database_count": 288,
+    "database_hash_count": 288,
+    "database_hash_set_encoding": "sorted lowercase SHA-256 values joined with LF, no trailing LF",
+    "database_hash_set_sha256": "bbc63e8b34376d7f92e34183906df244593800180af91748927b932b721ed389",
+    "hash_order": "sha256_ascending",
+    "private_paths_emitted": false
+  },
+  "materialization_version": "LTMD_U1_UNIVERSAL_INDEX_MATERIALIZATION_0.1",
+  "preservation": {
+    "compressed_bytes": 83745081,
+    "compressed_sha256": "8ae9c16b7d31a500b07cbed4084cbc98da72f1630edef136a929ad76176d9c71",
+    "private_archive_redownload_verified": true,
+    "storage_location_publicly_emitted": false
+  },
+  "privacy": {
+    "ocr_text_emitted": false,
+    "page_ids_emitted": false,
+    "private_storage_paths_emitted": false,
+    "source_urls_emitted": false
+  },
+  "reconciliation": {
+    "canonical_row_order": "page_id_ascending",
+    "conflicts": 0,
+    "duplicate_page_ids": 0,
+    "fts_rows": 86549,
+    "identical_duplicate_rows_deduplicated": 0,
+    "sqlite_integrity_check": "ok",
+    "unique_canonical_objects": 492,
+    "unique_pages": 86549
+  },
+  "scientific_state": {
+    "human_validation_required_for_semantic_ready": true,
+    "ocr_available": true,
+    "search_result_state": "computational_candidate",
+    "semantic_ready": false,
+    "text_verified": false
+  }
+}

--- a/docs/LTMD_U1_UNIVERSAL_INDEX_MATERIALIZATION_0_1.md
+++ b/docs/LTMD_U1_UNIVERSAL_INDEX_MATERIALIZATION_0_1.md
@@ -1,0 +1,128 @@
+# LTMD-U1 — materialización del Índice Universal 0.1
+
+**Versión del corte:** `LTMD_U1_UNIVERSAL_INDEX_MATERIALIZATION_0.1`  
+**Fecha:** 2026-08-30
+
+## Resultado
+
+La bóveda privada FTRL-U1 fue reconstruida desde sus productos preservados, sin volver a descargar páginas fuente ni ejecutar OCR nuevo. La enumeración cerró exactamente en:
+
+- **288** bases SQLite privadas;
+- **86,549** filas de página;
+- **86,549** `page_id` únicos;
+- **492** objetos canónicos;
+- **0** duplicados idénticos entre bases;
+- **0** conflictos de identidad/hash.
+
+Las 288 bases presentan una sola variante de esquema `pages` y todas contienen los campos mínimos exigidos por el builder del Índice Universal.
+
+## Índice privado
+
+El corpus se materializó como una base SQLite3 privada con tabla `pages`, dimensiones indexadas y FTS5 `pages_fts`.
+
+Estado final canónico:
+
+- páginas `pages`: **86,549**;
+- filas FTS5: **86,549**;
+- objetos canónicos: **492**;
+- `duplicate_page_ids`: **0**;
+- `PRAGMA integrity_check`: **ok**;
+- orden canónico de filas: `page_id_ascending`;
+- tokenizer: `unicode61 remove_diacritics 2`;
+- tamaño lógico: **209,022,976 bytes**;
+- SHA-256 del SQLite privado: `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`.
+
+El archivo SQLite no se publica en GitHub.
+
+## Preservación
+
+La copia privada canónica se comprimió de forma determinista para preservación:
+
+- tamaño comprimido: **83,745,081 bytes**;
+- SHA-256 comprimido: `8ae9c16b7d31a500b07cbed4084cbc98da72f1630edef136a929ad76176d9c71`.
+
+Después de archivarla privadamente se realizó una redescarga independiente. El archivo redescargado reprodujo exactamente el SHA-256 comprimido y, al descomprimirlo en flujo, reprodujo el SHA-256 del SQLite lógico. La ubicación privada no se expone en la superficie pública.
+
+## Identidad del conjunto de entrada
+
+Para evitar que nombres o rutas locales formen parte de la identidad del corpus, las 288 bases se representan por sus SHA-256 ordenados lexicográficamente. La huella del conjunto —los 288 SHA-256 en minúsculas unidos con `LF`, sin `LF` terminal— es:
+
+`bbc63e8b34376d7f92e34183906df244593800180af91748927b932b721ed389`
+
+Esta huella permite comparar reconstrucciones realizadas en directorios o equipos diferentes sin exigir nombres de archivo idénticos.
+
+## Distribución técnica
+
+### Por generación
+
+| generación | páginas |
+|---:|---:|
+| 1960 | 3,536 |
+| 1966 | 6,680 |
+| 1972 | 7,020 |
+| 1982 | 3,292 |
+| 1988 | 5,274 |
+| 1993 | 21,708 |
+| 2008 | 6,538 |
+| 2011 | 7,611 |
+| 2014 | 13,752 |
+| 2018 | 2,744 |
+| 2019 | 8,394 |
+
+### Por grado
+
+| grado | páginas |
+|---:|---:|
+| 1 | 10,459 |
+| 2 | 10,814 |
+| 3 | 20,333 |
+| 4 | 13,059 |
+| 5 | 12,710 |
+| 6 | 19,174 |
+
+### Por ola operacional
+
+| ola | páginas |
+|---|---:|
+| W1 | 6,516 |
+| W2 | 11,945 |
+| W3 | 20,765 |
+| W4 | 2,414 |
+| W5 | 2,653 |
+| W6 | 5,258 |
+| W7 | 3,261 |
+| W8 | 1,490 |
+| W9 | 448 |
+| W10 | 11,937 |
+| W11 | 19,862 |
+
+La ola sigue siendo una dimensión operacional de LTMD; no se reinterpreta automáticamente como ontología curricular.
+
+## Smoke tests FTS5
+
+Se realizaron consultas corpus-wide únicamente para verificar recuperación, filtrado y comportamiento del tokenizer. Estos conteos son **señales computacionales**, no hallazgos históricos validados.
+
+- `raramuri`: 23 páginas candidatas / 17 libros;
+- `rarámuri`: 23 / 17, confirmando equivalencia diacrítica esperada;
+- `democracia`: 359 / 107;
+- frase `"medio ambiente"`: 427 / 206;
+- `migracion`: 289 / 97;
+- `familia`: 3,816 / 461;
+- `discapacidad`: 95 / 38;
+- `tecnologia`: 533 / 181.
+
+En la ejecución local, todas estas consultas de conteo simple se resolvieron en milisegundos. El desempeño observado es diagnóstico del entorno de prueba, no un benchmark contractual.
+
+## Frontera científica
+
+La existencia de un índice full-text no cambia la categoría epistemológica de los resultados:
+
+- `ocr_available != text_verified`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- una coincidencia FTS5 se clasifica como `computational_candidate`;
+- `semantic_ready` permanece en **false** para esta capa corpus-wide.
+
+## Siguiente fase
+
+El Índice Universal elimina la necesidad de construir un ledger privado distinto para cada pregunta temática. La siguiente capa debe ser un motor genérico que reciba consultas FTS5 acotadas, aplique filtros por generación/grado/ola, calcule páginas y libros únicos y devuelva sólo agregados seguros con procedencia y advertencias epistemológicas.

--- a/schemas/ltmd_u1_universal_index_manifest.schema.json
+++ b/schemas/ltmd_u1_universal_index_manifest.schema.json
@@ -10,7 +10,7 @@
     "input": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["database_count", "database_hashes", "private_paths_emitted"],
+      "required": ["database_count", "database_hashes", "database_hash_order", "private_paths_emitted"],
       "properties": {
         "database_count": {"type": "integer", "minimum": 1},
         "database_hashes": {
@@ -18,21 +18,21 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["slot", "basename", "sha256"],
+            "required": ["sha256", "bytes"],
             "properties": {
-              "slot": {"type": "integer", "minimum": 1},
-              "basename": {"type": "string", "minLength": 1},
-              "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+              "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+              "bytes": {"type": "integer", "minimum": 1}
             }
           }
         },
+        "database_hash_order": {"const": "sha256_ascending"},
         "private_paths_emitted": {"const": false}
       }
     },
     "reconciliation": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["unique_pages", "unique_canonical_objects", "fts_rows", "duplicate_page_ids", "sqlite_integrity_check", "identical_duplicate_rows_deduplicated", "conflicts"],
+      "required": ["unique_pages", "unique_canonical_objects", "fts_rows", "duplicate_page_ids", "sqlite_integrity_check", "identical_duplicate_rows_deduplicated", "conflicts", "canonical_row_order"],
       "properties": {
         "unique_pages": {"type": "integer", "minimum": 1},
         "unique_canonical_objects": {"type": "integer", "minimum": 1},
@@ -40,7 +40,8 @@
         "duplicate_page_ids": {"const": 0},
         "sqlite_integrity_check": {"const": "ok"},
         "identical_duplicate_rows_deduplicated": {"type": "integer", "minimum": 0},
-        "conflicts": {"const": 0}
+        "conflicts": {"const": 0},
+        "canonical_row_order": {"const": "page_id_ascending"}
       }
     },
     "dimensions": {
@@ -56,11 +57,12 @@
     "index": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["format", "fts_table", "tokenizer", "sha256", "private", "contains_search_text", "publish_index_file"],
+      "required": ["format", "fts_table", "tokenizer", "canonical_row_order", "sha256", "private", "contains_search_text", "publish_index_file"],
       "properties": {
         "format": {"const": "SQLite3 + FTS5"},
         "fts_table": {"const": "pages_fts"},
         "tokenizer": {"const": "unicode61 remove_diacritics 2"},
+        "canonical_row_order": {"const": "page_id_ascending"},
         "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
         "private": {"const": true},
         "contains_search_text": {"const": true},

--- a/scripts/build_u1_universal_index.py
+++ b/scripts/build_u1_universal_index.py
@@ -7,6 +7,11 @@ The builder reconciles page-level FTRL SQLite databases into one private search 
 It may read OCR-derived search text and source URLs, but those values remain inside the
 private SQLite output. The companion manifest is text-free and suitable for public audit.
 
+Reproducibility rules:
+- source databases are identified in the public manifest by content hash, not local path/name;
+- reconciled pages are inserted in global `page_id` ascending order, independent of input filenames;
+- duplicate page IDs are accepted only when their technical fingerprint is identical.
+
 Scientific boundary:
     ocr_available != text_verified
     search_hit != historical_claim
@@ -17,9 +22,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 import sqlite3
-from collections import Counter
 from pathlib import Path
 from typing import Iterable
 
@@ -107,8 +110,8 @@ def page_fingerprint(row: dict) -> tuple:
 
 
 def iter_source_pages(db_paths: list[Path]):
-    """Yield one canonical row per unique page_id and fail on conflicting duplicates."""
-    seen: dict[str, tuple] = {}
+    """Yield globally page_id-sorted canonical rows; fail on conflicting duplicates."""
+    seen: dict[str, tuple[tuple, dict]] = {}
     duplicate_rows = 0
     for db_path in db_paths:
         connection = sqlite3.connect(str(db_path))
@@ -121,7 +124,7 @@ def iter_source_pages(db_paths: list[Path]):
                     f"{db_path.name}: pages table missing required columns: " + ", ".join(sorted(missing))
                 )
             selected = [name for name in PRIVATE_OUTPUT_COLUMNS if name in columns]
-            sql = "SELECT " + ", ".join(quote_identifier(name) for name in selected) + " FROM pages ORDER BY page_id"
+            sql = "SELECT " + ", ".join(quote_identifier(name) for name in selected) + " FROM pages"
             for source_row in connection.execute(sql):
                 row = {name: source_row[name] if name in source_row.keys() else None for name in PRIVATE_OUTPUT_COLUMNS}
                 page_id = str(row.get("page_id") or "").strip()
@@ -130,18 +133,30 @@ def iter_source_pages(db_paths: list[Path]):
                 fingerprint = page_fingerprint(row)
                 previous = seen.get(page_id)
                 if previous is not None:
-                    if previous != fingerprint:
+                    if previous[0] != fingerprint:
                         raise RuntimeError(f"conflicting duplicate page_id: {page_id} in {db_path.name}")
                     duplicate_rows += 1
                     continue
-                seen[page_id] = fingerprint
-                yield row
+                seen[page_id] = (fingerprint, row)
         finally:
             connection.close()
+
     iter_source_pages.duplicate_rows = duplicate_rows
+    for page_id in sorted(seen):
+        yield seen[page_id][1]
 
 
 iter_source_pages.duplicate_rows = 0
+
+
+def canonical_input_hashes(db_paths: list[Path]) -> list[dict]:
+    """Return content-addressed input identities independent of local filenames and paths."""
+    records = [
+        {"sha256": sha256_file(path), "bytes": path.stat().st_size}
+        for path in db_paths
+    ]
+    records.sort(key=lambda row: (row["sha256"], row["bytes"]))
+    return records
 
 
 def initialize_index(connection: sqlite3.Connection) -> None:
@@ -275,23 +290,13 @@ def build_index(
     if output_path.exists():
         output_path.unlink()
 
-    input_hashes = [
-        {"slot": index + 1, "basename": path.name, "sha256": sha256_file(path)}
-        for index, path in enumerate(db_paths)
-    ]
+    input_hashes = canonical_input_hashes(db_paths)
 
     connection = sqlite3.connect(str(output_path))
     try:
         initialize_index(connection)
-        connection.execute("BEGIN")
-        page_counter = Counter()
-        objects: set[str] = set()
-        inserted = 0
         for row in iter_source_pages(db_paths):
             insert_page(connection, row)
-            inserted += 1
-            page_counter[str(row.get("wave"))] += 1
-            objects.add(str(row.get("canonical_viewer_key")))
         connection.commit()
 
         connection.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
@@ -303,6 +308,7 @@ def build_index(
             connection,
             {
                 "builder_version": VERSION,
+                "canonical_row_order": "page_id_ascending",
                 "unique_pages": verification["unique_pages"],
                 "unique_canonical_objects": verification["unique_canonical_objects"],
                 "text_verified": False,
@@ -321,18 +327,21 @@ def build_index(
         "input": {
             "database_count": len(db_paths),
             "database_hashes": input_hashes,
+            "database_hash_order": "sha256_ascending",
             "private_paths_emitted": False,
         },
         "reconciliation": {
             **verification,
             "identical_duplicate_rows_deduplicated": int(iter_source_pages.duplicate_rows),
             "conflicts": 0,
+            "canonical_row_order": "page_id_ascending",
         },
         "dimensions": dimensions,
         "index": {
             "format": "SQLite3 + FTS5",
             "fts_table": "pages_fts",
             "tokenizer": "unicode61 remove_diacritics 2",
+            "canonical_row_order": "page_id_ascending",
             "sha256": index_sha256,
             "private": True,
             "contains_search_text": True,

--- a/tests/test_build_u1_universal_index.py
+++ b/tests/test_build_u1_universal_index.py
@@ -1,6 +1,7 @@
 import hashlib
 import importlib.util
 import json
+import shutil
 import sqlite3
 from pathlib import Path
 
@@ -101,6 +102,8 @@ def test_build_reconciles_duplicate_and_builds_fts(tmp_path):
     assert manifest["reconciliation"]["unique_canonical_objects"] == 2
     assert manifest["reconciliation"]["identical_duplicate_rows_deduplicated"] == 1
     assert manifest["reconciliation"]["conflicts"] == 0
+    assert manifest["reconciliation"]["canonical_row_order"] == "page_id_ascending"
+    assert manifest["input"]["database_hash_order"] == "sha256_ascending"
     assert manifest["index"]["private"] is True
     assert manifest["scientific_state"]["semantic_ready"] is False
 
@@ -132,7 +135,7 @@ def test_conflicting_duplicate_page_id_fails(tmp_path):
         raise AssertionError("expected conflict gate")
 
 
-def test_manifest_is_text_free_and_path_free(tmp_path):
+def test_manifest_is_text_free_path_free_and_filename_independent(tmp_path):
     db = tmp_path / "private_wave.sqlite"
     make_source_db(db, [row("p1", "B1", 1993, 5, "W3", "secreto rarámuri")])
     output = tmp_path / "private_universal.sqlite"
@@ -144,10 +147,36 @@ def test_manifest_is_text_free_and_path_free(tmp_path):
     assert "secreto" not in payload
     assert "example.invalid" not in payload
     assert str(tmp_path) not in payload
+    assert "private_wave.sqlite" not in payload
     assert "p1" not in payload
     assert saved["privacy"]["ocr_text_in_manifest"] is False
     assert saved["privacy"]["page_ids_in_manifest"] is False
     assert saved["input"]["private_paths_emitted"] is False
+    assert set(saved["input"]["database_hashes"][0]) == {"sha256", "bytes"}
+
+
+def test_binary_index_is_independent_of_input_filenames_and_order(tmp_path):
+    source_a = tmp_path / "source_a.sqlite"
+    source_b = tmp_path / "source_b.sqlite"
+    make_source_db(source_a, [row("p9", "B9", 2014, 6, "W7", "nueve", 9)])
+    make_source_db(source_b, [row("p1", "B1", 1993, 5, "W3", "uno", 1)])
+
+    set1 = tmp_path / "set1"
+    set2 = tmp_path / "set2"
+    set1.mkdir()
+    set2.mkdir()
+    shutil.copyfile(source_a, set1 / "a.sqlite")
+    shutil.copyfile(source_b, set1 / "z.sqlite")
+    shutil.copyfile(source_a, set2 / "z.sqlite")
+    shutil.copyfile(source_b, set2 / "a.sqlite")
+
+    out1, man1 = tmp_path / "one.sqlite", tmp_path / "one.json"
+    out2, man2 = tmp_path / "two.sqlite", tmp_path / "two.json"
+    m1 = mod.build_index(sorted(set1.glob("*.sqlite")), out1, man1, expected_pages=2, expected_objects=2)
+    m2 = mod.build_index(sorted(set2.glob("*.sqlite")), out2, man2, expected_pages=2, expected_objects=2)
+
+    assert m1["index"]["sha256"] == m2["index"]["sha256"]
+    assert man1.read_bytes() == man2.read_bytes()
 
 
 def test_u1_cardinality_gate_rejects_wrong_counts(tmp_path):


### PR DESCRIPTION
## Summary

Turns the universal-index foundation into a canonical, materially verified corpus-wide artifact.

### Reproducibility fix
The original builder was logically deterministic but could let local input filenames affect SQLite row insertion order and therefore the binary SHA. This PR removes that dependency:
- reconciles all pages first and inserts globally in `page_id` ascending order;
- identifies input databases by SHA-256 rather than local names/paths;
- orders input provenance by content hash;
- adds CI proving that swapping source filenames/order yields the same binary index SHA and identical manifest.

### Real U1 materialization
Reconstructed the preserved FTRL vault without new OCR and verified:
- 288 private SQLite databases;
- 86,549 unique pages;
- 492 canonical objects;
- 86,549 FTS5 rows;
- 0 duplicate page IDs;
- 0 identity/hash conflicts;
- `PRAGMA integrity_check = ok`.

Canonical private index:
- SQLite3 + FTS5 (`unicode61 remove_diacritics 2`);
- global row order `page_id_ascending`;
- 209,022,976 bytes;
- SHA-256 `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`.

The compressed private preservation copy was uploaded, redownloaded and stream-decompressed; both compressed and logical SHA-256 values matched exactly. No private storage location is emitted in GitHub.

### Corpus-wide smoke tests
Count-only FTS tests confirmed accent-insensitive retrieval (`raramuri` == `rarámuri`) and arbitrary queries such as democracia, medio ambiente, migracion, familia, discapacidad and tecnologia. These remain computational candidates, not historical claims.

### Public artifacts
- text-free materialization summary under `data/research/`;
- detailed methodological/materialization report;
- updated content-addressed manifest schema and reproducibility tests.

## Scientific state
`ocr_available=true`, `text_verified=false`, `semantic_ready=false`; FTS results are `computational_candidate` and human validation remains required for semantic promotion.

## Next
Build the generic corpus-wide query engine over the private Universal Index, then expose only safe aggregates and filters to LTMD Analytics.