### PR TITLE
Analytics: add LTMD-U1 lexical dimensions 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -13,11 +13,13 @@ on:
       - 'scripts/query_u1_universal_index.py'
       - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'scripts/build_u1_lexical_positions.py'
+      - 'scripts/build_u1_lexical_dimensions.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
+      - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -25,6 +27,7 @@ on:
       - 'tests/test_query_u1_universal_index.py'
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - 'tests/test_build_u1_lexical_positions.py'
+      - 'tests/test_build_u1_lexical_dimensions.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -38,11 +41,13 @@ on:
       - 'scripts/query_u1_universal_index.py'
       - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'scripts/build_u1_lexical_positions.py'
+      - 'scripts/build_u1_lexical_dimensions.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
+      - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -50,6 +55,7 @@ on:
       - 'tests/test_query_u1_universal_index.py'
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - 'tests/test_build_u1_lexical_positions.py'
+      - 'tests/test_build_u1_lexical_dimensions.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -75,6 +81,7 @@ jobs:
           tests/test_query_u1_universal_index.py
           tests/test_build_u1_corpus_analytics_manifest.py
           tests/test_build_u1_lexical_positions.py
+          tests/test_build_u1_lexical_dimensions.py
       - name: Validate Analytics JSON schemas
         run: |
           python - <<'PY'
@@ -86,6 +93,7 @@ jobs:
               'schemas/ltmd_u1_corpus_query_response.schema.json',
               'schemas/ltmd_u1_corpus_analytics_manifest.schema.json',
               'schemas/ltmd_u1_lexical_positions_public_summary.schema.json',
+              'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))

--- a/data/analytics/ltmd_u1_lexical_dimensions_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_lexical_dimensions_materialization_0_1.json
@@ -1,0 +1,38 @@
+{
+  "materialization_version": "LTMD_U1_LEXICAL_DIMENSIONS_MATERIALIZATION_0.1",
+  "source": {
+    "version": "LTMD_U1_LEXICAL_POSITIONS_0.1",
+    "sha256": "59340c6f91fb7a2e9763ba84c1c6b9accfcd9f9f369a9a7b9ce2a9eeca9d7e8e"
+  },
+  "counts": {
+    "term_page_stats_rows": 7848708,
+    "term_dimension_stats_rows": 1517473,
+    "generation_term_rows": 598484,
+    "grade_term_rows": 437827,
+    "wave_term_rows": 481162,
+    "dimension_denominator_rows": 28
+  },
+  "private_artifact": {
+    "sqlite_bytes": 158904320,
+    "sqlite_sha256": "018d2bf6520fc8e1cda5aa34c0dfedb39ae9320a07d95e0fe193c17423eeb99b",
+    "gzip_bytes": 50842335,
+    "gzip_sha256": "475941720453781b0ff44c1689a32cc60a976aa95184caf1abd400dfe28e27c8",
+    "quick_check": "ok",
+    "publish": false
+  },
+  "privacy": {
+    "term_values_public": false,
+    "page_identifiers_public": false,
+    "full_term_dimension_matrix_public": false
+  },
+  "scientific_state": {
+    "result_state": "exploratory_signal",
+    "text_verified": false,
+    "semantic_ready": false,
+    "wave_is_operational_not_curricular_ontology": true
+  },
+  "preservation": {
+    "large_artifact_drive_upload_succeeded": false,
+    "reconstructible_from_lexical_positions": true
+  }
+}

