### PR TITLE
Product: add LTMD-U1 corpus-wide query engine 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -10,12 +10,15 @@ on:
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
+      - 'scripts/query_u1_universal_index.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
+      - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
+      - 'tests/test_query_u1_universal_index.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -26,12 +29,15 @@ on:
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
+      - 'scripts/query_u1_universal_index.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
+      - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
+      - 'tests/test_query_u1_universal_index.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -54,6 +60,7 @@ jobs:
           tests/test_query_indigenous_analytics.py
           tests/test_analytics_api.py
           tests/test_build_u1_universal_index.py
+          tests/test_query_u1_universal_index.py
       - name: Validate Analytics JSON schemas
         run: |
           python - <<'PY'
@@ -62,6 +69,7 @@ jobs:
           paths = [
               'schemas/ltmd_analytics_query_response.schema.json',
               'schemas/ltmd_u1_universal_index_manifest.schema.json',
+              'schemas/ltmd_u1_corpus_query_response.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))

--- a/docs/LTMD_U1_CORPUS_QUERY_ENGINE_0_1.md
+++ b/docs/LTMD_U1_CORPUS_QUERY_ENGINE_0_1.md
@@ -1,0 +1,105 @@
+# LTMD-U1 — motor de consulta corpus-wide 0.1
+
+Versión: **LTMD_U1_CORPUS_QUERY_ENGINE_0.1**
+
+## Propósito
+
+Esta capa convierte el Índice Universal privado LTMD-U1 en un motor de recuperación transversal. A diferencia de los primeros verticales temáticos, no requiere un ledger específico para cada pregunta: recibe una expresión FTS5, aplica filtros sobre el mismo universo de 86,549 páginas y devuelve exclusivamente agregados.
+
+El motor **no devuelve** OCR, `search_text`, snippets, `page_id`, URL fuente, hashes de página/OCR ni rutas privadas.
+
+## Entrada
+
+- Índice Universal privado `LTMD_U1_UNIVERSAL_INDEX_0.1`.
+- Expresión FTS5 mediante `--query`.
+- Filtros repetibles:
+  - `--generation`
+  - `--grade-code`
+  - `--wave`
+- Desglose opcional:
+  - `--group-by generation`
+  - `--group-by grade_code`
+  - `--group-by wave`
+- Verificación criptográfica opcional del índice mediante `--expected-index-sha256`.
+
+Ejemplo privado:
+
+```bash
+python scripts/query_u1_universal_index.py \
+  --index /ruta/privada/ltmd_u1_universal_index_0_1.sqlite \
+  --expected-index-sha256 aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2 \
+  --query '"medio ambiente"' \
+  --generation 2014 \
+  --grade-code 6 \
+  --group-by wave
+```
+
+## Denominadores exactos
+
+El Índice Universal contiene el universo de páginas, no sólo los hits. Por ello, para cualquier combinación admitida de generación, grado y ola, el motor calcula:
+
+- `corpus_pages_in_scope`;
+- `corpus_books_in_scope`;
+- `candidate_pages`;
+- `candidate_books`;
+- `candidate_pages_per_1000`.
+
+La tasa utiliza exactamente el mismo conjunto de filtros en numerador y denominador. Esto elimina la limitación del primer motor temático, que sólo disponía de denominadores por generación.
+
+Cuando se solicita `group_by`, cada grupo recalcula su propio denominador dentro del universo filtrado.
+
+## Consulta FTS5
+
+`--query` acepta sintaxis FTS5. La expresión se pasa como parámetro enlazado a SQLite; los filtros también son parametrizados. Un error de sintaxis FTS5 se devuelve como error genérico `invalid FTS5 query expression`, sin propagar detalles internos de SQLite.
+
+El tokenizer heredado del Índice Universal es `unicode61 remove_diacritics 2`. Por tanto, búsquedas como `raramuri` y `rarámuri` recuperan el mismo término normalizado cuando el resto de la expresión es equivalente.
+
+## Contrato de salida
+
+La respuesta JSON utiliza `schemas/ltmd_u1_corpus_query_response.schema.json` y sólo expone:
+
+- consulta suministrada;
+- filtros normalizados;
+- métricas agregadas;
+- breakdown agregado opcional;
+- versión del motor e índice;
+- SHA-256 del índice sólo cuando fue verificado explícitamente;
+- advertencias epistemológicas.
+
+No se emiten identificadores ni contenido que permita reconstruir las páginas fuente.
+
+## Estado epistemológico
+
+Toda respuesta 0.1 conserva:
+
+```text
+result_state = exploratory_signal
+human_validation_complete = false
+```
+
+Las reglas obligatorias son:
+
+- `ocr_available != text_verified`;
+- `search_hit != historical_claim`;
+- `zero_hits != demonstrated_absence`;
+- `computational_candidate != semantic_ready`.
+
+Una búsqueda puede priorizar investigación o alimentar una visualización; no sustituye validación humana del constructo.
+
+## Privacidad
+
+El índice universal y su OCR derivado permanecen privados. El motor está diseñado para ejecutarse server-side/local-only. El output no contiene:
+
+- texto OCR;
+- snippets;
+- `page_id`;
+- `canonical_viewer_key`;
+- URL fuente;
+- hashes de páginas;
+- paths del filesystem.
+
+El conteo de libros se calcula internamente mediante `COUNT(DISTINCT canonical_viewer_key)` pero ese identificador no se devuelve.
+
+## Próximo paso
+
+Tras validar este motor contra el índice canónico real, LTMD Analytics debe generalizar su contrato HTTP para consumirlo. Antes del staging se fijará además el **Corpus Analytics Manifest 0.1**, con denominadores y dimensiones auditables del universo utilizado por producto.

--- a/schemas/ltmd_u1_corpus_query_response.schema.json
+++ b/schemas/ltmd_u1_corpus_query_response.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_corpus_query_response.schema.json",
+  "title": "LTMD-U1 corpus-wide query response 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["query", "filters", "result_state", "metrics", "provenance", "warnings"],
+  "properties": {
+    "query": {"type": "string", "minLength": 1, "maxLength": 500},
+    "filters": {"$ref": "#/$defs/filters"},
+    "result_state": {"const": "exploratory_signal"},
+    "metrics": {"$ref": "#/$defs/metrics"},
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["query_engine_version", "index_version", "index_sha256", "human_validation_complete"],
+      "properties": {
+        "query_engine_version": {"const": "LTMD_U1_CORPUS_QUERY_ENGINE_0.1"},
+        "index_version": {"const": "LTMD_U1_UNIVERSAL_INDEX_0.1"},
+        "index_sha256": {
+          "oneOf": [
+            {"type": "null"},
+            {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+          ]
+        },
+        "human_validation_complete": {"const": false}
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"type": "string", "minLength": 1}
+    },
+    "group_by": {"enum": ["generation", "grade_code", "wave"]},
+    "breakdown": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["dimension", "value", "result_state", "metrics"],
+        "properties": {
+          "dimension": {"enum": ["generation", "grade_code", "wave"]},
+          "value": {"type": "string", "minLength": 1},
+          "result_state": {"const": "exploratory_signal"},
+          "metrics": {"$ref": "#/$defs/metrics"}
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {"required": ["group_by"]},
+      "then": {"required": ["breakdown"]}
+    },
+    {
+      "if": {"required": ["breakdown"]},
+      "then": {"required": ["group_by"]}
+    }
+  ],
+  "$defs": {
+    "filters": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["generation", "grade_code", "wave"],
+      "properties": {
+        "generation": {"type": "array", "uniqueItems": true, "items": {"type": "integer", "minimum": 0}},
+        "grade_code": {"type": "array", "uniqueItems": true, "items": {"type": "integer", "minimum": 0}},
+        "wave": {"type": "array", "uniqueItems": true, "items": {"type": "string", "pattern": "^W[0-9]+$"}}
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["candidate_pages", "candidate_books", "corpus_pages_in_scope", "corpus_books_in_scope", "candidate_pages_per_1000"],
+      "properties": {
+        "candidate_pages": {"type": "integer", "minimum": 0},
+        "candidate_books": {"type": "integer", "minimum": 0},
+        "corpus_pages_in_scope": {"type": "integer", "minimum": 0},
+        "corpus_books_in_scope": {"type": "integer", "minimum": 0},
+        "candidate_pages_per_1000": {
+          "oneOf": [
+            {"type": "null"},
+            {"type": "number", "minimum": 0}
+          ]
+        }
+      }
+    }
+  }
+}

