### PR TITLE
Analytics: materialize LTMD-U1 lexical positions 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -12,16 +12,19 @@ on:
       - 'scripts/build_u1_universal_index.py'
       - 'scripts/query_u1_universal_index.py'
       - 'scripts/build_u1_corpus_analytics_manifest.py'
+      - 'scripts/build_u1_lexical_positions.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
+      - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
       - 'tests/test_query_u1_universal_index.py'
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
+      - 'tests/test_build_u1_lexical_positions.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -34,16 +37,19 @@ on:
       - 'scripts/build_u1_universal_index.py'
       - 'scripts/query_u1_universal_index.py'
       - 'scripts/build_u1_corpus_analytics_manifest.py'
+      - 'scripts/build_u1_lexical_positions.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
+      - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
       - 'tests/test_build_u1_universal_index.py'
       - 'tests/test_query_u1_universal_index.py'
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
+      - 'tests/test_build_u1_lexical_positions.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -68,6 +74,7 @@ jobs:
           tests/test_build_u1_universal_index.py
           tests/test_query_u1_universal_index.py
           tests/test_build_u1_corpus_analytics_manifest.py
+          tests/test_build_u1_lexical_positions.py
       - name: Validate Analytics JSON schemas
         run: |
           python - <<'PY'
@@ -78,6 +85,7 @@ jobs:
               'schemas/ltmd_u1_universal_index_manifest.schema.json',
               'schemas/ltmd_u1_corpus_query_response.schema.json',
               'schemas/ltmd_u1_corpus_analytics_manifest.schema.json',
+              'schemas/ltmd_u1_lexical_positions_public_summary.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))

--- a/data/analytics/ltmd_u1_lexical_positions_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_lexical_positions_materialization_0_1.json
@@ -1,0 +1,41 @@
+{
+  "materialization_version": "LTMD_U1_LEXICAL_POSITIONS_MATERIALIZATION_0.1",
+  "source_index": {
+    "version": "LTMD_U1_UNIVERSAL_INDEX_0.1",
+    "sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2",
+    "tokenizer": "unicode61 remove_diacritics 2"
+  },
+  "counts": {
+    "unique_terms": 239259,
+    "token_instances": 13265844,
+    "term_page_relations": 7848708,
+    "unique_pages": 86549,
+    "unique_objects": 492,
+    "term_stats_rows": 239259
+  },
+  "private_artifact": {
+    "sqlite_bytes": 763662336,
+    "sqlite_sha256": "59340c6f91fb7a2e9763ba84c1c6b9accfcd9f9f369a9a7b9ce2a9eeca9d7e8e",
+    "gzip_bytes": 317808648,
+    "gzip_sha256": "1c8248c040ce4a2fe0464f5d6b98b50f5c8d51c581fa65eb90094756b53bcb1b",
+    "quick_check": "ok",
+    "publish": false
+  },
+  "privacy": {
+    "full_vocabulary_public": false,
+    "token_positions_public": false,
+    "rare_terms_public_by_default": false,
+    "ocr_text_public": false
+  },
+  "scientific_state": {
+    "result_state": "exploratory_signal",
+    "text_verified": false,
+    "semantic_ready": false,
+    "frequency_is_semantic_claim": false
+  },
+  "preservation": {
+    "receipt_preserved_privately": true,
+    "large_artifact_drive_upload_succeeded": false,
+    "reconstructible_from_canonical_index": true
+  }
+}

