### PR TITLE
Product: add LTMD-U1 Corpus Analytics Manifest 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -11,14 +11,17 @@ on:
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
       - 'scripts/query_u1_universal_index.py'
+      - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
+      - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
       - 'tests/test_query_u1_universal_index.py'
+      - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -30,14 +33,17 @@ on:
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
       - 'scripts/query_u1_universal_index.py'
+      - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
+      - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
       - 'tests/test_query_u1_universal_index.py'
+      - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -61,6 +67,7 @@ jobs:
           tests/test_analytics_api.py
           tests/test_build_u1_universal_index.py
           tests/test_query_u1_universal_index.py
+          tests/test_build_u1_corpus_analytics_manifest.py
       - name: Validate Analytics JSON schemas
         run: |
           python - <<'PY'
@@ -70,6 +77,7 @@ jobs:
               'schemas/ltmd_analytics_query_response.schema.json',
               'schemas/ltmd_u1_universal_index_manifest.schema.json',
               'schemas/ltmd_u1_corpus_query_response.schema.json',
+              'schemas/ltmd_u1_corpus_analytics_manifest.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))

--- a/data/research/ltmd_u1_corpus_analytics_manifest_summary_0_1.json
+++ b/data/research/ltmd_u1_corpus_analytics_manifest_summary_0_1.json
@@ -1,0 +1,72 @@
+{
+  "dimension_cardinality": {
+    "generations": 11,
+    "grades": 6,
+    "nonempty_generation_grade_wave_cells": 267,
+    "waves": 11
+  },
+  "full_manifest": {
+    "preserved_private": true,
+    "public_repository_contains_full_manifest": false,
+    "sha256": "0966bba7bdd7410476e0eec42a3a5257a18994e8754666a649243b7fc4dda13a",
+    "version": "LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0.1"
+  },
+  "index": {
+    "private": true,
+    "sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2",
+    "sqlite_integrity_check": "ok",
+    "tokenizer": "unicode61 remove_diacritics 2",
+    "version": "LTMD_U1_UNIVERSAL_INDEX_0.1"
+  },
+  "ocr_quality": {
+    "available_pages": 80968,
+    "interpretation": "engine_confidence_only_not_CER_WER_or_human_text_verification",
+    "max": 97.007088,
+    "mean": 88.55164136444027,
+    "median": 92.0614865,
+    "metric": "page_level_ocr_engine_confidence_mean",
+    "min": 0.0,
+    "p10": 79.6217163,
+    "p25": 88.04625374999999,
+    "p75": 94.12816125,
+    "p90": 95.3290431,
+    "unavailable_pages": 5581
+  },
+  "privacy": {
+    "book_identifiers_emitted": false,
+    "full_manifest_private": true,
+    "ocr_or_search_text_emitted": false,
+    "page_ids_emitted": false,
+    "private_storage_location_emitted": false,
+    "public_summary_aggregate_only": true,
+    "source_urls_emitted": false
+  },
+  "scientific_state": {
+    "corpus_ready_for_computational_retrieval": true,
+    "default_result_state": "exploratory_signal",
+    "human_validation_deferred_not_cancelled": true,
+    "ocr_available": true,
+    "semantic_ready": false,
+    "text_verified": false
+  },
+  "summary_version": "LTMD_U1_CORPUS_ANALYTICS_MANIFEST_SUMMARY_0.1",
+  "technical_coverage": {
+    "coverage_version": "LTMD_U1_COVERAGE_0.14",
+    "retained_register_version": "LTMD_U1_RETAINED_SOURCE_REGISTER_0.2",
+    "retention_status_counts": {
+      "active_retention": 13,
+      "final_exception": 5
+    }
+  },
+  "universe": {
+    "active_retentions": 13,
+    "canonical_processing_objects": 492,
+    "effective_technical_identities": 524,
+    "final_exceptions": 5,
+    "fts_rows": 86549,
+    "historical_identities": 542,
+    "human_semantic_validated_identities": 0,
+    "indexed_pages": 86549,
+    "residual_identities": 18
+  }
+}