--- a/docs/LTMD_U1_LEXICAL_DIMENSIONS_0_1.md
+++ b/docs/LTMD_U1_LEXICAL_DIMENSIONS_0_1.md
@@ -1,0 +1,72 @@
+# LTMD-U1 — dimensiones léxicas 0.1
+
+Versión de artefacto privado: **LTMD_U1_LEXICAL_DIMENSIONS_0.1**  
+Constructor público: **LTMD_U1_LEXICAL_DIMENSIONS_BUILDER_0.1**
+
+## Propósito
+
+Esta capa deriva estadísticas léxicas por generación, grado y ola a partir de `LTMD_U1_LEXICAL_POSITIONS_0.1`. No vuelve a leer OCR, no vuelve a consultar FTS5 y no introduce otra tokenización.
+
+La separación en un SQLite privado propio mantiene inmutable el artefacto de posiciones léxicas y permite versionar de forma independiente los derivados dimensionales.
+
+## Contrato
+
+El artefacto contiene:
+
+- `term_page_stats`: frecuencia de cada término por página;
+- `term_dimension_stats`: frecuencia, páginas y objetos para cada término dentro de cada valor de generación, grado u ola;
+- `dimension_denominators`: páginas y objetos del mismo universo para cada valor dimensional;
+- `meta`: versión, cardinalidades y estado científico.
+
+Las tasas posteriores deben usar el numerador y el denominador del mismo valor dimensional. No se admiten denominadores globales para filtros parciales.
+
+## Corte canónico 0.1
+
+Materializado desde `LTMD_U1_LEXICAL_POSITIONS_0.1`:
+
+- 7,848,708 filas término–página;
+- 1,517,473 filas término–dimensión;
+  - 598,484 por generación;
+  - 437,827 por grado;
+  - 481,162 por ola;
+- 28 denominadores dimensionales:
+  - 11 generaciones;
+  - 6 grados;
+  - 11 olas.
+
+Los denominadores reproducen exactamente el universo de 86,549 páginas del Corpus Analytics Manifest 0.1.
+
+El SQLite privado pesa 158,904,320 bytes y tiene SHA-256 `018d2bf6520fc8e1cda5aa34c0dfedb39ae9320a07d95e0fe193c17423eeb99b`. La copia gzip local pesa 50,842,335 bytes y tiene SHA-256 `475941720453781b0ff44c1689a32cc60a976aa95184caf1abd400dfe28e27c8`. El artefacto pasó `quick_check = ok`.
+
+## Privacidad
+
+El artefacto es privado. GitHub no publica:
+
+- términos ni vocabulario;
+- identificadores de página u objeto;
+- matrices término×dimensión completas;
+- OCR o snippets;
+- rutas privadas.
+
+La superficie pública sólo fija constructor, tests, contrato, cardinalidades y hashes.
+
+## Estado científico
+
+Toda frecuencia sigue siendo una señal computacional:
+
+- `text_verified = false`;
+- `semantic_ready = false`;
+- `result_state = exploratory_signal`.
+
+La ola (`wave`) continúa siendo una taxonomía operacional, no una ontología curricular.
+
+## Reentrada
+
+Con los denominadores dimensionales ya cerrados, el siguiente bloque es:
+
+1. bigramas y trigramas derivados de `token_positions` con límites de página;
+2. supresión de secuencias raras antes de cualquier publicación;
+3. coocurrencias por ventana con frecuencia y dispersión por páginas/objetos;
+4. contrato público de publicación/supresión.
+
+No se vuelve a tokenizar OCR ni a barrer FTS5.