--- a/docs/LTMD_U1_LEXICAL_POSITIONS_0_1.md
+++ b/docs/LTMD_U1_LEXICAL_POSITIONS_0_1.md
@@ -1,0 +1,76 @@
+# LTMD-U1 — posiciones léxicas y estadística unigram 0.1
+
+Versión de artefacto privado: **LTMD_U1_LEXICAL_POSITIONS_0.1**  
+Constructor público: **LTMD_U1_LEXICAL_POSITIONS_BUILDER_0.1**
+
+## Propósito
+
+Esta capa convierte el FTS5 del Índice Universal LTMD-U1 en una única materialización privada reutilizable para análisis léxico. El objetivo es evitar múltiples barridos incompatibles o redundantes sobre el OCR: la misma normalización FTS5 alimenta frecuencia, dispersión y los futuros n-gramas/coocurrencias.
+
+El tokenizer es exactamente `unicode61 remove_diacritics 2`, heredado del Índice Universal. No se introduce una tokenización paralela.
+
+## Estructura privada
+
+El SQLite generado contiene:
+
+- `terms`: vocabulario normalizado, frecuencia de páginas y ocurrencias;
+- `objects`: mapa interno de objetos canónicos a identificadores enteros;
+- `pages`: dimensiones técnicas mínimas por fila del índice;
+- `token_positions`: `term_id`, fila de página y posición del token;
+- `term_pages`: relación única término-página;
+- `term_stats`: frecuencia global y dispersión por objetos/generaciones/grados/olas.
+
+El vocabulario y las posiciones son **privados**. No son un dataset público.
+
+## Un solo barrido FTS5
+
+`fts5vocab(..., 'instance')` se recorre una sola vez para materializar `token_positions`. Después se crean índices por `(page_rowid, token_offset)` y `(term_id, page_rowid)`. Los productos posteriores deben consultar esta materialización en vez de volver a tokenizar OCR o ejecutar barridos independientes de FTS5.
+
+Esto permite construir n-gramas y ventanas de coocurrencia conservando la misma secuencia de tokens que usa el buscador.
+
+## Corte canónico 0.1
+
+La materialización real sobre `LTMD_U1_UNIVERSAL_INDEX_0.1` produjo:
+
+- 86,549 páginas;
+- 492 objetos canónicos;
+- 239,259 términos FTS5 distintos;
+- 13,265,844 instancias de token;
+- 7,848,708 relaciones término-página;
+- 239,259 filas de estadística global.
+
+El SQLite privado pasó `quick_check = ok`.
+
+## Privacidad
+
+No deben publicarse por defecto:
+
+- vocabulario completo;
+- términos raros;
+- posiciones de tokens;
+- identificadores de página u objeto;
+- texto OCR o snippets;
+- URLs de fuente.
+
+La capa pública se limita a cardinalidades, hashes, políticas, agregados suficientemente dispersos y, en fases posteriores, rankings/coocurrencias que superen umbrales de publicación explícitos.
+
+## Frontera epistemológica
+
+Frecuencia de tokens OCR no equivale a significado histórico. Se mantienen:
+
+- `ocr_available != text_verified`;
+- `frequency != semantic meaning`;
+- `search_hit != historical_claim`;
+- `computational_candidate != semantic_ready`.
+
+El estado por defecto sigue siendo `exploratory_signal`.
+
+## Reentrada siguiente
+
+Sobre esta única materialización deben construirse, en orden:
+
+1. estadísticas por dimensión con denominadores exactos;
+2. bigramas/trigramas agregados con supresión de secuencias raras;
+3. coocurrencias por ventana con métricas de frecuencia y dispersión;
+4. contrato público de publicación/supresión;
+5. sólo después, consumo desde LTMD Analytics.