--- a/docs/LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0_1.md
+++ b/docs/LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0_1.md
@@ -1,0 +1,71 @@
+# LTMD-U1 — Corpus Analytics Manifest 0.1
+
+Versión: **LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0.1**
+
+## Función
+
+Este manifiesto fija el universo computacional que puede utilizar LTMD Analytics antes del staging. No es un catálogo bibliográfico nuevo ni una capa semántica: es un contrato reproducible de denominadores, cobertura técnica, dimensiones operacionales y calidad OCR agregada.
+
+Se construye desde tres fuentes canónicas: el Índice Universal U1 privado, el tablero público de cobertura U1 y el registro público de retenciones/excepciones. Si esas fuentes no reconcilian, el constructor falla.
+
+## Universo fijado
+
+El corte 0.1 exige:
+
+- 542 identidades históricas U1;
+- 524 identidades con cobertura técnica efectiva;
+- 492 objetos canónicos de procesamiento;
+- 86,549 páginas indexadas y 86,549 filas FTS5;
+- residual 18 = 13 `active_retention` + 5 `final_exception`;
+- 0 identidades con validación semántica humana incorporada.
+
+La diferencia entre 542 identidades históricas y 492 objetos canónicos preserva relaciones técnicas demostradas y excepciones; no autoriza aliases heurísticos.
+
+## Dimensiones
+
+El manifiesto calcula directamente desde el Índice Universal denominadores por generación, grado y ola operacional, además de todas las celdas no vacías generación × grado × ola. El corte real contiene **267 celdas no vacías**. Cada celda registra únicamente páginas y objetos canónicos únicos.
+
+La taxonomía `wave` sigue siendo logística/operacional y no se convierte en ontología curricular. Estos denominadores permiten que una consulta de Analytics use exactamente el mismo subuniverso en numerador y denominador.
+
+## Cobertura técnica
+
+El constructor no copia a ciegas las cifras del tablero. Verifica que la suma de las once olas coincida con los totales de identidades planificadas, cobertura efectiva, objetos canónicos y residual; que el residual global sea igual al registro de fuentes retenidas; que `active_retention + final_exception` sea exactamente el residual; que su distribución por ola coincida; y que los 492 objetos canónicos del tablero coincidan con el Índice Universal.
+
+## Calidad OCR
+
+El manifiesto agrega `ocr_confidence_mean` a escala corpus. Esta cifra es una señal producida por el motor OCR y **no** es CER, WER, corrección humana ni `text_verified`.
+
+La salida utiliza explícitamente:
+
+`engine_confidence_only_not_CER_WER_or_human_text_verification`
+
+El corte real tiene confianza disponible para 80,968 páginas y no disponible para 5,581.
+
+## Estado epistemológico
+
+El contrato mantiene:
+
+```text
+ocr_available = true
+text_verified = false
+corpus_ready_for_computational_retrieval = true
+semantic_ready = false
+default_result_state = exploratory_signal
+human_validation_deferred_not_cancelled = true
+```
+
+Reglas obligatorias: `ocr_available != text_verified`; `corpus_ready != semantic_ready`; `search_hit != historical_claim`; `zero_hits != demonstrated_absence`.
+
+## Privacidad y publicación
+
+El manifiesto no incorpora OCR, `search_text`, snippets, `page_id`, claves de libro, URLs fuente, hashes de páginas/OCR ni paths privados. La copia integral del manifiesto de operación se preserva en el archivo privado de LTMD Analytics; GitHub conserva el constructor, el esquema y una huella/resumen agregado del corte.
+
+El Índice Universal completo continúa privado y no debe publicarse.
+
+## Integridad
+
+El Corpus Analytics Manifest 0.1 se vincula al Índice Universal canónico mediante su SHA-256. Una reconstrucción contra otro índice debe fallar si se solicita el gate criptográfico y el hash no coincide.
+
+## Secuencia canónica
+
+Con este contrato cerrado, el siguiente frente es construir los derivados corpus-wide de **léxico, dispersión, n-gramas y coocurrencias**. La reutilización/similitud transversal y los verticales temáticos siguen después. Staging e interfaz permanecen downstream.