--- a/schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json
+++ b/schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json",
+  "title": "LTMD-U1 lexical dimensions public summary 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["materialization_version", "source", "counts", "private_artifact", "privacy", "scientific_state", "preservation"],
+  "properties": {
+    "materialization_version": {"const": "LTMD_U1_LEXICAL_DIMENSIONS_MATERIALIZATION_0.1"},
+    "source": {
+      "type": "object", "additionalProperties": false,
+      "required": ["version", "sha256"],
+      "properties": {
+        "version": {"const": "LTMD_U1_LEXICAL_POSITIONS_0.1"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"}
+      }
+    },
+    "counts": {
+      "type": "object", "additionalProperties": false,
+      "required": ["term_page_stats_rows", "term_dimension_stats_rows", "generation_term_rows", "grade_term_rows", "wave_term_rows", "dimension_denominator_rows"],
+      "properties": {
+        "term_page_stats_rows": {"type": "integer", "minimum": 1},
+        "term_dimension_stats_rows": {"type": "integer", "minimum": 1},
+        "generation_term_rows": {"type": "integer", "minimum": 1},
+        "grade_term_rows": {"type": "integer", "minimum": 1},
+        "wave_term_rows": {"type": "integer", "minimum": 1},
+        "dimension_denominator_rows": {"type": "integer", "minimum": 1}
+      }
+    },
+    "private_artifact": {
+      "type": "object", "additionalProperties": false,
+      "required": ["sqlite_bytes", "sqlite_sha256", "gzip_bytes", "gzip_sha256", "quick_check", "publish"],
+      "properties": {
+        "sqlite_bytes": {"type": "integer", "minimum": 1},
+        "sqlite_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "gzip_bytes": {"type": "integer", "minimum": 1},
+        "gzip_sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "quick_check": {"const": "ok"},
+        "publish": {"const": false}
+      }
+    },
+    "privacy": {
+      "type": "object", "additionalProperties": false,
+      "required": ["term_values_public", "page_identifiers_public", "full_term_dimension_matrix_public"],
+      "properties": {
+        "term_values_public": {"const": false},
+        "page_identifiers_public": {"const": false},
+        "full_term_dimension_matrix_public": {"const": false}
+      }
+    },
+    "scientific_state": {
+      "type": "object", "additionalProperties": false,
+      "required": ["result_state", "text_verified", "semantic_ready", "wave_is_operational_not_curricular_ontology"],
+      "properties": {
+        "result_state": {"const": "exploratory_signal"},
+        "text_verified": {"const": false},
+        "semantic_ready": {"const": false},
+        "wave_is_operational_not_curricular_ontology": {"const": true}
+      }
+    },
+    "preservation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["large_artifact_drive_upload_succeeded", "reconstructible_from_lexical_positions"],
+      "properties": {
+        "large_artifact_drive_upload_succeeded": {"const": false},
+        "reconstructible_from_lexical_positions": {"const": true}
+      }
+    }
+  }
+}