--- a/schemas/ltmd_u1_lexical_positions_public_summary.schema.json
+++ b/schemas/ltmd_u1_lexical_positions_public_summary.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_lexical_positions_public_summary.schema.json",
+  "title": "LTMD-U1 lexical positions public summary 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["materialization_version", "source_index", "counts", "private_artifact", "privacy", "scientific_state", "preservation"],
+  "properties": {
+    "materialization_version": {"const": "LTMD_U1_LEXICAL_POSITIONS_MATERIALIZATION_0.1"},
+    "source_index": {
+      "type": "object", "additionalProperties": false,
+      "required": ["version", "sha256", "tokenizer"],
+      "properties": {
+        "version": {"const": "LTMD_U1_UNIVERSAL_INDEX_0.1"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "tokenizer": {"const": "unicode61 remove_diacritics 2"}
+      }
+    },
+    "counts": {
+      "type": "object", "additionalProperties": false,
+      "required": ["unique_terms", "token_instances", "term_page_relations", "unique_pages", "unique_objects", "term_stats_rows"],
+      "properties": {
+        "unique_terms": {"type": "integer", "minimum": 1},
+        "token_instances": {"type": "integer", "minimum": 1},
+        "term_page_relations": {"type": "integer", "minimum": 1},
+        "unique_pages": {"type": "integer", "minimum": 1},
+        "unique_objects": {"type": "integer", "minimum": 1},
+        "term_stats_rows": {"type": "integer", "minimum": 1}
+      }
+    },
+    "private_artifact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sqlite_bytes", "sqlite_sha256", "gzip_bytes", "gzip_sha256", "quick_check", "publish"],
+      "properties": {
+        "sqlite_bytes": {"type": "integer", "minimum": 1},
+        "sqlite_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "gzip_bytes": {"type": "integer", "minimum": 1},
+        "gzip_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "quick_check": {"const": "ok"},
+        "publish": {"const": false}
+      }
+    },
+    "privacy": {
+      "type": "object", "additionalProperties": false,
+      "required": ["full_vocabulary_public", "token_positions_public", "rare_terms_public_by_default", "ocr_text_public"],
+      "properties": {
+        "full_vocabulary_public": {"const": false},
+        "token_positions_public": {"const": false},
+        "rare_terms_public_by_default": {"const": false},
+        "ocr_text_public": {"const": false}
+      }
+    },
+    "scientific_state": {
+      "type": "object", "additionalProperties": false,
+      "required": ["result_state", "text_verified", "semantic_ready", "frequency_is_semantic_claim"],
+      "properties": {
+        "result_state": {"const": "exploratory_signal"},
+        "text_verified": {"const": false},
+        "semantic_ready": {"const": false},
+        "frequency_is_semantic_claim": {"const": false}
+      }
+    },
+    "preservation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["receipt_preserved_privately", "large_artifact_drive_upload_succeeded", "reconstructible_from_canonical_index"],
+      "properties": {
+        "receipt_preserved_privately": {"const": true},
+        "large_artifact_drive_upload_succeeded": {"type": "boolean"},
+        "reconstructible_from_canonical_index": {"const": true}
+      }
+    }
+  }
+}