--- a/schemas/ltmd_u1_corpus_analytics_manifest.schema.json
+++ b/schemas/ltmd_u1_corpus_analytics_manifest.schema.json
@@ -1,0 +1,170 @@
+{
+  "$defs": {
+    "coverageWave": {
+      "additionalProperties": false,
+      "properties": {
+        "canonical_processing_objects": {"minimum": 0, "type": "integer"},
+        "effective_technical_identities": {"minimum": 0, "type": "integer"},
+        "operational_domain": {"minLength": 1, "type": "string"},
+        "planned_identities": {"minimum": 0, "type": "integer"},
+        "residual_identities": {"minimum": 0, "type": "integer"},
+        "technical_status": {"minLength": 1, "type": "string"},
+        "wave": {"pattern": "^W[0-9]+$", "type": "string"}
+      },
+      "required": ["wave", "operational_domain", "planned_identities", "effective_technical_identities", "canonical_processing_objects", "residual_identities", "technical_status"],
+      "type": "object"
+    },
+    "denominatorCell": {
+      "additionalProperties": false,
+      "properties": {
+        "canonical_objects": {"minimum": 1, "type": "integer"},
+        "generation": {"minimum": 0, "type": "integer"},
+        "grade_code": {"minimum": 0, "type": "integer"},
+        "pages": {"minimum": 1, "type": "integer"},
+        "wave": {"pattern": "^W[0-9]+$", "type": "string"}
+      },
+      "required": ["generation", "grade_code", "wave", "pages", "canonical_objects"],
+      "type": "object"
+    },
+    "dimensionRow": {
+      "additionalProperties": false,
+      "properties": {
+        "canonical_objects": {"minimum": 1, "type": "integer"},
+        "pages": {"minimum": 1, "type": "integer"},
+        "value": {"minLength": 1, "type": "string"}
+      },
+      "required": ["value", "pages", "canonical_objects"],
+      "type": "object"
+    }
+  },
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_corpus_analytics_manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "denominator_policy": {
+      "additionalProperties": false,
+      "properties": {
+        "filtered_denominators_come_from_same_universal_index": {"const": true},
+        "silent_imputation": {"const": false},
+        "wave_is_operational_not_curricular_ontology": {"const": true},
+        "zero_hits_demonstrate_absence": {"const": false}
+      },
+      "required": ["filtered_denominators_come_from_same_universal_index", "silent_imputation", "wave_is_operational_not_curricular_ontology", "zero_hits_demonstrate_absence"],
+      "type": "object"
+    },
+    "dimensions": {
+      "additionalProperties": false,
+      "properties": {
+        "generation": {"items": {"$ref": "#/$defs/dimensionRow"}, "type": "array"},
+        "grade_code": {"items": {"$ref": "#/$defs/dimensionRow"}, "type": "array"},
+        "nonempty_generation_grade_wave_cells": {"items": {"$ref": "#/$defs/denominatorCell"}, "type": "array"},
+        "wave": {"items": {"$ref": "#/$defs/dimensionRow"}, "type": "array"}
+      },
+      "required": ["generation", "grade_code", "wave", "nonempty_generation_grade_wave_cells"],
+      "type": "object"
+    },
+    "index": {
+      "additionalProperties": false,
+      "properties": {
+        "private": {"const": true},
+        "publish_index_file": {"const": false},
+        "sha256": {"pattern": "^[a-f0-9]{64}$", "type": "string"},
+        "sqlite_integrity_check": {"const": "ok"},
+        "tokenizer": {"const": "unicode61 remove_diacritics 2"},
+        "version": {"const": "LTMD_U1_UNIVERSAL_INDEX_0.1"}
+      },
+      "required": ["version", "sha256", "sqlite_integrity_check", "tokenizer", "private", "publish_index_file"],
+      "type": "object"
+    },
+    "inputs": {
+      "additionalProperties": false,
+      "properties": {
+        "coverage_source": {"const": "data/catalog/ltmd_u1_coverage.md"},
+        "index_sha256": {"pattern": "^[a-f0-9]{64}$", "type": "string"},
+        "private_index_path_emitted": {"const": false},
+        "retained_source_register": {"const": "data/catalog/ltmd_u1_retained_source_register.csv"}
+      },
+      "required": ["index_sha256", "coverage_source", "retained_source_register", "private_index_path_emitted"],
+      "type": "object"
+    },
+    "manifest_version": {"const": "LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0.1"},
+    "ocr_quality": {
+      "additionalProperties": false,
+      "properties": {
+        "available_pages": {"minimum": 0, "type": "integer"},
+        "interpretation": {"const": "engine_confidence_only_not_CER_WER_or_human_text_verification"},
+        "max": {"type": ["number", "null"]},
+        "mean": {"type": ["number", "null"]},
+        "median": {"type": ["number", "null"]},
+        "metric": {"const": "page_level_ocr_engine_confidence_mean"},
+        "min": {"type": ["number", "null"]},
+        "p10": {"type": ["number", "null"]},
+        "p25": {"type": ["number", "null"]},
+        "p75": {"type": ["number", "null"]},
+        "p90": {"type": ["number", "null"]},
+        "unavailable_pages": {"minimum": 0, "type": "integer"}
+      },
+      "required": ["metric", "available_pages", "unavailable_pages", "mean", "min", "p10", "p25", "median", "p75", "p90", "max", "interpretation"],
+      "type": "object"
+    },
+    "privacy": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate_only_public_surface": {"const": true},
+        "book_identifiers_emitted": {"const": false},
+        "ocr_or_search_text_emitted": {"const": false},
+        "page_ids_emitted": {"const": false},
+        "page_or_ocr_hashes_emitted": {"const": false},
+        "private_storage_paths_emitted": {"const": false},
+        "snippets_emitted": {"const": false},
+        "source_urls_emitted": {"const": false}
+      },
+      "required": ["ocr_or_search_text_emitted", "snippets_emitted", "page_ids_emitted", "book_identifiers_emitted", "source_urls_emitted", "page_or_ocr_hashes_emitted", "private_storage_paths_emitted", "aggregate_only_public_surface"],
+      "type": "object"
+    },
+    "scientific_state": {
+      "additionalProperties": false,
+      "properties": {
+        "corpus_ready_for_computational_retrieval": {"const": true},
+        "default_result_state": {"const": "exploratory_signal"},
+        "human_validation_deferred_not_cancelled": {"const": true},
+        "ocr_available": {"const": true},
+        "semantic_ready": {"const": false},
+        "text_verified": {"const": false}
+      },
+      "required": ["ocr_available", "text_verified", "corpus_ready_for_computational_retrieval", "semantic_ready", "default_result_state", "human_validation_deferred_not_cancelled"],
+      "type": "object"
+    },
+    "technical_coverage": {
+      "additionalProperties": false,
+      "properties": {
+        "by_wave": {"items": {"$ref": "#/$defs/coverageWave"}, "maxItems": 11, "minItems": 11, "type": "array"},
+        "coverage_version": {"minLength": 1, "type": "string"},
+        "retained_register_version": {"minLength": 1, "type": "string"},
+        "retention_by_wave": {"additionalProperties": {"additionalProperties": {"minimum": 0, "type": "integer"}, "type": "object"}, "type": "object"},
+        "retention_status_counts": {"additionalProperties": {"minimum": 0, "type": "integer"}, "type": "object"}
+      },
+      "required": ["coverage_version", "retained_register_version", "by_wave", "retention_status_counts", "retention_by_wave"],
+      "type": "object"
+    },
+    "universe": {
+      "additionalProperties": false,
+      "properties": {
+        "active_retentions": {"minimum": 0, "type": "integer"},
+        "canonical_processing_objects": {"minimum": 1, "type": "integer"},
+        "effective_technical_identities": {"minimum": 0, "type": "integer"},
+        "final_exceptions": {"minimum": 0, "type": "integer"},
+        "fts_rows": {"minimum": 1, "type": "integer"},
+        "historical_identities": {"minimum": 1, "type": "integer"},
+        "human_semantic_validated_identities": {"minimum": 0, "type": "integer"},
+        "indexed_pages": {"minimum": 1, "type": "integer"},
+        "residual_identities": {"minimum": 0, "type": "integer"}
+      },
+      "required": ["historical_identities", "effective_technical_identities", "canonical_processing_objects", "indexed_pages", "fts_rows", "residual_identities", "active_retentions", "final_exceptions", "human_semantic_validated_identities"],
+      "type": "object"
+    }
+  },
+  "required": ["manifest_version", "universe", "index", "dimensions", "technical_coverage", "ocr_quality", "denominator_policy", "scientific_state", "privacy", "inputs"],
+  "title": "LTMD-U1 Corpus Analytics Manifest 0.1",
+  "type": "object"
+}