--- a/scripts/query_u1_universal_index.py
+++ b/scripts/query_u1_universal_index.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Query the private LTMD-U1 Universal Index and emit aggregate-only results.
+
+Version: LTMD_U1_CORPUS_QUERY_ENGINE_0.1
+
+The engine executes an FTS5 expression against the private Universal Index, applies exact
+corpus filters, and returns only aggregate counts/rates. It never emits OCR/search text,
+page IDs, source URLs, source/OCR hashes, snippets, or private filesystem paths.
+
+Scientific boundary:
+    ocr_available != text_verified
+    search_hit != historical_claim
+    zero_hits != demonstrated_absence
+    computational_candidate != semantic_ready
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+ENGINE_VERSION = "LTMD_U1_CORPUS_QUERY_ENGINE_0.1"
+INDEX_VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+MAX_QUERY_LENGTH = 500
+MAX_FILTER_VALUES = 50
+ALLOWED_GROUP_BY = {"generation", "grade_code", "wave"}
+DIMENSION_COLUMNS = {
+    "generation": "catalog_generation",
+    "grade_code": "grade_code",
+    "wave": "wave",
+}
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+WAVE_RE = re.compile(r"^W\d+$")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def normalize_numeric_values(name: str, values: Iterable[str] | None) -> list[int]:
+    if not values:
+        return []
+    normalized: set[int] = set()
+    for raw in values:
+        value = str(raw).strip()
+        if not value or not value.isdigit():
+            raise RuntimeError(f"{name} values must be unsigned integers")
+        normalized.add(int(value))
+    if len(normalized) > MAX_FILTER_VALUES:
+        raise RuntimeError(f"too many {name} values; maximum is {MAX_FILTER_VALUES}")
+    return sorted(normalized)
+
+
+def normalize_wave_values(values: Iterable[str] | None) -> list[str]:
+    if not values:
+        return []
+    normalized = {str(value).strip().upper() for value in values if str(value).strip()}
+    if len(normalized) > MAX_FILTER_VALUES:
+        raise RuntimeError(f"too many wave values; maximum is {MAX_FILTER_VALUES}")
+    invalid = sorted(value for value in normalized if not WAVE_RE.fullmatch(value))
+    if invalid:
+        raise RuntimeError("invalid wave value(s): " + ", ".join(invalid))
+    return sorted(normalized, key=lambda value: int(value[1:]))
+
+
+def normalize_filters(filters: dict[str, Iterable[str] | None]) -> dict[str, list]:
+    return {
+        "generation": normalize_numeric_values("generation", filters.get("generation")),
+        "grade_code": normalize_numeric_values("grade_code", filters.get("grade_code")),
+        "wave": normalize_wave_values(filters.get("wave")),
+    }
+
+
+def validate_query_expression(query_expression: str) -> str:
+    value = str(query_expression or "").strip()
+    if not value:
+        raise RuntimeError("FTS query must not be blank")
+    if len(value) > MAX_QUERY_LENGTH:
+        raise RuntimeError(f"FTS query exceeds {MAX_QUERY_LENGTH} characters")
+    if "\x00" in value:
+        raise RuntimeError("FTS query contains a NUL byte")
+    return value
+
+
+def validate_index(connection: sqlite3.Connection) -> dict:
+    tables = {
+        row[0]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")
+    }
+    missing = {"pages", "pages_fts", "index_meta"} - tables
+    if missing:
+        raise RuntimeError("not an LTMD-U1 Universal Index; missing: " + ", ".join(sorted(missing)))
+
+    columns = {row[1] for row in connection.execute("PRAGMA table_info(pages)")}
+    required = {
+        "id", "page_id", "canonical_viewer_key", "wave", "catalog_generation",
+        "grade_code", "search_text",
+    }
+    missing_columns = required - columns
+    if missing_columns:
+        raise RuntimeError("Universal Index pages table missing: " + ", ".join(sorted(missing_columns)))
+
+    meta = {}
+    for key, raw in connection.execute("SELECT key, value FROM index_meta"):
+        try:
+            meta[key] = json.loads(raw)
+        except json.JSONDecodeError:
+            meta[key] = raw
+    if meta.get("builder_version") != INDEX_VERSION:
+        raise RuntimeError(
+            f"unsupported Universal Index version: {meta.get('builder_version')!r}; expected {INDEX_VERSION}"
+        )
+    return meta
+
+
+def build_filter_clause(filters: dict[str, list], alias: str = "p") -> tuple[str, list]:
+    clauses = []
+    params: list = []
+    for public_name in ("generation", "grade_code", "wave"):
+        values = filters.get(public_name) or []
+        if not values:
+            continue
+        column = DIMENSION_COLUMNS[public_name]
+        placeholders = ",".join("?" for _ in values)
+        clauses.append(f"{alias}.{column} IN ({placeholders})")
+        params.extend(values)
+    return (" AND ".join(clauses) if clauses else "1=1"), params
+
+
+def count_scope(connection: sqlite3.Connection, filters: dict[str, list]) -> dict:
+    where, params = build_filter_clause(filters)
+    row = connection.execute(
+        f"SELECT COUNT(*), COUNT(DISTINCT p.canonical_viewer_key) FROM pages p WHERE {where}",
+        params,
+    ).fetchone()
+    return {"corpus_pages_in_scope": int(row[0]), "corpus_books_in_scope": int(row[1])}
+
+
+def count_hits(connection: sqlite3.Connection, query_expression: str, filters: dict[str, list]) -> dict:
+    where, params = build_filter_clause(filters)
+    sql = f"""
+        SELECT COUNT(*), COUNT(DISTINCT p.canonical_viewer_key)
+        FROM pages_fts f
+        JOIN pages p ON p.id = f.rowid
+        WHERE pages_fts MATCH ? AND {where}
+    """
+    try:
+        row = connection.execute(sql, [query_expression, *params]).fetchone()
+    except sqlite3.OperationalError as exc:
+        raise RuntimeError("invalid FTS5 query expression") from exc
+    return {"candidate_pages": int(row[0]), "candidate_books": int(row[1])}
+
+
+def combine_metrics(scope: dict, hits: dict) -> dict:
+    corpus_pages = scope["corpus_pages_in_scope"]
+    candidate_pages = hits["candidate_pages"]
+    return {
+        **hits,
+        **scope,
+        "candidate_pages_per_1000": (
+            candidate_pages / corpus_pages * 1000 if corpus_pages else None
+        ),
+    }
+
+
+def group_values(connection: sqlite3.Connection, filters: dict[str, list], group_by: str) -> list:
+    if group_by not in ALLOWED_GROUP_BY:
+        raise RuntimeError("group_by must be one of: " + ", ".join(sorted(ALLOWED_GROUP_BY)))
+    column = DIMENSION_COLUMNS[group_by]
+    where, params = build_filter_clause(filters)
+    rows = connection.execute(
+        f"SELECT DISTINCT p.{column} FROM pages p WHERE {where} ORDER BY p.{column}",
+        params,
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def with_group_filter(filters: dict[str, list], group_by: str, value) -> dict[str, list]:
+    result = {key: list(values) for key, values in filters.items()}
+    result[group_by] = [value]
+    return result
+
+
+def build_breakdown(
+    connection: sqlite3.Connection,
+    query_expression: str,
+    filters: dict[str, list],
+    group_by: str,
+) -> list[dict]:
+    breakdown = []
+    for value in group_values(connection, filters, group_by):
+        group_filters = with_group_filter(filters, group_by, value)
+        scope = count_scope(connection, group_filters)
+        hits = count_hits(connection, query_expression, group_filters)
+        breakdown.append({
+            "dimension": group_by,
+            "value": str(value),
+            "result_state": "exploratory_signal",
+            "metrics": combine_metrics(scope, hits),
+        })
+    return breakdown
+
+
+def query_index(
+    connection: sqlite3.Connection,
+    *,
+    query_expression: str,
+    filters: dict[str, Iterable[str] | None] | None = None,
+    group_by: str | None = None,
+    index_sha256: str | None = None,
+) -> dict:
+    expression = validate_query_expression(query_expression)
+    normalized_filters = normalize_filters(filters or {})
+    validate_index(connection)
+    if group_by is not None and group_by not in ALLOWED_GROUP_BY:
+        raise RuntimeError("group_by must be one of: " + ", ".join(sorted(ALLOWED_GROUP_BY)))
+    if index_sha256 is not None and not SHA256_RE.fullmatch(index_sha256):
+        raise RuntimeError("index_sha256 must be a lowercase SHA-256 value")
+
+    scope = count_scope(connection, normalized_filters)
+    hits = count_hits(connection, expression, normalized_filters)
+    metrics = combine_metrics(scope, hits)
+
+    warnings = [
+        "FTS5 matches are computational candidates/exploratory signals, not validated historical claims.",
+        "OCR-derived search text is not human-verified text.",
+    ]
+    if hits["candidate_pages"] == 0:
+        warnings.append("Zero FTS5 hits do not demonstrate historical absence.")
+
+    response = {
+        "query": expression,
+        "filters": normalized_filters,
+        "result_state": "exploratory_signal",
+        "metrics": metrics,
+        "provenance": {
+            "query_engine_version": ENGINE_VERSION,
+            "index_version": INDEX_VERSION,
+            "index_sha256": index_sha256,
+            "human_validation_complete": False,
+        },
+        "warnings": warnings,
+    }
+    if group_by:
+        response["group_by"] = group_by
+        response["breakdown"] = build_breakdown(
+            connection, expression, normalized_filters, group_by
+        )
+    return response
+
+
+def run(
+    index_path: Path,
+    *,
+    query_expression: str,
+    filters: dict[str, Iterable[str] | None] | None = None,
+    group_by: str | None = None,
+    expected_index_sha256: str | None = None,
+) -> dict:
+    path = index_path.expanduser().resolve()
+    if not path.is_file():
+        raise RuntimeError("Universal Index file is unavailable")
+
+    verified_sha = None
+    if expected_index_sha256 is not None:
+        expected = expected_index_sha256.strip().lower()
+        if not SHA256_RE.fullmatch(expected):
+            raise RuntimeError("expected index SHA-256 is invalid")
+        actual = sha256_file(path)
+        if actual != expected:
+            raise RuntimeError("Universal Index SHA-256 mismatch")
+        verified_sha = actual
+
+    connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        return query_index(
+            connection,
+            query_expression=query_expression,
+            filters=filters,
+            group_by=group_by,
+            index_sha256=verified_sha,
+        )
+    finally:
+        connection.close()
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index", required=True, help="Private LTMD-U1 Universal Index SQLite")
+    parser.add_argument("--query", required=True, help="FTS5 MATCH expression")
+    parser.add_argument("--generation", action="append")
+    parser.add_argument("--grade-code", action="append")
+    parser.add_argument("--wave", action="append")
+    parser.add_argument("--group-by", choices=sorted(ALLOWED_GROUP_BY))
+    parser.add_argument("--expected-index-sha256")
+    parser.add_argument("--output")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    response = run(
+        Path(args.index),
+        query_expression=args.query,
+        filters={
+            "generation": args.generation,
+            "grade_code": args.grade_code,
+            "wave": args.wave,
+        },
+        group_by=args.group_by,
+        expected_index_sha256=args.expected_index_sha256,
+    )
+    payload = json.dumps(response, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        Path(args.output).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_query_u1_universal_index.py
+++ b/tests/test_query_u1_universal_index.py
@@ -1,0 +1,188 @@
+import hashlib
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+BUILDER_PATH = Path(__file__).parents[1] / "scripts" / "build_u1_universal_index.py"
+BUILDER_SPEC = importlib.util.spec_from_file_location("build_u1_universal_index", BUILDER_PATH)
+builder = importlib.util.module_from_spec(BUILDER_SPEC)
+assert BUILDER_SPEC.loader is not None
+BUILDER_SPEC.loader.exec_module(builder)
+
+QUERY_PATH = Path(__file__).parents[1] / "scripts" / "query_u1_universal_index.py"
+QUERY_SPEC = importlib.util.spec_from_file_location("query_u1_universal_index", QUERY_PATH)
+mod = importlib.util.module_from_spec(QUERY_SPEC)
+assert QUERY_SPEC.loader is not None
+QUERY_SPEC.loader.exec_module(mod)
+
+
+def source_row(page_id, book, generation, grade, wave, text, page_index):
+    return {
+        "page_id": page_id,
+        "viewer_key": book,
+        "canonical_viewer_key": book,
+        "wave": wave,
+        "catalog_generation": generation,
+        "grade_code": grade,
+        "title_core": f"Book {book}",
+        "page_index": page_index,
+        "viewer_page": page_index,
+        "source_asset_url": f"https://example.invalid/{page_id}.jpg",
+        "source_sha256": hashlib.sha256((page_id + "source").encode()).hexdigest(),
+        "source_byte_size": 100,
+        "ocr_engine": "test",
+        "ocr_engine_version": "1",
+        "ocr_language": "spa",
+        "ocr_psm": 3,
+        "ocr_sha256": hashlib.sha256((page_id + "ocr").encode()).hexdigest(),
+        "search_text": text,
+        "search_text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "ocr_confidence_mean": 90.0,
+        "ocr_char_count": len(text),
+        "ocr_word_count": len(text.split()),
+        "generated_at": "2026-08-30T00:00:00Z",
+    }
+
+
+def make_source_db(path: Path):
+    rows = [
+        source_row("p1", "B1", 1993, 5, "W3", "democracia y lengua rarámuri", 1),
+        source_row("p2", "B1", 1993, 5, "W3", "familia y comunidad", 2),
+        source_row("p3", "B2", 2014, 6, "W7", "democracia participación", 1),
+        source_row("p4", "B3", 2014, 6, "W3", "tecnología y ciencia", 1),
+    ]
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE pages (
+                page_id TEXT, viewer_key TEXT, canonical_viewer_key TEXT, wave TEXT,
+                catalog_generation INTEGER, grade_code INTEGER, title_core TEXT,
+                page_index INTEGER, viewer_page INTEGER, source_asset_url TEXT,
+                source_sha256 TEXT, source_byte_size INTEGER, ocr_engine TEXT,
+                ocr_engine_version TEXT, ocr_language TEXT, ocr_psm INTEGER,
+                ocr_sha256 TEXT, search_text TEXT, search_text_sha256 TEXT,
+                ocr_confidence_mean REAL, ocr_char_count INTEGER, ocr_word_count INTEGER,
+                generated_at TEXT
+            )
+            """
+        )
+        fields = list(rows[0])
+        for row in rows:
+            connection.execute(
+                "INSERT INTO pages (" + ",".join(fields) + ") VALUES (" + ",".join("?" for _ in fields) + ")",
+                [row[field] for field in fields],
+            )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def make_index(tmp_path: Path) -> Path:
+    source = tmp_path / "source.sqlite"
+    make_source_db(source)
+    index = tmp_path / "universal.sqlite"
+    manifest = tmp_path / "manifest.json"
+    builder.build_index([source], index, manifest, expected_pages=4, expected_objects=3)
+    return index
+
+
+def test_query_exact_counts_and_scope_denominator(tmp_path):
+    index = make_index(tmp_path)
+    response = mod.run(
+        index,
+        query_expression="democracia",
+        filters={"generation": ["2014"], "grade_code": ["6"], "wave": None},
+    )
+    assert response["metrics"] == {
+        "candidate_pages": 1,
+        "candidate_books": 1,
+        "corpus_pages_in_scope": 2,
+        "corpus_books_in_scope": 2,
+        "candidate_pages_per_1000": 500.0,
+    }
+    assert response["filters"]["generation"] == [2014]
+    assert response["filters"]["grade_code"] == [6]
+    assert response["result_state"] == "exploratory_signal"
+
+
+def test_combined_grade_wave_denominator_is_exact(tmp_path):
+    index = make_index(tmp_path)
+    response = mod.run(
+        index,
+        query_expression="democracia",
+        filters={"generation": ["2014"], "grade_code": ["6"], "wave": ["W7"]},
+    )
+    assert response["metrics"]["candidate_pages"] == 1
+    assert response["metrics"]["corpus_pages_in_scope"] == 1
+    assert response["metrics"]["candidate_pages_per_1000"] == 1000.0
+
+
+def test_breakdown_uses_group_specific_denominators(tmp_path):
+    index = make_index(tmp_path)
+    response = mod.run(index, query_expression="democracia", group_by="generation")
+    by_generation = {row["value"]: row["metrics"] for row in response["breakdown"]}
+    assert by_generation["1993"]["candidate_pages"] == 1
+    assert by_generation["1993"]["corpus_pages_in_scope"] == 2
+    assert by_generation["1993"]["candidate_pages_per_1000"] == 500.0
+    assert by_generation["2014"]["candidate_pages"] == 1
+    assert by_generation["2014"]["corpus_pages_in_scope"] == 2
+
+
+def test_accent_insensitive_fts_and_private_surface(tmp_path):
+    index = make_index(tmp_path)
+    plain = mod.run(index, query_expression="raramuri")
+    accented = mod.run(index, query_expression="rarámuri")
+    assert plain["metrics"]["candidate_pages"] == 1
+    assert plain["metrics"] == accented["metrics"]
+    rendered = json.dumps(plain, ensure_ascii=False)
+    for forbidden in ("page_id", "search_text", "source_asset_url", "source_sha256", "ocr_sha256", "example.invalid", "p1"):
+        assert forbidden not in rendered
+
+
+def test_zero_hits_warns_that_absence_is_not_demonstrated(tmp_path):
+    index = make_index(tmp_path)
+    response = mod.run(index, query_expression="inexistente")
+    assert response["metrics"]["candidate_pages"] == 0
+    assert response["metrics"]["candidate_books"] == 0
+    assert response["metrics"]["corpus_pages_in_scope"] == 4
+    assert any("do not demonstrate historical absence" in warning for warning in response["warnings"])
+
+
+def test_invalid_fts_expression_is_sanitized(tmp_path):
+    index = make_index(tmp_path)
+    try:
+        mod.run(index, query_expression='"unterminated')
+    except RuntimeError as exc:
+        assert str(exc) == "invalid FTS5 query expression"
+    else:
+        raise AssertionError("expected invalid FTS expression")
+
+
+def test_index_hash_verification(tmp_path):
+    index = make_index(tmp_path)
+    expected = mod.sha256_file(index)
+    response = mod.run(index, query_expression="familia", expected_index_sha256=expected)
+    assert response["provenance"]["index_sha256"] == expected
+    try:
+        mod.run(index, query_expression="familia", expected_index_sha256="0" * 64)
+    except RuntimeError as exc:
+        assert str(exc) == "Universal Index SHA-256 mismatch"
+    else:
+        raise AssertionError("expected SHA mismatch")
+
+
+def test_filter_validation(tmp_path):
+    index = make_index(tmp_path)
+    for filters, expected_fragment in [
+        ({"generation": ["x"]}, "generation values"),
+        ({"grade_code": ["six"]}, "grade_code values"),
+        ({"wave": ["history"]}, "invalid wave"),
+    ]:
+        try:
+            mod.run(index, query_expression="familia", filters=filters)
+        except RuntimeError as exc:
+            assert expected_fragment in str(exc)
+        else:
+            raise AssertionError("expected filter validation failure")


### PR DESCRIPTION
## Summary

Adds the generic **LTMD-U1 corpus-wide query engine 0.1** on top of the private Universal Index.

### Capabilities
- arbitrary FTS5 MATCH expressions over the 86,549-page U1 index;
- exact filters by catalog generation, grade and wave;
- exact in-scope denominators for pages and unique books using the same active filters as the numerator;
- optional aggregate breakdown by generation, grade or wave;
- read-only index access with optional SHA-256 verification;
- aggregate-only JSON output governed by a JSON Schema.

### Privacy/scientific contract
The response never emits OCR/search text, snippets, page IDs, canonical book identifiers, source URLs, page/OCR hashes or private filesystem paths. Results remain `exploratory_signal`; `human_validation_complete=false`; zero hits do not demonstrate historical absence.

### Real canonical-index validation
Validated against private `LTMD_U1_UNIVERSAL_INDEX_0.1` SHA-256 `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2` (86,549 pages / 492 canonical objects).

Count-only checks reproduced prior corpus-wide smoke tests, including `raramuri` = `rarámuri` (23 pages / 17 books), `democracia` (359 / 107), `"medio ambiente"` (427 / 206), `familia` (3,816 / 461) and other arbitrary terms.

A combined filter `generation=2014, grade=6, wave=W7` resolves an exact denominator of 209 pages / 1 book; `democracia` returns 15 candidate pages there (71.7703 per 1,000 pages). A deliberately nonexistent expression returns 0 candidates while retaining the explicit no-absence warning.

### Tests/CI
Adds tests for exact denominators, combined filters, group-specific denominators, accent-insensitive FTS, private-surface guarantees, zero-hit semantics, invalid FTS sanitization, SHA verification and filter validation. The Analytics workflow also validates the new response schema.

## Next
After merge, promote the corpus-wide full-text task to complete and build the **Corpus Analytics Manifest 0.1** / master dimensions before exposing this engine through the HTTP product surface. Staging remains downstream.