--- a/scripts/build_u1_lexical_positions.py
+++ b/scripts/build_u1_lexical_positions.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Materialize private lexical positions and aggregate unigram statistics from LTMD-U1 FTS5.
+
+Version: LTMD_U1_LEXICAL_POSITIONS_BUILDER_0.1
+
+The output SQLite is PRIVATE. It contains the normalized FTS5 vocabulary and token positions
+needed for dispersion, n-grams and co-occurrence analysis. Public output is limited to a
+text-free aggregate summary.
+
+Scientific boundaries:
+  ocr_available != text_verified
+  frequency != semantic meaning
+  computational_candidate != semantic_ready
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+BUILDER_VERSION = "LTMD_U1_LEXICAL_POSITIONS_BUILDER_0.1"
+ARTIFACT_VERSION = "LTMD_U1_LEXICAL_POSITIONS_0.1"
+INDEX_VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+EXPECTED_TOKENIZER = "unicode61 remove_diacritics 2"
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_index_meta(connection: sqlite3.Connection) -> dict:
+    tables = {
+        row[0]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")
+    }
+    missing = {"pages", "pages_fts", "index_meta"} - tables
+    if missing:
+        raise RuntimeError("not an LTMD-U1 Universal Index; missing: " + ", ".join(sorted(missing)))
+    meta = {}
+    for key, raw in connection.execute("SELECT key, value FROM index_meta"):
+        try:
+            meta[key] = json.loads(raw)
+        except json.JSONDecodeError:
+            meta[key] = raw
+    if meta.get("builder_version") != INDEX_VERSION:
+        raise RuntimeError(f"unsupported Universal Index version: {meta.get('builder_version')!r}")
+    fts_sql = connection.execute("SELECT sql FROM sqlite_master WHERE name='pages_fts'").fetchone()[0]
+    normalized = " ".join(fts_sql.split())
+    if "unicode61 remove_diacritics 2" not in normalized:
+        raise RuntimeError("Universal Index tokenizer differs from the canonical LTMD-U1 tokenizer")
+    return meta
+
+
+def verify_source(path: Path, expected_sha256: str | None) -> str | None:
+    if not path.is_file():
+        raise RuntimeError("Universal Index file is unavailable")
+    if expected_sha256 is None:
+        return None
+    expected = expected_sha256.strip().lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise RuntimeError("expected index SHA-256 is invalid")
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RuntimeError("Universal Index SHA-256 mismatch")
+    return actual
+
+
+def _remove_sqlite_family(path: Path) -> None:
+    for candidate in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if candidate.exists():
+            candidate.unlink()
+
+
+def build_private_artifact(index_path: Path, output_path: Path, *, overwrite: bool = False) -> dict:
+    index_path = index_path.expanduser().resolve()
+    output_path = output_path.expanduser().resolve()
+    if output_path.exists() and not overwrite:
+        raise RuntimeError("output already exists; pass --overwrite to replace it")
+    if overwrite:
+        _remove_sqlite_family(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    source = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True, timeout=60)
+    try:
+        source_meta = read_index_meta(source)
+        source.execute("ATTACH DATABASE ? AS lex", (str(output_path),))
+        source.executescript(
+            """
+            PRAGMA lex.journal_mode=WAL;
+            PRAGMA lex.synchronous=NORMAL;
+            PRAGMA lex.cache_size=-200000;
+            CREATE TABLE lex.meta(key TEXT PRIMARY KEY, value TEXT NOT NULL) WITHOUT ROWID;
+            CREATE TABLE lex.terms(
+                term_id INTEGER PRIMARY KEY,
+                term TEXT NOT NULL UNIQUE,
+                page_count INTEGER NOT NULL,
+                occurrence_count INTEGER NOT NULL
+            );
+            CREATE TABLE lex.objects(
+                object_id INTEGER PRIMARY KEY,
+                canonical_viewer_key TEXT NOT NULL UNIQUE
+            );
+            CREATE TABLE lex.pages(
+                page_rowid INTEGER PRIMARY KEY,
+                object_id INTEGER NOT NULL,
+                generation INTEGER,
+                grade_code INTEGER,
+                wave TEXT
+            );
+            CREATE TABLE lex.token_positions(
+                term_id INTEGER NOT NULL,
+                page_rowid INTEGER NOT NULL,
+                token_offset INTEGER NOT NULL
+            );
+            CREATE VIRTUAL TABLE temp.vocab_row USING fts5vocab(main, pages_fts, 'row');
+            CREATE VIRTUAL TABLE temp.vocab_instance USING fts5vocab(main, pages_fts, 'instance');
+            """
+        )
+        source.execute(
+            "INSERT INTO lex.terms(term,page_count,occurrence_count) "
+            "SELECT term,doc,cnt FROM vocab_row ORDER BY term"
+        )
+        source.execute(
+            "INSERT INTO lex.objects(canonical_viewer_key) "
+            "SELECT DISTINCT canonical_viewer_key FROM main.pages ORDER BY canonical_viewer_key"
+        )
+        source.execute(
+            """
+            INSERT INTO lex.pages(page_rowid,object_id,generation,grade_code,wave)
+            SELECT p.id,o.object_id,p.catalog_generation,p.grade_code,p.wave
+            FROM main.pages p
+            JOIN lex.objects o ON o.canonical_viewer_key=p.canonical_viewer_key
+            ORDER BY p.id
+            """
+        )
+        source.commit()
+
+        source.execute(
+            """
+            INSERT INTO lex.token_positions(term_id,page_rowid,token_offset)
+            SELECT t.term_id,v.doc,v.offset
+            FROM vocab_instance v
+            JOIN lex.terms t ON t.term=v.term
+            """
+        )
+        source.commit()
+
+        source.execute(
+            "CREATE INDEX lex.idx_token_positions_page_offset "
+            "ON token_positions(page_rowid,token_offset)"
+        )
+        source.commit()
+        source.execute(
+            "CREATE INDEX lex.idx_token_positions_term_page "
+            "ON token_positions(term_id,page_rowid)"
+        )
+        source.commit()
+
+        source.execute(
+            """
+            CREATE TABLE lex.term_pages(
+                term_id INTEGER NOT NULL,
+                page_rowid INTEGER NOT NULL,
+                PRIMARY KEY(term_id,page_rowid)
+            ) WITHOUT ROWID
+            """
+        )
+        source.execute(
+            "INSERT INTO lex.term_pages(term_id,page_rowid) "
+            "SELECT term_id,page_rowid FROM lex.token_positions GROUP BY term_id,page_rowid"
+        )
+        source.commit()
+
+        source.execute(
+            """
+            CREATE TABLE lex.term_stats(
+                term_id INTEGER PRIMARY KEY,
+                page_count INTEGER NOT NULL,
+                occurrence_count INTEGER NOT NULL,
+                object_count INTEGER NOT NULL,
+                generation_count INTEGER NOT NULL,
+                grade_count INTEGER NOT NULL,
+                wave_count INTEGER NOT NULL
+            )
+            """
+        )
+        source.execute(
+            """
+            INSERT INTO lex.term_stats
+            SELECT t.term_id,t.page_count,t.occurrence_count,
+                   COUNT(DISTINCT p.object_id),
+                   COUNT(DISTINCT p.generation),
+                   COUNT(DISTINCT p.grade_code),
+                   COUNT(DISTINCT p.wave)
+            FROM lex.terms t
+            JOIN lex.term_pages tp ON tp.term_id=t.term_id
+            JOIN lex.pages p ON p.page_rowid=tp.page_rowid
+            GROUP BY t.term_id
+            """
+        )
+        source.commit()
+
+        counts = {
+            "unique_terms": int(source.execute("SELECT COUNT(*) FROM lex.terms").fetchone()[0]),
+            "token_instances": int(source.execute("SELECT COUNT(*) FROM lex.token_positions").fetchone()[0]),
+            "term_page_relations": int(source.execute("SELECT COUNT(*) FROM lex.term_pages").fetchone()[0]),
+            "unique_pages": int(source.execute("SELECT COUNT(*) FROM lex.pages").fetchone()[0]),
+            "unique_objects": int(source.execute("SELECT COUNT(*) FROM lex.objects").fetchone()[0]),
+            "term_stats_rows": int(source.execute("SELECT COUNT(*) FROM lex.term_stats").fetchone()[0]),
+        }
+        expected_pages = int(source_meta.get("unique_pages", counts["unique_pages"]))
+        expected_objects = int(source_meta.get("unique_canonical_objects", counts["unique_objects"]))
+        if counts["unique_pages"] != expected_pages:
+            raise RuntimeError("lexical page count does not match Universal Index")
+        if counts["unique_objects"] != expected_objects:
+            raise RuntimeError("lexical object count does not match Universal Index")
+        if counts["term_stats_rows"] != counts["unique_terms"]:
+            raise RuntimeError("term_stats does not cover the full vocabulary")
+
+        metadata = {
+            "builder_version": BUILDER_VERSION,
+            "artifact_version": ARTIFACT_VERSION,
+            "source_index_version": INDEX_VERSION,
+            "tokenizer": EXPECTED_TOKENIZER,
+            **counts,
+            "private": True,
+            "full_vocabulary_private": True,
+            "token_positions_private": True,
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+        }
+        for key, value in metadata.items():
+            source.execute(
+                "INSERT INTO lex.meta(key,value) VALUES(?,?)",
+                (key, json.dumps(value, ensure_ascii=False)),
+            )
+        source.commit()
+        quick = source.execute("PRAGMA lex.quick_check").fetchone()[0]
+        if quick != "ok":
+            raise RuntimeError("lexical artifact quick_check failed")
+        source.execute("PRAGMA lex.wal_checkpoint(TRUNCATE)")
+        source.execute("PRAGMA lex.journal_mode=DELETE")
+        source.commit()
+    finally:
+        source.close()
+
+    return {
+        "builder_version": BUILDER_VERSION,
+        "artifact_version": ARTIFACT_VERSION,
+        "source_index_version": INDEX_VERSION,
+        "tokenizer": EXPECTED_TOKENIZER,
+        "counts": counts,
+        "private_artifact": {
+            "bytes": output_path.stat().st_size,
+            "sha256": sha256_file(output_path),
+            "publish": False,
+        },
+        "privacy": {
+            "full_vocabulary_emitted_publicly": False,
+            "token_positions_emitted_publicly": False,
+            "ocr_text_emitted_publicly": False,
+            "page_ids_emitted_publicly": False,
+            "source_urls_emitted_publicly": False,
+            "rare_terms_publish_by_default": False,
+        },
+        "scientific_state": {
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+            "frequency_is_semantic_claim": False,
+        },
+    }
+
+
+def run(index_path: Path, output_path: Path, *, expected_index_sha256: str | None = None, overwrite: bool = False) -> dict:
+    verified_source_sha = verify_source(index_path, expected_index_sha256)
+    summary = build_private_artifact(index_path, output_path, overwrite=overwrite)
+    summary["source_index_sha256"] = verified_source_sha
+    return summary
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--index", required=True, help="Private LTMD-U1 Universal Index SQLite")
+    parser.add_argument("--output", required=True, help="Private lexical-position SQLite output")
+    parser.add_argument("--summary", help="Optional public-safe aggregate JSON summary")
+    parser.add_argument("--expected-index-sha256")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    summary = run(
+        Path(args.index),
+        Path(args.output),
+        expected_index_sha256=args.expected_index_sha256,
+        overwrite=args.overwrite,
+    )
+    payload = json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.summary:
+        Path(args.summary).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_u1_lexical_positions.py
+++ b/tests/test_build_u1_lexical_positions.py
@@ -1,0 +1,91 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / 'scripts' / 'build_u1_lexical_positions.py'
+SPEC = importlib.util.spec_from_file_location('build_u1_lexical_positions', SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_index(path: Path):
+    c = sqlite3.connect(path)
+    c.executescript('''
+    CREATE TABLE pages(
+      id INTEGER PRIMARY KEY, page_id TEXT NOT NULL, canonical_viewer_key TEXT NOT NULL,
+      wave TEXT, catalog_generation INTEGER, grade_code INTEGER, search_text TEXT NOT NULL
+    );
+    CREATE TABLE index_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);
+    CREATE VIRTUAL TABLE pages_fts USING fts5(search_text,content='pages',content_rowid='id',tokenize='unicode61 remove_diacritics 2');
+    ''')
+    rows = [
+      (1,'p1','B1','W1',1993,5,'lengua rarámuri comunidad'),
+      (2,'p2','B1','W1',1993,5,'comunidad y familia'),
+      (3,'p3','B2','W3',2014,6,'Raramuri familia democracia'),
+    ]
+    c.executemany('insert into pages values(?,?,?,?,?,?,?)',rows)
+    c.execute("insert into pages_fts(pages_fts) values('rebuild')")
+    meta = {'builder_version':mod.INDEX_VERSION,'unique_pages':3,'unique_canonical_objects':2,'text_verified':False,'semantic_ready':False}
+    for k,v in meta.items():
+        c.execute('insert into index_meta values(?,?)',(k,json.dumps(v)))
+    c.commit()
+    c.close()
+
+
+def test_materialization_counts_and_normalization(tmp_path):
+    src=tmp_path/'index.sqlite'
+    out=tmp_path/'lex.sqlite'
+    make_index(src)
+    summary=mod.run(src,out)
+    assert summary['counts']['unique_pages']==3
+    assert summary['counts']['unique_objects']==2
+    assert summary['counts']['token_instances']==9
+    c=sqlite3.connect(out)
+    terms=dict(c.execute('select term,term_id from terms'))
+    assert 'raramuri' in terms
+    assert 'rarámuri' not in terms
+    tid=terms['raramuri']
+    assert c.execute('select occurrence_count,page_count from terms where term_id=?',(tid,)).fetchone()==(2,2)
+    assert c.execute('select object_count,generation_count from term_stats where term_id=?',(tid,)).fetchone()==(2,2)
+    assert c.execute('pragma quick_check').fetchone()[0]=='ok'
+    c.close()
+
+
+def test_positions_preserve_page_order_for_downstream_ngrams(tmp_path):
+    src=tmp_path/'index.sqlite'
+    out=tmp_path/'lex.sqlite'
+    make_index(src)
+    mod.run(src,out)
+    c=sqlite3.connect(out)
+    page1=c.execute('''select t.term,x.token_offset from token_positions x join terms t using(term_id) where page_rowid=1 order by token_offset''').fetchall()
+    assert page1==[('lengua',0),('raramuri',1),('comunidad',2)]
+    c.close()
+
+
+def test_public_summary_does_not_emit_term_values(tmp_path):
+    src=tmp_path/'index.sqlite'
+    out=tmp_path/'lex.sqlite'
+    make_index(src)
+    summary=mod.run(src,out)
+    rendered=json.dumps(summary,ensure_ascii=False)
+    for forbidden in ('raramuri','comunidad','B1','p1'):
+        assert forbidden not in rendered
+    assert summary['privacy']['rare_terms_publish_by_default'] is False
+    assert summary['scientific_state']['semantic_ready'] is False
+
+
+def test_sha_gate(tmp_path):
+    src=tmp_path/'index.sqlite'
+    out=tmp_path/'lex.sqlite'
+    make_index(src)
+    actual=mod.sha256_file(src)
+    assert mod.run(src,out,expected_index_sha256=actual)['source_index_sha256']==actual
+    out2=tmp_path/'lex2.sqlite'
+    try:
+        mod.run(src,out2,expected_index_sha256='0'*64)
+    except RuntimeError as exc:
+        assert str(exc)=='Universal Index SHA-256 mismatch'
+    else:
+        raise AssertionError('expected SHA mismatch')


### PR DESCRIPTION
## Summary

Adds the single-pass private lexical-position layer for LTMD-U1. It reuses the exact FTS5 tokenizer from the canonical Universal Index and materializes one reusable token-position store instead of repeatedly scanning/tokenizing OCR.

### Canonical real-corpus materialization
- 86,549 pages
- 492 canonical objects
- 239,259 normalized FTS5 terms
- 13,265,844 token instances
- 7,848,708 unique term-page relations
- 239,259 global term-stat rows
- private SQLite `quick_check = ok`

Private artifact: 763,662,336 bytes, SHA-256 `59340c6f91fb7a2e9763ba84c1c6b9accfcd9f9f369a9a7b9ce2a9eeca9d7e8e`. Compressed: 317,808,648 bytes, SHA-256 `1c8248c040ce4a2fe0464f5d6b98b50f5c8d51c581fa65eb90094756b53bcb1b`.

### Architecture
The private SQLite contains normalized term IDs, page/object dimensions, token positions, unique term-page relations and global dispersion statistics. Downstream dimensional statistics, n-grams and co-occurrences will query this materialization and will not re-tokenize or rescan FTS5.

### Privacy/scientific boundary
The full vocabulary, rare terms, token positions, page/object identifiers and OCR remain private. GitHub receives only code, tests, documentation, hashes/cardinalities and a strict public-summary schema. Frequency remains an `exploratory_signal`; `text_verified=false`; `semantic_ready=false`.

### Preservation note
The small cryptographic receipt is preserved in the private Analytics vault. The available Drive upload path rejected the 317.8 MB compressed artifact, so this PR records `large_artifact_drive_upload_succeeded=false` rather than claiming preservation. The artifact remains reconstructible from the canonical Universal Index.

### Tests
Adds synthetic tests for tokenizer normalization, positional order needed by n-grams, public-summary privacy and source-index SHA verification. Extends the LTMD Analytics workflow/schema gate.

## Next
Keep the general lexicon/co-occurrence task open and build: exact dimensional statistics -> suppressed bigrams/trigrams -> windowed co-occurrences -> public publication/suppression contract. Staging remains downstream.