--- a/scripts/build_u1_lexical_dimensions.py
+++ b/scripts/build_u1_lexical_dimensions.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Build private dimensional lexical statistics from LTMD-U1 lexical positions.
+
+Version: LTMD_U1_LEXICAL_DIMENSIONS_BUILDER_0.1
+
+This stage never reads OCR/FTS5. It consumes the private lexical-position artifact and emits
+only aggregate term-by-dimension statistics plus exact denominators. The output remains private.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+BUILDER_VERSION = "LTMD_U1_LEXICAL_DIMENSIONS_BUILDER_0.1"
+ARTIFACT_VERSION = "LTMD_U1_LEXICAL_DIMENSIONS_0.1"
+SOURCE_VERSION = "LTMD_U1_LEXICAL_POSITIONS_0.1"
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+DIMENSIONS = (("generation", "generation"), ("grade_code", "grade_code"), ("wave", "wave"))
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def load_meta(c: sqlite3.Connection) -> dict:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    required = {"meta", "pages", "terms", "token_positions", "term_pages", "term_stats"}
+    missing = required - tables
+    if missing:
+        raise RuntimeError("not an LTMD lexical-position artifact; missing: " + ", ".join(sorted(missing)))
+    meta = {}
+    for k, raw in c.execute("SELECT key,value FROM meta"):
+        try:
+            meta[k] = json.loads(raw)
+        except json.JSONDecodeError:
+            meta[k] = raw
+    if meta.get("version") != SOURCE_VERSION and meta.get("artifact_version") != SOURCE_VERSION:
+        raise RuntimeError("unsupported lexical-position artifact version")
+    return meta
+
+
+def verify_source(path: Path, expected_sha256: str | None) -> str | None:
+    if not path.is_file():
+        raise RuntimeError("lexical-position artifact is unavailable")
+    if expected_sha256 is None:
+        return None
+    expected = expected_sha256.strip().lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise RuntimeError("expected lexical-position SHA-256 is invalid")
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RuntimeError("lexical-position SHA-256 mismatch")
+    return actual
+
+
+def remove_sqlite_family(path: Path) -> None:
+    for p in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if p.exists():
+            p.unlink()
+
+
+def build(source_path: Path, output_path: Path, *, overwrite: bool = False) -> dict:
+    source_path = source_path.expanduser().resolve()
+    output_path = output_path.expanduser().resolve()
+    if output_path.exists() and not overwrite:
+        raise RuntimeError("output already exists; pass --overwrite to replace it")
+    if overwrite:
+        remove_sqlite_family(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    c = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True, timeout=60)
+    try:
+        meta = load_meta(c)
+        c.execute("ATTACH DATABASE ? AS d", (str(output_path),))
+        c.executescript(
+            """
+            PRAGMA d.journal_mode=WAL;
+            PRAGMA d.synchronous=NORMAL;
+            PRAGMA d.cache_size=-200000;
+            CREATE TABLE d.meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
+            CREATE TABLE d.term_page_stats(
+                term_id INTEGER NOT NULL,
+                page_rowid INTEGER NOT NULL,
+                occurrence_count INTEGER NOT NULL,
+                PRIMARY KEY(term_id,page_rowid)
+            ) WITHOUT ROWID;
+            CREATE TABLE d.term_dimension_stats(
+                dimension TEXT NOT NULL,
+                value TEXT NOT NULL,
+                term_id INTEGER NOT NULL,
+                occurrence_count INTEGER NOT NULL,
+                page_count INTEGER NOT NULL,
+                object_count INTEGER NOT NULL,
+                PRIMARY KEY(dimension,value,term_id)
+            ) WITHOUT ROWID;
+            CREATE TABLE d.dimension_denominators(
+                dimension TEXT NOT NULL,
+                value TEXT NOT NULL,
+                page_count INTEGER NOT NULL,
+                object_count INTEGER NOT NULL,
+                PRIMARY KEY(dimension,value)
+            ) WITHOUT ROWID;
+            """
+        )
+        c.execute(
+            "INSERT INTO d.term_page_stats "
+            "SELECT term_id,page_rowid,COUNT(*) FROM main.token_positions GROUP BY term_id,page_rowid"
+        )
+        c.commit()
+
+        for public_name, column in DIMENSIONS:
+            c.execute(
+                f"""
+                INSERT INTO d.term_dimension_stats
+                SELECT ?,CAST(p.{column} AS TEXT),s.term_id,
+                       SUM(s.occurrence_count),COUNT(*),COUNT(DISTINCT p.object_id)
+                FROM d.term_page_stats s
+                JOIN main.pages p ON p.page_rowid=s.page_rowid
+                WHERE p.{column} IS NOT NULL
+                GROUP BY p.{column},s.term_id
+                """,
+                (public_name,),
+            )
+            c.execute(
+                f"""
+                INSERT INTO d.dimension_denominators
+                SELECT ?,CAST({column} AS TEXT),COUNT(*),COUNT(DISTINCT object_id)
+                FROM main.pages
+                WHERE {column} IS NOT NULL
+                GROUP BY {column}
+                """,
+                (public_name,),
+            )
+            c.commit()
+
+        counts = {
+            "term_page_stats_rows": int(c.execute("SELECT COUNT(*) FROM d.term_page_stats").fetchone()[0]),
+            "term_dimension_stats_rows": int(c.execute("SELECT COUNT(*) FROM d.term_dimension_stats").fetchone()[0]),
+            "generation_term_rows": int(c.execute("SELECT COUNT(*) FROM d.term_dimension_stats WHERE dimension='generation'").fetchone()[0]),
+            "grade_term_rows": int(c.execute("SELECT COUNT(*) FROM d.term_dimension_stats WHERE dimension='grade_code'").fetchone()[0]),
+            "wave_term_rows": int(c.execute("SELECT COUNT(*) FROM d.term_dimension_stats WHERE dimension='wave'").fetchone()[0]),
+            "dimension_denominator_rows": int(c.execute("SELECT COUNT(*) FROM d.dimension_denominators").fetchone()[0]),
+        }
+        expected_term_pages = int(meta.get("term_page_relations", counts["term_page_stats_rows"]))
+        if counts["term_page_stats_rows"] != expected_term_pages:
+            raise RuntimeError("term-page relation count differs from lexical-position artifact")
+        unique_pages = int(meta.get("unique_pages", c.execute("SELECT COUNT(*) FROM main.pages").fetchone()[0]))
+        for dimension, _ in DIMENSIONS:
+            total = c.execute(
+                "SELECT SUM(page_count) FROM d.dimension_denominators WHERE dimension=?", (dimension,)
+            ).fetchone()[0]
+            if int(total or 0) != unique_pages:
+                raise RuntimeError(f"{dimension} denominators do not cover all lexical pages")
+
+        metadata = {
+            "builder_version": BUILDER_VERSION,
+            "artifact_version": ARTIFACT_VERSION,
+            "source_version": SOURCE_VERSION,
+            **counts,
+            "private": True,
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+        }
+        for k, v in metadata.items():
+            c.execute("INSERT INTO d.meta VALUES(?,?)", (k, json.dumps(v, ensure_ascii=False)))
+        c.commit()
+        if c.execute("PRAGMA d.quick_check").fetchone()[0] != "ok":
+            raise RuntimeError("lexical-dimension artifact quick_check failed")
+        c.execute("PRAGMA d.wal_checkpoint(TRUNCATE)")
+        c.execute("PRAGMA d.journal_mode=DELETE")
+        c.commit()
+    finally:
+        c.close()
+
+    return {
+        "builder_version": BUILDER_VERSION,
+        "artifact_version": ARTIFACT_VERSION,
+        "source_version": SOURCE_VERSION,
+        "counts": counts,
+        "private_artifact": {
+            "bytes": output_path.stat().st_size,
+            "sha256": sha256_file(output_path),
+            "publish": False,
+        },
+        "privacy": {
+            "term_values_emitted_publicly": False,
+            "page_identifiers_emitted_publicly": False,
+            "dimension_aggregates_only": True,
+        },
+        "scientific_state": {
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+        },
+    }
+
+
+def run(source_path: Path, output_path: Path, *, expected_source_sha256: str | None = None, overwrite: bool = False) -> dict:
+    verified = verify_source(source_path, expected_source_sha256)
+    summary = build(source_path, output_path, overwrite=overwrite)
+    summary["source_sha256"] = verified
+    return summary
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", required=True)
+    p.add_argument("--output", required=True)
+    p.add_argument("--summary")
+    p.add_argument("--expected-source-sha256")
+    p.add_argument("--overwrite", action="store_true")
+    a = p.parse_args(argv)
+    result = run(Path(a.source), Path(a.output), expected_source_sha256=a.expected_source_sha256, overwrite=a.overwrite)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if a.summary:
+        Path(a.summary).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_u1_lexical_dimensions.py
+++ b/tests/test_build_u1_lexical_dimensions.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / 'scripts' / 'build_u1_lexical_dimensions.py'
+SPEC = importlib.util.spec_from_file_location('build_u1_lexical_dimensions', SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_source(path: Path):
+    c = sqlite3.connect(path)
+    c.executescript('''
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL);
+    CREATE TABLE terms(term_id INTEGER PRIMARY KEY,term TEXT,page_count INTEGER,occurrence_count INTEGER);
+    CREATE TABLE objects(object_id INTEGER PRIMARY KEY,canonical_viewer_key TEXT);
+    CREATE TABLE pages(page_rowid INTEGER PRIMARY KEY,object_id INTEGER,generation INTEGER,grade_code INTEGER,wave TEXT);
+    CREATE TABLE token_positions(term_id INTEGER,page_rowid INTEGER,token_offset INTEGER);
+    CREATE TABLE term_pages(term_id INTEGER,page_rowid INTEGER,PRIMARY KEY(term_id,page_rowid));
+    CREATE TABLE term_stats(term_id INTEGER PRIMARY KEY,page_count INTEGER,occurrence_count INTEGER,object_count INTEGER,generation_count INTEGER,grade_count INTEGER,wave_count INTEGER);
+    ''')
+    for k, v in {'version': mod.SOURCE_VERSION, 'term_page_relations': 4, 'unique_pages': 3}.items():
+        c.execute('insert into meta values(?,?)', (k, json.dumps(v)))
+    c.executemany('insert into terms values(?,?,?,?)', [(1,'a',2,3),(2,'b',2,2)])
+    c.executemany('insert into objects values(?,?)', [(1,'B1'),(2,'B2')])
+    c.executemany('insert into pages values(?,?,?,?,?)', [(1,1,1993,5,'W1'),(2,1,1993,5,'W1'),(3,2,2014,6,'W3')])
+    c.executemany('insert into token_positions values(?,?,?)', [(1,1,0),(1,1,1),(2,1,2),(1,3,0),(2,3,1)])
+    c.executemany('insert into term_pages values(?,?)', [(1,1),(1,3),(2,1),(2,3)])
+    c.executemany('insert into term_stats values(?,?,?,?,?,?,?)', [(1,2,3,2,2,2,2),(2,2,2,2,2,2,2)])
+    c.commit()
+    c.close()
+
+
+def test_dimension_counts_and_denominators(tmp_path):
+    src = tmp_path / 'source.sqlite'
+    out = tmp_path / 'dims.sqlite'
+    make_source(src)
+    summary = mod.run(src, out)
+    assert summary['counts']['term_page_stats_rows'] == 4
+    c = sqlite3.connect(out)
+    assert c.execute("select page_count,object_count from dimension_denominators where dimension='generation' and value='1993'").fetchone() == (2,1)
+    assert c.execute("select occurrence_count,page_count,object_count from term_dimension_stats where dimension='generation' and value='1993' and term_id=1").fetchone() == (2,1,1)
+    assert c.execute('pragma quick_check').fetchone()[0] == 'ok'
+    c.close()
+
+
+def test_summary_has_no_term_values_or_page_ids(tmp_path):
+    src = tmp_path / 'source.sqlite'
+    out = tmp_path / 'dims.sqlite'
+    make_source(src)
+    rendered = json.dumps(mod.run(src, out))
+    assert 'B1' not in rendered
+    assert '1993' not in rendered
+    assert mod.SOURCE_VERSION in rendered
+
+
+def test_sha_gate(tmp_path):
+    src = tmp_path / 'source.sqlite'
+    out = tmp_path / 'dims.sqlite'
+    make_source(src)
+    sha = mod.sha256_file(src)
+    assert mod.run(src, out, expected_source_sha256=sha)['source_sha256'] == sha
+    try:
+        mod.run(src, tmp_path / 'bad.sqlite', expected_source_sha256='0' * 64)
+    except RuntimeError as exc:
+        assert str(exc) == 'lexical-position SHA-256 mismatch'
+    else:
+        raise AssertionError('expected mismatch')


### PR DESCRIPTION
## Summary

Adds the second private lexical layer for LTMD-U1: exact term-by-dimension statistics derived from `LTMD_U1_LEXICAL_POSITIONS_0.1`, without reading OCR or rescanning FTS5.

### Canonical real-corpus materialization
- 7,848,708 term-page rows
- 1,517,473 term-dimension rows
  - 598,484 generation rows
  - 437,827 grade rows
  - 481,162 wave rows
- 28 exact dimension denominators = 11 generations + 6 grades + 11 operational waves
- all three denominator families sum to the same 86,549-page corpus
- private SQLite `quick_check = ok`

Private artifact: 158,904,320 bytes, SHA-256 `018d2bf6520fc8e1cda5aa34c0dfedb39ae9320a07d95e0fe193c17423eeb99b`. Gzip: 50,842,335 bytes, SHA-256 `475941720453781b0ff44c1689a32cc60a976aa95184caf1abd400dfe28e27c8`.

### Architecture
The builder validates the lexical-position artifact/version and optional SHA-256, materializes term-page occurrence counts once, then derives generation/grade/wave statistics and exact same-universe denominators. It does not modify the lexical-position artifact.

### Privacy/scientific boundary
GitHub receives no term values, page identifiers or full term×dimension matrices. `text_verified=false`, `semantic_ready=false`, and results remain `exploratory_signal`. `wave` remains operational rather than a curricular ontology.

### Preservation note
The available large-file Drive path did not preserve the 50.8 MB gzip during this session, so the public record explicitly states `large_artifact_drive_upload_succeeded=false`. The layer remains deterministically reconstructible from the canonical lexical-position artifact.

### Tests/CI
Adds tests for exact dimensional aggregates/denominators, public-summary privacy and source SHA verification; extends the Analytics workflow and schema validation.

## Next
Build page-bounded bigrams/trigrams from `token_positions`, apply rare-sequence suppression, then build windowed co-occurrences with frequency and dispersion. Do not re-tokenize OCR or rescan FTS5. Staging remains downstream.