--- a/scripts/build_u1_corpus_analytics_manifest.py
+++ b/scripts/build_u1_corpus_analytics_manifest.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Build the public-safe LTMD-U1 Corpus Analytics Manifest 0.1.
+
+Inputs:
+- private LTMD-U1 Universal Index SQLite;
+- public LTMD-U1 coverage Markdown;
+- public retained-source register CSV.
+
+The output contains aggregate denominators, technical coverage and OCR-engine
+quality summaries only. It never emits OCR/search text, page IDs, book keys,
+source URLs, page hashes or private filesystem paths.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+from collections import Counter
+from pathlib import Path
+
+VERSION = "LTMD_U1_CORPUS_ANALYTICS_MANIFEST_0.1"
+INDEX_VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+EXPECTED_PAGES = 86549
+EXPECTED_OBJECTS = 492
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_coverage(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    version_m = re.search(r"Versión:\s*`([^`]+)`", text)
+    universe_m = re.search(r"Universo U1:\s*\*\*(\d+)/(\d+)\*\*", text)
+    effective_m = re.search(r"Cobertura técnica efectiva[^:]*:\s*\*\*(\d+)/(\d+)", text)
+    objects_m = re.search(r"Objetos canónicos[^:]*:\s*\*\*(\d+)/(\d+)", text)
+    semantic_m = re.search(r"Cobertura semántica humana[^:]*:\s*\*\*(\d+)/(\d+)", text)
+    required = [version_m, universe_m, effective_m, objects_m, semantic_m]
+    if not all(required):
+        raise RuntimeError("coverage Markdown does not match expected LTMD-U1 structure")
+
+    rows = []
+    row_re = re.compile(
+        r"^\|\s*(W\d+)\s*\|\s*`([^`]+)`\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*`([^`]+)`\s*\|$"
+    )
+    for line in text.splitlines():
+        m = row_re.match(line)
+        if m:
+            rows.append({
+                "wave": m.group(1),
+                "operational_domain": m.group(2),
+                "planned_identities": int(m.group(3)),
+                "effective_technical_identities": int(m.group(4)),
+                "canonical_processing_objects": int(m.group(5)),
+                "residual_identities": int(m.group(6)),
+                "technical_status": m.group(7),
+            })
+    if len(rows) != 11:
+        raise RuntimeError(f"coverage wave table must contain 11 rows; got {len(rows)}")
+
+    return {
+        "version": version_m.group(1),
+        "historical_identities": int(universe_m.group(1)),
+        "universe_denominator": int(universe_m.group(2)),
+        "effective_technical_identities": int(effective_m.group(1)),
+        "canonical_processing_objects": int(objects_m.group(1)),
+        "human_semantic_validated_identities": int(semantic_m.group(1)),
+        "by_wave": rows,
+    }
+
+
+def parse_retained(path: Path) -> dict:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        raise RuntimeError("retained-source register is empty")
+    versions = {row["register_version"] for row in rows}
+    if len(versions) != 1:
+        raise RuntimeError("retained-source register has multiple versions")
+    status_counts = Counter(row["status"] for row in rows)
+    by_wave = {}
+    for row in rows:
+        slot = by_wave.setdefault(row["wave"], Counter())
+        slot[row["status"]] += 1
+    return {
+        "version": versions.pop(),
+        "rows": len(rows),
+        "status_counts": dict(sorted(status_counts.items())),
+        "by_wave": {
+            wave: dict(sorted(counts.items()))
+            for wave, counts in sorted(by_wave.items(), key=lambda item: int(item[0][1:]))
+        },
+    }
+
+
+def validate_index(connection: sqlite3.Connection) -> dict:
+    meta = {}
+    for key, raw in connection.execute("SELECT key, value FROM index_meta"):
+        try:
+            meta[key] = json.loads(raw)
+        except json.JSONDecodeError:
+            meta[key] = raw
+    if meta.get("builder_version") != INDEX_VERSION:
+        raise RuntimeError("unsupported Universal Index version")
+    pages = connection.execute("SELECT COUNT(*) FROM pages").fetchone()[0]
+    objects = connection.execute(
+        "SELECT COUNT(DISTINCT canonical_viewer_key) FROM pages"
+    ).fetchone()[0]
+    fts = connection.execute("SELECT COUNT(*) FROM pages_fts").fetchone()[0]
+    integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
+    if pages != fts or integrity != "ok":
+        raise RuntimeError("Universal Index integrity/cardinality gate failed")
+    return {"pages": int(pages), "canonical_objects": int(objects), "fts_rows": int(fts), "integrity": integrity}
+
+
+def dimension(connection: sqlite3.Connection, column: str, *, wave: bool = False) -> list[dict]:
+    order = f"CAST(SUBSTR({column},2) AS INTEGER)" if wave else column
+    rows = connection.execute(
+        f"""SELECT {column}, COUNT(*), COUNT(DISTINCT canonical_viewer_key)
+            FROM pages GROUP BY {column} ORDER BY {order}"""
+    ).fetchall()
+    return [
+        {"value": str(value), "pages": int(pages), "canonical_objects": int(objects)}
+        for value, pages, objects in rows
+    ]
+
+
+def denominator_cells(connection: sqlite3.Connection) -> list[dict]:
+    rows = connection.execute(
+        """SELECT catalog_generation, grade_code, wave,
+                  COUNT(*), COUNT(DISTINCT canonical_viewer_key)
+           FROM pages
+           GROUP BY catalog_generation, grade_code, wave
+           ORDER BY catalog_generation, grade_code, CAST(SUBSTR(wave,2) AS INTEGER)"""
+    ).fetchall()
+    return [
+        {
+            "generation": int(generation),
+            "grade_code": int(grade),
+            "wave": wave,
+            "pages": int(pages),
+            "canonical_objects": int(objects),
+        }
+        for generation, grade, wave, pages, objects in rows
+    ]
+
+
+def percentile(sorted_values: list[float], p: float) -> float | None:
+    if not sorted_values:
+        return None
+    pos = (len(sorted_values) - 1) * p
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = pos - lo
+    return sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac
+
+
+def ocr_quality(connection: sqlite3.Connection, total_pages: int) -> dict:
+    values = [
+        float(row[0])
+        for row in connection.execute(
+            "SELECT ocr_confidence_mean FROM pages WHERE ocr_confidence_mean IS NOT NULL ORDER BY ocr_confidence_mean"
+        )
+    ]
+    mean = sum(values) / len(values) if values else None
+    return {
+        "metric": "page_level_ocr_engine_confidence_mean",
+        "available_pages": len(values),
+        "unavailable_pages": total_pages - len(values),
+        "mean": mean,
+        "min": values[0] if values else None,
+        "p10": percentile(values, 0.10),
+        "p25": percentile(values, 0.25),
+        "median": percentile(values, 0.50),
+        "p75": percentile(values, 0.75),
+        "p90": percentile(values, 0.90),
+        "max": values[-1] if values else None,
+        "interpretation": "engine_confidence_only_not_CER_WER_or_human_text_verification",
+    }
+
+
+def build(index_path: Path, coverage_path: Path, retained_path: Path, output_path: Path,
+          expected_index_sha256: str | None = None,
+          expected_pages: int = EXPECTED_PAGES,
+          expected_objects: int = EXPECTED_OBJECTS) -> dict:
+    actual_sha = sha256_file(index_path)
+    if expected_index_sha256 and actual_sha != expected_index_sha256.lower():
+        raise RuntimeError("Universal Index SHA-256 mismatch")
+
+    coverage = parse_coverage(coverage_path)
+    retained = parse_retained(retained_path)
+    connection = sqlite3.connect(f"file:{index_path.resolve()}?mode=ro", uri=True)
+    try:
+        index_state = validate_index(connection)
+        if index_state["pages"] != expected_pages:
+            raise RuntimeError(f"page cardinality mismatch: {index_state['pages']} != {expected_pages}")
+        if index_state["canonical_objects"] != expected_objects:
+            raise RuntimeError(
+                f"canonical object cardinality mismatch: {index_state['canonical_objects']} != {expected_objects}"
+            )
+        if coverage["historical_identities"] != coverage["universe_denominator"]:
+            raise RuntimeError("coverage universe numerator/denominator mismatch")
+        residual = coverage["historical_identities"] - coverage["effective_technical_identities"]
+        wave_planned = sum(row["planned_identities"] for row in coverage["by_wave"])
+        wave_effective = sum(row["effective_technical_identities"] for row in coverage["by_wave"])
+        wave_objects = sum(row["canonical_processing_objects"] for row in coverage["by_wave"])
+        wave_residual = sum(row["residual_identities"] for row in coverage["by_wave"])
+        if wave_planned != coverage["historical_identities"]:
+            raise RuntimeError("coverage wave planned identities do not reconcile with universe")
+        if wave_effective != coverage["effective_technical_identities"]:
+            raise RuntimeError("coverage wave effective identities do not reconcile with total")
+        if wave_objects != coverage["canonical_processing_objects"]:
+            raise RuntimeError("coverage wave canonical objects do not reconcile with total")
+        if wave_residual != residual:
+            raise RuntimeError("coverage wave residual identities do not reconcile with total")
+        if residual != retained["rows"]:
+            raise RuntimeError("coverage residual does not equal retained-source register rows")
+        if coverage["canonical_processing_objects"] != index_state["canonical_objects"]:
+            raise RuntimeError("coverage canonical objects do not match Universal Index")
+        if retained["status_counts"].get("active_retention", 0) + retained["status_counts"].get("final_exception", 0) != residual:
+            raise RuntimeError("retention lifecycle does not reconcile with residual")
+
+        residual_by_wave = {row["wave"]: row["residual_identities"] for row in coverage["by_wave"] if row["residual_identities"]}
+        retention_rows_by_wave = {
+            wave: sum(status_counts.values())
+            for wave, status_counts in retained["by_wave"].items()
+        }
+        if residual_by_wave != retention_rows_by_wave:
+            raise RuntimeError("retention rows by wave do not reconcile with coverage residual distribution")
+
+        manifest = {
+            "manifest_version": VERSION,
+            "universe": {
+                "historical_identities": coverage["historical_identities"],
+                "effective_technical_identities": coverage["effective_technical_identities"],
+                "canonical_processing_objects": coverage["canonical_processing_objects"],
+                "indexed_pages": index_state["pages"],
+                "fts_rows": index_state["fts_rows"],
+                "residual_identities": residual,
+                "active_retentions": retained["status_counts"].get("active_retention", 0),
+                "final_exceptions": retained["status_counts"].get("final_exception", 0),
+                "human_semantic_validated_identities": coverage["human_semantic_validated_identities"],
+            },
+            "index": {
+                "version": INDEX_VERSION,
+                "sha256": actual_sha,
+                "sqlite_integrity_check": index_state["integrity"],
+                "tokenizer": "unicode61 remove_diacritics 2",
+                "private": True,
+                "publish_index_file": False,
+            },
+            "dimensions": {
+                "generation": dimension(connection, "catalog_generation"),
+                "grade_code": dimension(connection, "grade_code"),
+                "wave": dimension(connection, "wave", wave=True),
+                "nonempty_generation_grade_wave_cells": denominator_cells(connection),
+            },
+            "technical_coverage": {
+                "coverage_version": coverage["version"],
+                "retained_register_version": retained["version"],
+                "by_wave": coverage["by_wave"],
+                "retention_status_counts": retained["status_counts"],
+                "retention_by_wave": retained["by_wave"],
+            },
+            "ocr_quality": ocr_quality(connection, index_state["pages"]),
+            "denominator_policy": {
+                "filtered_denominators_come_from_same_universal_index": True,
+                "silent_imputation": False,
+                "wave_is_operational_not_curricular_ontology": True,
+                "zero_hits_demonstrate_absence": False,
+            },
+            "scientific_state": {
+                "ocr_available": True,
+                "text_verified": False,
+                "corpus_ready_for_computational_retrieval": True,
+                "semantic_ready": False,
+                "default_result_state": "exploratory_signal",
+                "human_validation_deferred_not_cancelled": True,
+            },
+            "privacy": {
+                "ocr_or_search_text_emitted": False,
+                "snippets_emitted": False,
+                "page_ids_emitted": False,
+                "book_identifiers_emitted": False,
+                "source_urls_emitted": False,
+                "page_or_ocr_hashes_emitted": False,
+                "private_storage_paths_emitted": False,
+                "aggregate_only_public_surface": True,
+            },
+            "inputs": {
+                "index_sha256": actual_sha,
+                "coverage_source": "data/catalog/ltmd_u1_coverage.md",
+                "retained_source_register": "data/catalog/ltmd_u1_retained_source_register.csv",
+                "private_index_path_emitted": False,
+            },
+        }
+    finally:
+        connection.close()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--index", required=True)
+    p.add_argument("--coverage", default="data/catalog/ltmd_u1_coverage.md")
+    p.add_argument("--retained-register", default="data/catalog/ltmd_u1_retained_source_register.csv")
+    p.add_argument("--output", required=True)
+    p.add_argument("--expected-index-sha256")
+    p.add_argument("--expected-pages", type=int, default=EXPECTED_PAGES)
+    p.add_argument("--expected-objects", type=int, default=EXPECTED_OBJECTS)
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    a = parse_args(argv)
+    manifest = build(
+        Path(a.index), Path(a.coverage), Path(a.retained_register), Path(a.output),
+        expected_index_sha256=a.expected_index_sha256,
+        expected_pages=a.expected_pages,
+        expected_objects=a.expected_objects,
+    )
+    print(json.dumps({
+        "manifest_version": manifest["manifest_version"],
+        "indexed_pages": manifest["universe"]["indexed_pages"],
+        "canonical_processing_objects": manifest["universe"]["canonical_processing_objects"],
+        "denominator_cells": len(manifest["dimensions"]["nonempty_generation_grade_wave_cells"]),
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_u1_corpus_analytics_manifest.py
+++ b/tests/test_build_u1_corpus_analytics_manifest.py
@@ -1,0 +1,149 @@
+import csv
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "build_u1_corpus_analytics_manifest.py"
+SPEC = importlib.util.spec_from_file_location("build_u1_corpus_analytics_manifest", SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_index(path: Path):
+    c = sqlite3.connect(path)
+    try:
+        c.executescript("""
+        CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        INSERT INTO index_meta VALUES ('builder_version', '"LTMD_U1_UNIVERSAL_INDEX_0.1"');
+        CREATE TABLE pages(
+          id INTEGER PRIMARY KEY, page_id TEXT UNIQUE, canonical_viewer_key TEXT,
+          wave TEXT, catalog_generation INTEGER, grade_code INTEGER,
+          search_text TEXT, ocr_confidence_mean REAL
+        );
+        CREATE VIRTUAL TABLE pages_fts USING fts5(search_text, content='pages', content_rowid='id');
+        """)
+        rows = [
+            (1, 'p1', 'B1', 'W1', 1993, 5, 'alpha', 90.0),
+            (2, 'p2', 'B1', 'W1', 1993, 5, 'beta', None),
+            (3, 'p3', 'B2', 'W2', 2014, 6, 'gamma', 80.0),
+            (4, 'p4', 'B3', 'W2', 2014, 6, 'delta', 100.0),
+        ]
+        c.executemany('INSERT INTO pages VALUES (?,?,?,?,?,?,?,?)', rows)
+        c.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
+        c.commit()
+    finally:
+        c.close()
+
+
+def make_coverage(path: Path, *, effective=4, objects=3):
+    path.write_text(f'''# LTMD-U1 — tablero de cobertura técnica
+
+Versión: `TEST_COVERAGE_0.1`.
+
+## Totales
+
+- Universo U1: **4/4** identidades catalogadas.
+- Cobertura técnica efectiva cerrada o resuelta: **{effective}/4 (100%)**.
+- Objetos canónicos de procesamiento cerrados: **{objects}/4 (75%)**.
+- Cobertura semántica humana validada incorporada al tablero: **0/4**.
+
+## Por ola
+
+| ola | dominio operacional | plan | efectiva | canónicos | restantes | estado |
+|---|---|---:|---:|---:|---:|---|
+| W1 | `a` | 1 | 1 | 1 | 0 | `closed` |
+| W2 | `b` | 1 | 1 | 1 | 0 | `closed` |
+| W3 | `c` | 1 | 1 | 1 | 0 | `closed` |
+| W4 | `d` | 1 | {1 if effective == 4 else 0} | 0 | {0 if effective == 4 else 1} | `closed` |
+| W5 | `e` | 0 | 0 | 0 | 0 | `closed` |
+| W6 | `f` | 0 | 0 | 0 | 0 | `closed` |
+| W7 | `g` | 0 | 0 | 0 | 0 | `closed` |
+| W8 | `h` | 0 | 0 | 0 | 0 | `closed` |
+| W9 | `i` | 0 | 0 | 0 | 0 | `closed` |
+| W10 | `j` | 0 | 0 | 0 | 0 | `closed` |
+| W11 | `k` | 0 | 0 | 0 | 0 | `closed` |
+''', encoding='utf-8')
+
+
+def make_retained(path: Path, rows=None):
+    fields = ['register_version','wave','operational_domain','viewer_key','catalog_generation','grade_code','retention_class','retention_detail','tracking_issue','status']
+    with path.open('w', encoding='utf-8', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=fields)
+        w.writeheader()
+        for row in rows or []:
+            w.writerow({
+                'register_version':'TEST_RETENTION_0.1','wave':'W4','operational_domain':'d',
+                'viewer_key':'PRIVATE_ID','catalog_generation':'2014','grade_code':'1',
+                'retention_class':'x','retention_detail':'private detail','tracking_issue':'1',
+                'status':row,
+            })
+
+
+def build_fixture(tmp_path: Path):
+    index = tmp_path/'index.sqlite'
+    coverage = tmp_path/'coverage.md'
+    retained = tmp_path/'retained.csv'
+    output = tmp_path/'manifest.json'
+    make_index(index)
+    make_coverage(coverage, effective=3, objects=3)
+    make_retained(retained, ['active_retention'])
+    manifest = mod.build(index, coverage, retained, output, expected_index_sha256=mod.sha256_file(index), expected_pages=4, expected_objects=3)
+    return index, coverage, retained, output, manifest
+
+
+def test_manifest_reconciles_and_builds_exact_denominators(tmp_path):
+    _, _, _, _, m = build_fixture(tmp_path)
+    assert m['universe']['indexed_pages'] == 4
+    assert m['universe']['canonical_processing_objects'] == 3
+    assert m['universe']['residual_identities'] == 1
+    assert m['universe']['active_retentions'] == 1
+    cells = m['dimensions']['nonempty_generation_grade_wave_cells']
+    assert cells == [
+        {'generation':1993,'grade_code':5,'wave':'W1','pages':2,'canonical_objects':1},
+        {'generation':2014,'grade_code':6,'wave':'W2','pages':2,'canonical_objects':2},
+    ]
+    assert sum(row['pages'] for row in cells) == 4
+
+
+def test_ocr_quality_is_engine_confidence_not_text_verification(tmp_path):
+    _, _, _, _, m = build_fixture(tmp_path)
+    q = m['ocr_quality']
+    assert q['available_pages'] == 3
+    assert q['unavailable_pages'] == 1
+    assert q['mean'] == 90.0
+    assert q['min'] == 80.0 and q['max'] == 100.0
+    assert q['interpretation'] == 'engine_confidence_only_not_CER_WER_or_human_text_verification'
+    assert m['scientific_state']['text_verified'] is False
+    assert m['scientific_state']['semantic_ready'] is False
+
+
+def test_public_manifest_surface_omits_private_rows_and_text(tmp_path):
+    _, _, _, output, m = build_fixture(tmp_path)
+    rendered = output.read_text(encoding='utf-8')
+    for forbidden in ('PRIVATE_ID', 'private detail', 'alpha', 'beta', 'gamma', 'delta', 'file:/'):
+        assert forbidden not in rendered
+    assert m['privacy']['aggregate_only_public_surface'] is True
+    assert m['privacy']['source_urls_emitted'] is False
+
+
+def test_residual_mismatch_is_rejected(tmp_path):
+    index = tmp_path/'index.sqlite'; make_index(index)
+    coverage = tmp_path/'coverage.md'; make_coverage(coverage, effective=4, objects=3)
+    retained = tmp_path/'retained.csv'; make_retained(retained, ['active_retention'])
+    try:
+        mod.build(index, coverage, retained, tmp_path/'out.json', expected_pages=4, expected_objects=3)
+    except RuntimeError as exc:
+        assert 'coverage residual does not equal retained-source register rows' in str(exc)
+    else:
+        raise AssertionError('expected residual mismatch gate')
+
+
+def test_index_sha_mismatch_is_rejected(tmp_path):
+    index, coverage, retained, _, _ = build_fixture(tmp_path)
+    try:
+        mod.build(index, coverage, retained, tmp_path/'out2.json', expected_index_sha256='0'*64, expected_pages=4, expected_objects=3)
+    except RuntimeError as exc:
+        assert str(exc) == 'Universal Index SHA-256 mismatch'
+    else:
+        raise AssertionError('expected SHA mismatch')


### PR DESCRIPTION
## Summary

Adds the reproducible **LTMD-U1 Corpus Analytics Manifest 0.1** that fixes the exact computational universe used by product analytics before staging.

### Canonical reconciliation
The builder combines the private Universal Index with the public U1 coverage board and retained-source register, then fails unless all layers reconcile:
- 542 historical identities;
- 524 effective technical identities;
- 492 canonical processing objects;
- 86,549 indexed pages / FTS5 rows;
- residual 18 = 13 `active_retention` + 5 `final_exception`;
- wave-level planned/effective/canonical/residual sums match global totals;
- retention/exceptions reconcile by wave;
- Universal Index integrity and optional SHA-256 gate pass.

### Exact dimensions
The real canonical index produces:
- 11 generations;
- 6 grade codes;
- 11 operational waves;
- **267 non-empty generation × grade × wave denominator cells**.

Each dimension/cell contains aggregate page counts and unique canonical-object counts only. `wave` remains an operational taxonomy, not a curricular ontology.

### OCR quality boundary
The manifest records aggregate page-level OCR-engine confidence for 80,968 pages (5,581 unavailable). This is explicitly labeled `engine_confidence_only_not_CER_WER_or_human_text_verification`; it is not CER/WER and does not promote `text_verified`.

### Privacy and preservation
The full generated manifest contains no OCR/search text, snippets, page IDs, book identifiers, source URLs, page/OCR hashes or private paths. Its canonical private copy was preserved and redownload-verified at 47,646 bytes with SHA-256:
`0966bba7bdd7410476e0eec42a3a5257a18994e8754666a649243b7fc4dda13a`

GitHub receives the builder, strict JSON Schema, tests, documentation and a compact aggregate summary/hash — not the private operational manifest or Universal Index.

### Scientific state
- `ocr_available=true`
- `text_verified=false`
- `corpus_ready_for_computational_retrieval=true`
- `semantic_ready=false`
- default result state `exploratory_signal`
- human validation remains deferred, not cancelled.

### Tests/CI
Adds synthetic tests for denominator construction, coverage/retention reconciliation, privacy surface, OCR-confidence semantics and index SHA mismatch. Extends LTMD Analytics CI and schema validation.

## Next
After merge, close the manifest/dimensions task and activate corpus-wide **lexicon, dispersion, n-grams and co-occurrences**. Reuse/similarity and thematic verticals remain downstream; staging still waits.