### PR TITLE
Analytics: add LTMD-U1 n-grams and co-occurrences 0.1

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -7,6 +7,7 @@ on:
       - 'analytics_api/**'
       - 'passenger_wsgi.py'
       - 'requirements-analytics.txt'
+      - 'requirements-analytics-build.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
@@ -14,12 +15,18 @@ on:
       - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'scripts/build_u1_lexical_positions.py'
       - 'scripts/build_u1_lexical_dimensions.py'
+      - 'scripts/build_u1_ngrams.py'
+      - 'scripts/build_u1_cooccurrences.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
       - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
+      - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
+      - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
+      - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -28,6 +35,8 @@ on:
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - 'tests/test_build_u1_lexical_positions.py'
       - 'tests/test_build_u1_lexical_dimensions.py'
+      - 'tests/test_build_u1_ngrams.py'
+      - 'tests/test_build_u1_cooccurrences.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -35,6 +44,7 @@ on:
       - 'analytics_api/**'
       - 'passenger_wsgi.py'
       - 'requirements-analytics.txt'
+      - 'requirements-analytics-build.txt'
       - 'scripts/build_indigenous_analytics_mart.py'
       - 'scripts/query_indigenous_analytics.py'
       - 'scripts/build_u1_universal_index.py'
@@ -42,12 +52,18 @@ on:
       - 'scripts/build_u1_corpus_analytics_manifest.py'
       - 'scripts/build_u1_lexical_positions.py'
       - 'scripts/build_u1_lexical_dimensions.py'
+      - 'scripts/build_u1_ngrams.py'
+      - 'scripts/build_u1_cooccurrences.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
       - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
       - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
       - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
+      - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
+      - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
+      - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -56,6 +72,8 @@ on:
       - 'tests/test_build_u1_corpus_analytics_manifest.py'
       - 'tests/test_build_u1_lexical_positions.py'
       - 'tests/test_build_u1_lexical_dimensions.py'
+      - 'tests/test_build_u1_ngrams.py'
+      - 'tests/test_build_u1_cooccurrences.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -70,7 +88,7 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install Analytics and test dependencies
-        run: python -m pip install --disable-pip-version-check -r requirements-analytics.txt pytest jsonschema
+        run: python -m pip install --disable-pip-version-check -r requirements-analytics.txt -r requirements-analytics-build.txt pytest jsonschema
       - name: Run Analytics unit and HTTP tests
         run: >-
           python -m pytest -q
@@ -82,7 +100,9 @@ jobs:
           tests/test_build_u1_corpus_analytics_manifest.py
           tests/test_build_u1_lexical_positions.py
           tests/test_build_u1_lexical_dimensions.py
-      - name: Validate Analytics JSON schemas
+          tests/test_build_u1_ngrams.py
+          tests/test_build_u1_cooccurrences.py
+      - name: Validate Analytics JSON schemas and materialization records
         run: |
           python - <<'PY'
           import json
@@ -94,9 +114,23 @@ jobs:
               'schemas/ltmd_u1_corpus_analytics_manifest.schema.json',
               'schemas/ltmd_u1_lexical_positions_public_summary.schema.json',
               'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json',
+              'schemas/ltmd_u1_ngrams_public_summary.schema.json',
+              'schemas/ltmd_u1_cooccurrences_public_summary.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))
               Draft202012Validator.check_schema(schema)
               print(f'{path}: OK')
+
+          validations = [
+              ('schemas/ltmd_u1_ngrams_public_summary.schema.json',
+               'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'),
+              ('schemas/ltmd_u1_cooccurrences_public_summary.schema.json',
+               'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'),
+          ]
+          for schema_path, data_path in validations:
+              schema = json.load(open(schema_path, encoding='utf-8'))
+              data = json.load(open(data_path, encoding='utf-8'))
+              Draft202012Validator(schema).validate(data)
+              print(f'{data_path}: VALID')
           PY

--- a/data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json
@@ -1,0 +1,55 @@
+{
+  "artifact_version": "LTMD_U1_COOCCURRENCES_0.1",
+  "builder_version": "LTMD_U1_COOCCURRENCES_BUILDER_0.1",
+  "counts": {
+    "cooccurrence_rows": 2540432,
+    "public_eligible_rows": 81451,
+    "raw_pair_occurrences": 64208256,
+    "unique_pair_page_relations": 52653670,
+    "unique_pairs_before_private_floor": 10426262
+  },
+  "method": {
+    "bucket_count": 64,
+    "private_retention": {
+      "min_occurrences": 3,
+      "min_pages": 2
+    },
+    "public_suppression": {
+      "each_term_min_objects": 10,
+      "each_term_min_pages": 20,
+      "min_objects": 10,
+      "min_occurrences": 75,
+      "min_pages": 25
+    },
+    "same_page_only": true,
+    "thresholds_preregistered_before_result_inspection": true,
+    "unordered_distinct_terms": true,
+    "window_max_tokens": 5
+  },
+  "privacy": {
+    "ocr_text_emitted_publicly": false,
+    "page_identifiers_emitted_publicly": false,
+    "pair_values_emitted_publicly": false,
+    "rare_pairs_emitted_publicly": false,
+    "term_values_emitted_publicly": false
+  },
+  "private_artifact": {
+    "bytes": 109342720,
+    "gzip_bytes": 37079913,
+    "gzip_sha256": "1694bbec7645821ceaccd9a135e4a1718944c8ab190d6b901930dcf536de488a",
+    "preserved_private": true,
+    "redownload_verified": true,
+    "sha256": "ec6a6126ac425d2fffdcd92732c6abe62ab4f0bd8c360bc32da072674a5eccde"
+  },
+  "scientific_state": {
+    "cooccurrence_is_semantic_relation": false,
+    "default_result_state": "exploratory_signal",
+    "semantic_ready": false,
+    "text_verified": false
+  },
+  "source": {
+    "lexical_reconstruction_sha256": "c57b30bf69acc0f38e406e45d23f37e5de59a4ec90f0fa9294de4c067512fd02",
+    "lexical_version": "LTMD_U1_LEXICAL_POSITIONS_0.1",
+    "universal_index_sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2"
+  }
+}

--- a/data/analytics/ltmd_u1_ngrams_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_ngrams_materialization_0_1.json
@@ -1,0 +1,58 @@
+{
+  "artifact_version": "LTMD_U1_NGRAMS_0.1",
+  "builder_version": "LTMD_U1_NGRAMS_BUILDER_0.1",
+  "counts": {
+    "bigram_public_eligible_rows": 28886,
+    "bigram_rows": 1008422,
+    "raw_bigram_instances": 13184868,
+    "raw_trigram_instances": 13104392,
+    "trigram_public_eligible_rows": 8096,
+    "trigram_rows": 908179,
+    "unique_bigrams_before_private_floor": 2455883,
+    "unique_trigrams_before_private_floor": 5796137
+  },
+  "method": {
+    "page_bounded": true,
+    "private_retention": {
+      "bigram_min_occurrences": 2,
+      "bigram_min_pages": 2,
+      "trigram_min_occurrences": 3,
+      "trigram_min_pages": 2
+    },
+    "public_suppression": {
+      "bigram_min_objects": 10,
+      "bigram_min_occurrences": 50,
+      "bigram_min_pages": 20,
+      "trigram_min_objects": 10,
+      "trigram_min_occurrences": 75,
+      "trigram_min_pages": 25
+    },
+    "thresholds_preregistered_before_result_inspection": true
+  },
+  "privacy": {
+    "ocr_text_emitted_publicly": false,
+    "page_identifiers_emitted_publicly": false,
+    "rare_sequences_emitted_publicly": false,
+    "sequence_values_emitted_publicly": false,
+    "term_values_emitted_publicly": false
+  },
+  "private_artifact": {
+    "bytes": 91435008,
+    "gzip_bytes": 29732543,
+    "gzip_sha256": "ec5b5c92c65e18cc5a00611c87f1d9620153938b903000a6d72be723c6e95556",
+    "preserved_private": true,
+    "redownload_verified": true,
+    "sha256": "459a69ce856d68855272adfc481bcf631c7631ba2a91410f54edf25c35ad5c9f"
+  },
+  "scientific_state": {
+    "default_result_state": "exploratory_signal",
+    "frequency_is_semantic_claim": false,
+    "semantic_ready": false,
+    "text_verified": false
+  },
+  "source": {
+    "lexical_reconstruction_sha256": "c57b30bf69acc0f38e406e45d23f37e5de59a4ec90f0fa9294de4c067512fd02",
+    "lexical_version": "LTMD_U1_LEXICAL_POSITIONS_0.1",
+    "universal_index_sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2"
+  }
+}

--- a/docs/LTMD_U1_NGRAMS_COOCCURRENCES_0_1.md
+++ b/docs/LTMD_U1_NGRAMS_COOCCURRENCES_0_1.md
@@ -1,0 +1,29 @@
+# LTMD-U1 — n-gramas y coocurrencias corpus-wide 0.1
+
+Versiones: `LTMD_U1_NGRAMS_0.1` y `LTMD_U1_COOCCURRENCES_0.1`.
+
+Esta capa deriva exclusivamente de `LTMD_U1_LEXICAL_POSITIONS_0.1`. **No vuelve a leer OCR, no vuelve a tokenizar y no vuelve a barrer FTS5.** Los términos, secuencias, pares y localizadores de página permanecen privados. GitHub publica sólo código, contratos, cardinalidades, hashes y estados epistemológicos no sustitutivos.
+
+## Umbrales fijados antes de inspeccionar resultados
+
+Los umbrales se fijaron antes de observar frases o pares concretos y no se ajustan retrospectivamente para favorecer resultados particulares.
+
+**N-gramas privados:** bigramas con al menos 2 ocurrencias en 2 páginas; trigramas con al menos 3 ocurrencias en 2 páginas. **Elegibilidad pública:** bigramas ≥50 ocurrencias, ≥20 páginas y ≥10 objetos; trigramas ≥75 ocurrencias, ≥25 páginas y ≥10 objetos. La elegibilidad no autoriza por sí misma publicación literal: sólo satisface el umbral computacional de supresión.
+
+**Coocurrencias:** pares no ordenados de términos distintos, dentro de la misma página y con distancia máxima de 5 tokens. Piso privado: ≥3 ocurrencias y ≥2 páginas. Elegibilidad pública: ≥75 ocurrencias, ≥25 páginas y ≥10 objetos, además de que cada término tenga dispersión propia de ≥20 páginas y ≥10 objetos.
+
+## Materialización real U1
+
+N-gramas: 13,184,868 instancias de bigrama y 13,104,392 de trigrama; 2,455,883 bigramas y 5,796,137 trigramas únicos antes del piso privado; 1,008,422 y 908,179 filas retenidas; 28,886 y 8,096 filas cumplen el umbral computacional de elegibilidad pública.
+
+Coocurrencias: 64,208,256 parejas posicionales brutas; 10,426,262 pares únicos; 52,653,670 relaciones par-página; 2,540,432 filas retenidas y 81,451 filas que cumplen el umbral computacional de elegibilidad pública.
+
+Los dos SQLite privados pasaron `quick_check=ok`, fueron comprimidos, archivados en la bóveda privada Analytics y **redescargados para verificar sus SHA-256**. Los resúmenes públicos no contienen rutas ni IDs de Drive.
+
+## Estado científico
+
+`text_verified=false`, `semantic_ready=false` y el estado por defecto es `exploratory_signal`. Frecuencia no equivale a significado; coocurrencia no equivale a relación semántica; una secuencia OCR no se convierte automáticamente en evidencia histórica validada.
+
+## Reentrada
+
+Con esta capa cerrada, la ruta canónica continúa con **reutilización/similitud transversal** antes de verticales adicionales, staging e interfaz.

--- a/requirements-analytics-build.txt
+++ b/requirements-analytics-build.txt
@@ -1,0 +1,3 @@
+# Build-time dependency for corpus-wide lexical derivations.
+# Kept separate from the operated Flask runtime and frozen scientific release environment.
+numpy>=2,<3

--- a/schemas/ltmd_u1_cooccurrences_public_summary.schema.json
+++ b/schemas/ltmd_u1_cooccurrences_public_summary.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LTMD-U1 co-occurrences public-safe materialization summary 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["builder_version","artifact_version","source","method","counts","private_artifact","privacy","scientific_state"],
+  "properties": {
+    "builder_version": {"const": "LTMD_U1_COOCCURRENCES_BUILDER_0.1"},
+    "artifact_version": {"const": "LTMD_U1_COOCCURRENCES_0.1"},
+    "source": {"type":"object","additionalProperties":false,"required":["lexical_version","lexical_reconstruction_sha256","universal_index_sha256"],"properties":{"lexical_version":{"const":"LTMD_U1_LEXICAL_POSITIONS_0.1"},"lexical_reconstruction_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"}}},
+    "method": {"type":"object","additionalProperties":false,"required":["window_max_tokens","same_page_only","unordered_distinct_terms","thresholds_preregistered_before_result_inspection","private_retention","public_suppression","bucket_count"],"properties":{"window_max_tokens":{"const":5},"same_page_only":{"const":true},"unordered_distinct_terms":{"const":true},"thresholds_preregistered_before_result_inspection":{"const":true},"private_retention":{"type":"object"},"public_suppression":{"type":"object"},"bucket_count":{"const":64}}},
+    "counts": {"type":"object","additionalProperties":{"type":"integer","minimum":0}},
+    "private_artifact": {"type":"object","additionalProperties":false,"required":["bytes","sha256","gzip_bytes","gzip_sha256","preserved_private","redownload_verified"],"properties":{"bytes":{"type":"integer","minimum":1},"sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"gzip_bytes":{"type":"integer","minimum":1},"gzip_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"preserved_private":{"const":true},"redownload_verified":{"const":true}}},
+    "privacy": {"type":"object","additionalProperties":{"type":"boolean"}},
+    "scientific_state": {"type":"object","additionalProperties":true,"required":["text_verified","semantic_ready","default_result_state","cooccurrence_is_semantic_relation"],"properties":{"text_verified":{"const":false},"semantic_ready":{"const":false},"default_result_state":{"const":"exploratory_signal"},"cooccurrence_is_semantic_relation":{"const":false}}}
+  }
+}

--- a/schemas/ltmd_u1_ngrams_public_summary.schema.json
+++ b/schemas/ltmd_u1_ngrams_public_summary.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LTMD-U1 n-grams public-safe materialization summary 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["builder_version","artifact_version","source","method","counts","private_artifact","privacy","scientific_state"],
+  "properties": {
+    "builder_version": {"const": "LTMD_U1_NGRAMS_BUILDER_0.1"},
+    "artifact_version": {"const": "LTMD_U1_NGRAMS_0.1"},
+    "source": {"type":"object","additionalProperties":false,"required":["lexical_version","lexical_reconstruction_sha256","universal_index_sha256"],"properties":{"lexical_version":{"const":"LTMD_U1_LEXICAL_POSITIONS_0.1"},"lexical_reconstruction_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"}}},
+    "method": {"type":"object","additionalProperties":false,"required":["page_bounded","thresholds_preregistered_before_result_inspection","private_retention","public_suppression"],"properties":{"page_bounded":{"const":true},"thresholds_preregistered_before_result_inspection":{"const":true},"private_retention":{"type":"object"},"public_suppression":{"type":"object"}}},
+    "counts": {"type":"object","additionalProperties":{"type":"integer","minimum":0}},
+    "private_artifact": {"type":"object","additionalProperties":false,"required":["bytes","sha256","gzip_bytes","gzip_sha256","preserved_private","redownload_verified"],"properties":{"bytes":{"type":"integer","minimum":1},"sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"gzip_bytes":{"type":"integer","minimum":1},"gzip_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"preserved_private":{"const":true},"redownload_verified":{"const":true}}},
+    "privacy": {"type":"object","additionalProperties":{"type":"boolean"}},
+    "scientific_state": {"type":"object","additionalProperties":true,"required":["text_verified","semantic_ready","default_result_state"],"properties":{"text_verified":{"const":false},"semantic_ready":{"const":false},"default_result_state":{"const":"exploratory_signal"}}}
+  }
+}

--- a/scripts/build_u1_cooccurrences.py
+++ b/scripts/build_u1_cooccurrences.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Build private LTMD-U1 windowed co-occurrence statistics from lexical positions.
+
+Version: LTMD_U1_COOCCURRENCES_BUILDER_0.1
+
+Pairs are unordered distinct terms, bounded to the same page, and counted once per forward
+positional pair within a five-token window. The builder consumes lexical positions only: it
+never reads OCR or FTS5. Co-occurrence is an exploratory computational signal, not a semantic
+relation claim.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+BUILDER_VERSION = "LTMD_U1_COOCCURRENCES_BUILDER_0.1"
+ARTIFACT_VERSION = "LTMD_U1_COOCCURRENCES_0.1"
+SOURCE_VERSION = "LTMD_U1_LEXICAL_POSITIONS_0.1"
+TERM_BITS = 18
+TERM_MASK = (1 << TERM_BITS) - 1
+BUCKETS = 64
+WINDOW_MAX_TOKENS = 5
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+RECORD_DTYPE = np.dtype([("key", "<u8"), ("page", "<u4")])
+PRIVATE_RETENTION = {"min_occurrences": 3, "min_pages": 2}
+PUBLIC_SUPPRESSION = {
+    "min_occurrences": 75,
+    "min_pages": 25,
+    "min_objects": 10,
+    "each_term_min_pages": 20,
+    "each_term_min_objects": 10,
+}
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_source(path: Path, expected_sha256: str | None) -> str | None:
+    if not path.is_file():
+        raise RuntimeError("lexical-position artifact is unavailable")
+    if expected_sha256 is None:
+        return None
+    expected = expected_sha256.strip().lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise RuntimeError("expected lexical-position SHA-256 is invalid")
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RuntimeError("lexical-position SHA-256 mismatch")
+    return actual
+
+
+def _decode_json(raw: str):
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def load_meta(c: sqlite3.Connection) -> dict:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    required = {"meta", "pages", "terms", "token_positions", "term_stats"}
+    missing = required - tables
+    if missing:
+        raise RuntimeError("not an LTMD lexical-position artifact; missing: " + ", ".join(sorted(missing)))
+    meta = {k: _decode_json(v) for k, v in c.execute("SELECT key,value FROM meta")}
+    version = meta.get("artifact_version", meta.get("version"))
+    if version != SOURCE_VERSION:
+        raise RuntimeError("unsupported lexical-position artifact version")
+    max_term = int(c.execute("SELECT COALESCE(MAX(term_id),0) FROM terms").fetchone()[0])
+    if max_term > TERM_MASK:
+        raise RuntimeError("term IDs exceed the 18-bit LTMD co-occurrence encoding")
+    return meta
+
+
+def _remove_sqlite_family(path: Path) -> None:
+    for p in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if p.exists():
+            p.unlink()
+
+
+def _metadata_arrays(c: sqlite3.Connection):
+    max_page = int(c.execute("SELECT COALESCE(MAX(page_rowid),0) FROM pages").fetchone()[0])
+    max_term = int(c.execute("SELECT COALESCE(MAX(term_id),0) FROM terms").fetchone()[0])
+    objects = np.zeros(max_page + 1, dtype=np.uint16)
+    gen_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    grade_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    wave_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    term_pages = np.zeros(max_term + 1, dtype=np.uint32)
+    term_objects = np.zeros(max_term + 1, dtype=np.uint16)
+    generations = [r[0] for r in c.execute("SELECT DISTINCT generation FROM pages WHERE generation IS NOT NULL ORDER BY generation")]
+    grades = [r[0] for r in c.execute("SELECT DISTINCT grade_code FROM pages WHERE grade_code IS NOT NULL ORDER BY grade_code")]
+    waves = [r[0] for r in c.execute("SELECT DISTINCT wave FROM pages WHERE wave IS NOT NULL ORDER BY wave")]
+    if max(len(generations), len(grades), len(waves)) > 16:
+        raise RuntimeError("dimension cardinality exceeds compact LTMD bitmask capacity")
+    gm, grm, wm = ({v: i for i, v in enumerate(x)} for x in (generations, grades, waves))
+    ordered_objects = []
+    for page, obj, gen, grade, wave in c.execute(
+        "SELECT page_rowid,object_id,generation,grade_code,wave FROM pages ORDER BY page_rowid"
+    ):
+        objects[page] = obj
+        ordered_objects.append(obj)
+        if gen is not None: gen_mask[page] = np.uint16(1 << gm[gen])
+        if grade is not None: grade_mask[page] = np.uint16(1 << grm[grade])
+        if wave is not None: wave_mask[page] = np.uint16(1 << wm[wave])
+    if any(a > b for a, b in zip(ordered_objects, ordered_objects[1:])):
+        raise RuntimeError("lexical pages do not preserve object-contiguous page order")
+    for term_id, page_count, object_count in c.execute("SELECT term_id,page_count,object_count FROM term_stats"):
+        term_pages[term_id] = page_count
+        term_objects[term_id] = object_count
+    return objects, gen_mask, grade_mask, wave_mask, term_pages, term_objects
+
+
+def _flush_bucket_chunk(bucket_paths, keys_parts, page_parts):
+    if not keys_parts:
+        return
+    keys = np.concatenate(keys_parts)
+    pages = np.concatenate(page_parts)
+    bucket_ids = (keys & np.uint64(BUCKETS - 1)).astype(np.uint8)
+    order = np.argsort(bucket_ids, kind="stable")
+    keys, pages, bucket_ids = keys[order], pages[order], bucket_ids[order]
+    boundaries = np.flatnonzero(np.r_[True, bucket_ids[1:] != bucket_ids[:-1], True])
+    for start, end in zip(boundaries[:-1], boundaries[1:]):
+        bucket = int(bucket_ids[start])
+        arr = np.empty(end - start, dtype=RECORD_DTYPE)
+        arr["key"], arr["page"] = keys[start:end], pages[start:end]
+        with bucket_paths[bucket].open("ab") as f:
+            arr.tofile(f)
+
+
+def _partition(c: sqlite3.Connection, bucket_paths: list[Path]) -> tuple[int, int]:
+    for p in bucket_paths:
+        p.write_bytes(b"")
+    key_parts, page_parts, buffered = [], [], 0
+    raw_total, nonempty_pages = 0, 0
+
+    def flush_page(page: int, terms: list[int], offsets: list[int]):
+        nonlocal buffered, raw_total, nonempty_pages, key_parts, page_parts
+        if not terms:
+            return
+        nonempty_pages += 1
+        a = np.asarray(terms, dtype=np.uint64)
+        off = np.asarray(offsets, dtype=np.int64)
+        local = []
+        for distance in range(1, WINDOW_MAX_TOKENS + 1):
+            if a.size <= distance:
+                break
+            x, y = a[:-distance], a[distance:]
+            valid = (off[distance:] - off[:-distance] <= WINDOW_MAX_TOKENS) & (x != y)
+            if not np.any(valid):
+                continue
+            xv, yv = x[valid], y[valid]
+            lo, hi = np.minimum(xv, yv), np.maximum(xv, yv)
+            local.append((lo << np.uint64(TERM_BITS)) | hi)
+        if local:
+            keys = np.concatenate(local)
+            pages = np.full(keys.size, page, dtype=np.uint32)
+            key_parts.append(keys); page_parts.append(pages)
+            buffered += int(keys.size); raw_total += int(keys.size)
+        if buffered >= 500_000:
+            _flush_bucket_chunk(bucket_paths, key_parts, page_parts)
+            key_parts, page_parts, buffered = [], [], 0
+
+    last_page = None
+    terms: list[int] = []
+    offsets: list[int] = []
+    for page, term, offset in c.execute(
+        "SELECT page_rowid,term_id,token_offset FROM token_positions ORDER BY page_rowid,token_offset"
+    ):
+        if last_page is None:
+            last_page = page
+        if page != last_page:
+            flush_page(last_page, terms, offsets)
+            terms, offsets, last_page = [], [], page
+        terms.append(term); offsets.append(offset)
+    if last_page is not None:
+        flush_page(last_page, terms, offsets)
+    _flush_bucket_chunk(bucket_paths, key_parts, page_parts)
+    return raw_total, nonempty_pages
+
+
+def _process_bucket(
+    path: Path,
+    objects: np.ndarray,
+    gen_mask: np.ndarray,
+    grade_mask: np.ndarray,
+    wave_mask: np.ndarray,
+    term_pages: np.ndarray,
+    term_objects: np.ndarray,
+):
+    n = path.stat().st_size // RECORD_DTYPE.itemsize
+    if n == 0:
+        return [], {"raw_rows": 0, "unique_pairs": 0, "unique_pair_page": 0, "retained": 0, "public": 0}
+    arr = np.memmap(path, dtype=RECORD_DTYPE, mode="r+", shape=(n,))
+    arr.sort(order=["key", "page"]); arr.flush()
+    keys, pages = arr["key"], arr["page"]
+    key_start = np.empty(n, dtype=bool); key_start[0] = True; key_start[1:] = keys[1:] != keys[:-1]
+    starts = np.flatnonzero(key_start); ends = np.empty_like(starts); ends[:-1], ends[-1] = starts[1:], n
+    occurrence_count = (ends - starts).astype(np.uint32); group_keys = np.asarray(keys[starts], dtype=np.uint64)
+    kp_start = key_start.copy(); kp_start[1:] |= pages[1:] != pages[:-1]
+    unique_keys, unique_pages = np.asarray(keys[kp_start], dtype=np.uint64), np.asarray(pages[kp_start], dtype=np.uint32)
+    ug_start = np.empty(unique_keys.size, dtype=bool); ug_start[0] = True; ug_start[1:] = unique_keys[1:] != unique_keys[:-1]
+    ustarts = np.flatnonzero(ug_start); uends = np.empty_like(ustarts); uends[:-1], uends[-1] = ustarts[1:], unique_keys.size
+    page_count = (uends - ustarts).astype(np.uint32)
+    if not np.array_equal(group_keys, unique_keys[ustarts]):
+        raise RuntimeError("co-occurrence key/page aggregation mismatch")
+    obj_values = objects[unique_pages]
+    obj_change = ug_start.copy(); obj_change[1:] |= obj_values[1:] != obj_values[:-1]
+    object_count = np.add.reduceat(obj_change.astype(np.uint16), ustarts).astype(np.uint32)
+    generation_count = np.bitwise_count(np.bitwise_or.reduceat(gen_mask[unique_pages], ustarts)).astype(np.uint8)
+    grade_count = np.bitwise_count(np.bitwise_or.reduceat(grade_mask[unique_pages], ustarts)).astype(np.uint8)
+    wave_count = np.bitwise_count(np.bitwise_or.reduceat(wave_mask[unique_pages], ustarts)).astype(np.uint8)
+    t1 = (group_keys >> np.uint64(TERM_BITS)).astype(np.uint32)
+    t2 = (group_keys & np.uint64(TERM_MASK)).astype(np.uint32)
+    keep = (occurrence_count >= PRIVATE_RETENTION["min_occurrences"]) & (page_count >= PRIVATE_RETENTION["min_pages"])
+    public = keep & (occurrence_count >= PUBLIC_SUPPRESSION["min_occurrences"]) & (
+        page_count >= PUBLIC_SUPPRESSION["min_pages"]
+    ) & (object_count >= PUBLIC_SUPPRESSION["min_objects"]) & (
+        term_pages[t1] >= PUBLIC_SUPPRESSION["each_term_min_pages"]
+    ) & (term_pages[t2] >= PUBLIC_SUPPRESSION["each_term_min_pages"]) & (
+        term_objects[t1] >= PUBLIC_SUPPRESSION["each_term_min_objects"]
+    ) & (term_objects[t2] >= PUBLIC_SUPPRESSION["each_term_min_objects"])
+    rows = [
+        (int(t1[i]), int(t2[i]), int(occurrence_count[i]), int(page_count[i]), int(object_count[i]),
+         int(generation_count[i]), int(grade_count[i]), int(wave_count[i]), int(public[i]))
+        for i in np.flatnonzero(keep)
+    ]
+    stats = {
+        "raw_rows": int(n), "unique_pairs": int(group_keys.size), "unique_pair_page": int(unique_keys.size),
+        "retained": int(keep.sum()), "public": int(public.sum()),
+    }
+    del arr
+    return rows, stats
+
+
+def build(source_path: Path, output_path: Path, *, overwrite: bool = False) -> dict:
+    source_path = source_path.expanduser().resolve(); output_path = output_path.expanduser().resolve()
+    if output_path.exists() and not overwrite:
+        raise RuntimeError("output already exists; pass --overwrite to replace it")
+    if overwrite: _remove_sqlite_family(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True, timeout=120)
+    try:
+        source_meta = load_meta(source)
+        objects, gen_mask, grade_mask, wave_mask, term_pages, term_objects = _metadata_arrays(source)
+        with tempfile.TemporaryDirectory(prefix="ltmd-cooc-") as tmp:
+            bucket_paths = [Path(tmp) / f"bucket-{i:02d}.bin" for i in range(BUCKETS)]
+            raw_pair_occurrences, nonempty_pages = _partition(source, bucket_paths)
+            out = sqlite3.connect(output_path, timeout=120)
+            try:
+                out.executescript("""
+                PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-200000;
+                CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
+                CREATE TABLE cooccurrences(
+                    t1 INTEGER NOT NULL,t2 INTEGER NOT NULL,occurrence_count INTEGER NOT NULL,
+                    page_count INTEGER NOT NULL,object_count INTEGER NOT NULL,generation_count INTEGER NOT NULL,
+                    grade_count INTEGER NOT NULL,wave_count INTEGER NOT NULL,public_eligible INTEGER NOT NULL,
+                    PRIMARY KEY(t1,t2)) WITHOUT ROWID;
+                CREATE INDEX idx_cooc_public ON cooccurrences(public_eligible,occurrence_count DESC);
+                """)
+                unique_pairs = unique_pair_page = retained = public = 0
+                bucket_stats = []
+                for bucket, path in enumerate(bucket_paths):
+                    rows, stats = _process_bucket(path, objects, gen_mask, grade_mask, wave_mask, term_pages, term_objects)
+                    if rows:
+                        out.executemany("INSERT INTO cooccurrences VALUES(?,?,?,?,?,?,?,?,?)", rows)
+                        out.commit()
+                    unique_pairs += stats["unique_pairs"]
+                    unique_pair_page += stats["unique_pair_page"]
+                    retained += stats["retained"]
+                    public += stats["public"]
+                    bucket_stats.append({"bucket": bucket, **stats})
+                if int(out.execute("SELECT COUNT(*) FROM cooccurrences").fetchone()[0]) != retained:
+                    raise RuntimeError("co-occurrence retained-row reconciliation mismatch")
+                if int(out.execute("SELECT COUNT(*) FROM cooccurrences WHERE public_eligible=1").fetchone()[0]) != public:
+                    raise RuntimeError("co-occurrence public-row reconciliation mismatch")
+                counts = {
+                    "nonempty_tokenized_pages": nonempty_pages,
+                    "raw_pair_occurrences": raw_pair_occurrences,
+                    "unique_pairs_before_private_floor": unique_pairs,
+                    "unique_pair_page_relations": unique_pair_page,
+                    "cooccurrence_rows": retained,
+                    "public_eligible_rows": public,
+                }
+                metadata = {
+                    "builder_version": BUILDER_VERSION,
+                    "artifact_version": ARTIFACT_VERSION,
+                    "source_lexical_version": SOURCE_VERSION,
+                    "window_max_tokens": WINDOW_MAX_TOKENS,
+                    "same_page_only": True,
+                    "unordered_distinct_terms": True,
+                    "thresholds_preregistered_before_result_inspection": True,
+                    "private_retention": PRIVATE_RETENTION,
+                    "public_suppression": PUBLIC_SUPPRESSION,
+                    **counts,
+                    "private": True,
+                    "text_verified": False,
+                    "semantic_ready": False,
+                    "default_result_state": "exploratory_signal",
+                    "cooccurrence_is_semantic_relation": False,
+                }
+                for k, v in metadata.items():
+                    out.execute("INSERT INTO meta VALUES(?,?)", (k, json.dumps(v, ensure_ascii=False, sort_keys=True)))
+                out.commit()
+                if out.execute("PRAGMA quick_check").fetchone()[0] != "ok":
+                    raise RuntimeError("co-occurrence artifact quick_check failed")
+                out.execute("PRAGMA wal_checkpoint(TRUNCATE)"); out.execute("PRAGMA journal_mode=DELETE"); out.commit()
+            finally:
+                out.close()
+    finally:
+        source.close()
+    return {
+        "builder_version": BUILDER_VERSION,
+        "artifact_version": ARTIFACT_VERSION,
+        "source_lexical_version": SOURCE_VERSION,
+        "counts": counts,
+        "method": {
+            "window_max_tokens": WINDOW_MAX_TOKENS,
+            "same_page_only": True,
+            "unordered_distinct_terms": True,
+            "bucket_count": BUCKETS,
+            "thresholds_preregistered_before_result_inspection": True,
+            "private_retention": PRIVATE_RETENTION,
+            "public_suppression": PUBLIC_SUPPRESSION,
+        },
+        "private_artifact": {"bytes": output_path.stat().st_size, "sha256": sha256_file(output_path), "publish": False},
+        "privacy": {
+            "term_values_emitted_publicly": False,
+            "pair_values_emitted_publicly": False,
+            "page_identifiers_emitted_publicly": False,
+            "ocr_text_emitted_publicly": False,
+        },
+        "scientific_state": {
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+            "cooccurrence_is_semantic_relation": False,
+        },
+        "source_meta_cardinality": {
+            "unique_pages": source_meta.get("unique_pages"),
+            "unique_objects": source_meta.get("unique_objects", source_meta.get("unique_canonical_objects")),
+        },
+    }
+
+
+def run(source_path: Path, output_path: Path, *, expected_source_sha256: str | None = None, overwrite: bool = False) -> dict:
+    verified = verify_source(source_path, expected_source_sha256)
+    summary = build(source_path, output_path, overwrite=overwrite)
+    summary["source_lexical_sha256"] = verified
+    return summary
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", required=True, help="Private LTMD_U1_LEXICAL_POSITIONS_0.1 SQLite")
+    p.add_argument("--output", required=True, help="Private co-occurrence SQLite output")
+    p.add_argument("--summary", help="Optional public-safe aggregate JSON summary")
+    p.add_argument("--expected-source-sha256")
+    p.add_argument("--overwrite", action="store_true")
+    a = p.parse_args(argv)
+    result = run(Path(a.source), Path(a.output), expected_source_sha256=a.expected_source_sha256, overwrite=a.overwrite)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if a.summary: Path(a.summary).write_text(payload, encoding="utf-8")
+    else: print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_u1_ngrams.py
+++ b/scripts/build_u1_ngrams.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Build private page-bounded LTMD-U1 bigram/trigram statistics from lexical positions.
+
+Version: LTMD_U1_NGRAMS_BUILDER_0.1
+
+This builder never reads OCR or FTS5. It consumes LTMD_U1_LEXICAL_POSITIONS_0.1,
+uses the already materialized token positions, and keeps all sequence values private.
+Publication eligibility is computed from preregistered suppression thresholds; eligibility
+is not itself a claim of semantic validity or permission to redistribute source text.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+BUILDER_VERSION = "LTMD_U1_NGRAMS_BUILDER_0.1"
+ARTIFACT_VERSION = "LTMD_U1_NGRAMS_0.1"
+SOURCE_VERSION = "LTMD_U1_LEXICAL_POSITIONS_0.1"
+TERM_BITS = 18
+TERM_MASK = (1 << TERM_BITS) - 1
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+RECORD_DTYPE = np.dtype([("key", "<u8"), ("page", "<u4")])
+
+PRIVATE_RETENTION = {
+    "bigram_min_occurrences": 2,
+    "bigram_min_pages": 2,
+    "trigram_min_occurrences": 3,
+    "trigram_min_pages": 2,
+}
+PUBLIC_SUPPRESSION = {
+    "bigram_min_occurrences": 50,
+    "bigram_min_pages": 20,
+    "bigram_min_objects": 10,
+    "trigram_min_occurrences": 75,
+    "trigram_min_pages": 25,
+    "trigram_min_objects": 10,
+}
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_source(path: Path, expected_sha256: str | None) -> str | None:
+    if not path.is_file():
+        raise RuntimeError("lexical-position artifact is unavailable")
+    if expected_sha256 is None:
+        return None
+    expected = expected_sha256.strip().lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise RuntimeError("expected lexical-position SHA-256 is invalid")
+    actual = sha256_file(path)
+    if actual != expected:
+        raise RuntimeError("lexical-position SHA-256 mismatch")
+    return actual
+
+
+def _decode_json(raw: str):
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+
+
+def load_meta(c: sqlite3.Connection) -> dict:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    required = {"meta", "pages", "terms", "token_positions", "term_stats"}
+    missing = required - tables
+    if missing:
+        raise RuntimeError("not an LTMD lexical-position artifact; missing: " + ", ".join(sorted(missing)))
+    meta = {k: _decode_json(v) for k, v in c.execute("SELECT key,value FROM meta")}
+    version = meta.get("artifact_version", meta.get("version"))
+    if version != SOURCE_VERSION:
+        raise RuntimeError("unsupported lexical-position artifact version")
+    max_term = int(c.execute("SELECT COALESCE(MAX(term_id),0) FROM terms").fetchone()[0])
+    if max_term > TERM_MASK:
+        raise RuntimeError("term IDs exceed the 18-bit LTMD n-gram encoding")
+    return meta
+
+
+def _remove_sqlite_family(path: Path) -> None:
+    for p in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if p.exists():
+            p.unlink()
+
+
+def _page_metadata(c: sqlite3.Connection):
+    max_page = int(c.execute("SELECT COALESCE(MAX(page_rowid),0) FROM pages").fetchone()[0])
+    objects = np.zeros(max_page + 1, dtype=np.uint16)
+    gen_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    grade_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    wave_mask = np.zeros(max_page + 1, dtype=np.uint16)
+    generations = [r[0] for r in c.execute("SELECT DISTINCT generation FROM pages WHERE generation IS NOT NULL ORDER BY generation")]
+    grades = [r[0] for r in c.execute("SELECT DISTINCT grade_code FROM pages WHERE grade_code IS NOT NULL ORDER BY grade_code")]
+    waves = [r[0] for r in c.execute("SELECT DISTINCT wave FROM pages WHERE wave IS NOT NULL ORDER BY wave")]
+    if max(len(generations), len(grades), len(waves)) > 16:
+        raise RuntimeError("dimension cardinality exceeds compact LTMD bitmask capacity")
+    gm = {v: i for i, v in enumerate(generations)}
+    grm = {v: i for i, v in enumerate(grades)}
+    wm = {v: i for i, v in enumerate(waves)}
+    ordered_objects = []
+    for page, obj, gen, grade, wave in c.execute(
+        "SELECT page_rowid,object_id,generation,grade_code,wave FROM pages ORDER BY page_rowid"
+    ):
+        objects[page] = obj
+        ordered_objects.append(obj)
+        if gen is not None:
+            gen_mask[page] = np.uint16(1 << gm[gen])
+        if grade is not None:
+            grade_mask[page] = np.uint16(1 << grm[grade])
+        if wave is not None:
+            wave_mask[page] = np.uint16(1 << wm[wave])
+    if any(a > b for a, b in zip(ordered_objects, ordered_objects[1:])):
+        raise RuntimeError("lexical pages do not preserve object-contiguous page order")
+    return objects, gen_mask, grade_mask, wave_mask
+
+
+def _append_records(path: Path, keys: np.ndarray, page: int) -> None:
+    if keys.size == 0:
+        return
+    arr = np.empty(keys.size, dtype=RECORD_DTYPE)
+    arr["key"] = keys
+    arr["page"] = page
+    with path.open("ab") as f:
+        arr.tofile(f)
+
+
+def _materialize_raw(c: sqlite3.Connection, bigram_path: Path, trigram_path: Path) -> tuple[int, int, int]:
+    bigram_path.write_bytes(b"")
+    trigram_path.write_bytes(b"")
+    bigram_instances = 0
+    trigram_instances = 0
+    nonempty_pages = 0
+
+    def flush(page: int, terms: list[int], offsets: list[int]):
+        nonlocal bigram_instances, trigram_instances, nonempty_pages
+        if not terms:
+            return
+        nonempty_pages += 1
+        a = np.asarray(terms, dtype=np.uint64)
+        off = np.asarray(offsets, dtype=np.int64)
+        if a.size >= 2:
+            valid = off[1:] == off[:-1] + 1
+            keys = ((a[:-1] << np.uint64(TERM_BITS)) | a[1:])[valid]
+            _append_records(bigram_path, keys, page)
+            bigram_instances += int(keys.size)
+        if a.size >= 3:
+            valid = (off[1:-1] == off[:-2] + 1) & (off[2:] == off[1:-1] + 1)
+            keys = (
+                (a[:-2] << np.uint64(TERM_BITS * 2))
+                | (a[1:-1] << np.uint64(TERM_BITS))
+                | a[2:]
+            )[valid]
+            _append_records(trigram_path, keys, page)
+            trigram_instances += int(keys.size)
+
+    last_page = None
+    terms: list[int] = []
+    offsets: list[int] = []
+    for page, term, offset in c.execute(
+        "SELECT page_rowid,term_id,token_offset FROM token_positions ORDER BY page_rowid,token_offset"
+    ):
+        if last_page is None:
+            last_page = page
+        if page != last_page:
+            flush(last_page, terms, offsets)
+            terms, offsets, last_page = [], [], page
+        terms.append(term)
+        offsets.append(offset)
+    if last_page is not None:
+        flush(last_page, terms, offsets)
+    return bigram_instances, trigram_instances, nonempty_pages
+
+
+def _aggregate(
+    raw_path: Path,
+    kind: str,
+    objects: np.ndarray,
+    gen_mask: np.ndarray,
+    grade_mask: np.ndarray,
+    wave_mask: np.ndarray,
+):
+    n = raw_path.stat().st_size // RECORD_DTYPE.itemsize
+    if n == 0:
+        empty = np.array([], dtype=np.uint64)
+        return empty, *(np.array([], dtype=np.uint32) for _ in range(3)), *(np.array([], dtype=np.uint8) for _ in range(4)), 0, 0
+    arr = np.memmap(raw_path, dtype=RECORD_DTYPE, mode="r+", shape=(n,))
+    arr.sort(order=["key", "page"])
+    arr.flush()
+    keys, pages = arr["key"], arr["page"]
+
+    key_start = np.empty(n, dtype=bool)
+    key_start[0] = True
+    key_start[1:] = keys[1:] != keys[:-1]
+    starts = np.flatnonzero(key_start)
+    ends = np.empty_like(starts)
+    ends[:-1], ends[-1] = starts[1:], n
+    occurrence_count = (ends - starts).astype(np.uint32)
+    group_keys = np.asarray(keys[starts], dtype=np.uint64)
+
+    key_page_start = key_start.copy()
+    key_page_start[1:] |= pages[1:] != pages[:-1]
+    unique_keys = np.asarray(keys[key_page_start], dtype=np.uint64)
+    unique_pages = np.asarray(pages[key_page_start], dtype=np.uint32)
+    unique_group_start = np.empty(unique_keys.size, dtype=bool)
+    unique_group_start[0] = True
+    unique_group_start[1:] = unique_keys[1:] != unique_keys[:-1]
+    ustarts = np.flatnonzero(unique_group_start)
+    uends = np.empty_like(ustarts)
+    uends[:-1], uends[-1] = ustarts[1:], unique_keys.size
+    page_count = (uends - ustarts).astype(np.uint32)
+    if not np.array_equal(group_keys, unique_keys[ustarts]):
+        raise RuntimeError("n-gram key/page aggregation mismatch")
+
+    obj_values = objects[unique_pages]
+    object_change = unique_group_start.copy()
+    object_change[1:] |= obj_values[1:] != obj_values[:-1]
+    object_count = np.add.reduceat(object_change.astype(np.uint16), ustarts).astype(np.uint32)
+    generation_count = np.bitwise_count(np.bitwise_or.reduceat(gen_mask[unique_pages], ustarts)).astype(np.uint8)
+    grade_count = np.bitwise_count(np.bitwise_or.reduceat(grade_mask[unique_pages], ustarts)).astype(np.uint8)
+    wave_count = np.bitwise_count(np.bitwise_or.reduceat(wave_mask[unique_pages], ustarts)).astype(np.uint8)
+
+    if kind == "bigram":
+        keep = (occurrence_count >= PRIVATE_RETENTION["bigram_min_occurrences"]) & (
+            page_count >= PRIVATE_RETENTION["bigram_min_pages"]
+        )
+        public = keep & (occurrence_count >= PUBLIC_SUPPRESSION["bigram_min_occurrences"]) & (
+            page_count >= PUBLIC_SUPPRESSION["bigram_min_pages"]
+        ) & (object_count >= PUBLIC_SUPPRESSION["bigram_min_objects"])
+    else:
+        keep = (occurrence_count >= PRIVATE_RETENTION["trigram_min_occurrences"]) & (
+            page_count >= PRIVATE_RETENTION["trigram_min_pages"]
+        )
+        public = keep & (occurrence_count >= PUBLIC_SUPPRESSION["trigram_min_occurrences"]) & (
+            page_count >= PUBLIC_SUPPRESSION["trigram_min_pages"]
+        ) & (object_count >= PUBLIC_SUPPRESSION["trigram_min_objects"])
+
+    result = (
+        group_keys[keep], occurrence_count[keep], page_count[keep], object_count[keep],
+        generation_count[keep], grade_count[keep], wave_count[keep], public[keep].astype(np.uint8),
+        int(group_keys.size), int(unique_keys.size),
+    )
+    del arr
+    return result
+
+
+def _insert_rows(c: sqlite3.Connection, table: str, aggregated) -> None:
+    keys, occ, pages, objects, generations, grades, waves, public, _, _ = aggregated
+    rows = []
+    if table == "bigrams":
+        for key, a, b, d, e, f, g, h in zip(keys, occ, pages, objects, generations, grades, waves, public):
+            k = int(key)
+            rows.append((k >> TERM_BITS, k & TERM_MASK, int(a), int(b), int(d), int(e), int(f), int(g), int(h)))
+            if len(rows) >= 50_000:
+                c.executemany("INSERT INTO bigrams VALUES(?,?,?,?,?,?,?,?,?)", rows)
+                c.commit(); rows = []
+    else:
+        for key, a, b, d, e, f, g, h in zip(keys, occ, pages, objects, generations, grades, waves, public):
+            k = int(key)
+            rows.append((k >> (TERM_BITS * 2), (k >> TERM_BITS) & TERM_MASK, k & TERM_MASK, int(a), int(b), int(d), int(e), int(f), int(g), int(h)))
+            if len(rows) >= 50_000:
+                c.executemany("INSERT INTO trigrams VALUES(?,?,?,?,?,?,?,?,?,?)", rows)
+                c.commit(); rows = []
+    if rows:
+        placeholders = "?,?,?,?,?,?,?,?,?" if table == "bigrams" else "?,?,?,?,?,?,?,?,?,?"
+        c.executemany(f"INSERT INTO {table} VALUES({placeholders})", rows)
+        c.commit()
+
+
+def build(source_path: Path, output_path: Path, *, overwrite: bool = False) -> dict:
+    source_path = source_path.expanduser().resolve()
+    output_path = output_path.expanduser().resolve()
+    if output_path.exists() and not overwrite:
+        raise RuntimeError("output already exists; pass --overwrite to replace it")
+    if overwrite:
+        _remove_sqlite_family(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    source = sqlite3.connect(f"file:{source_path}?mode=ro", uri=True, timeout=120)
+    try:
+        source_meta = load_meta(source)
+        objects, gen_mask, grade_mask, wave_mask = _page_metadata(source)
+        with tempfile.TemporaryDirectory(prefix="ltmd-ngrams-") as tmp:
+            tmpdir = Path(tmp)
+            braw, traw = tmpdir / "bigrams.bin", tmpdir / "trigrams.bin"
+            raw_bigram_instances, raw_trigram_instances, nonempty_pages = _materialize_raw(source, braw, traw)
+            bagg = _aggregate(braw, "bigram", objects, gen_mask, grade_mask, wave_mask)
+            tagg = _aggregate(traw, "trigram", objects, gen_mask, grade_mask, wave_mask)
+
+            out = sqlite3.connect(output_path, timeout=120)
+            try:
+                out.executescript("""
+                PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL; PRAGMA cache_size=-200000;
+                CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
+                CREATE TABLE bigrams(
+                    t1 INTEGER NOT NULL,t2 INTEGER NOT NULL,occurrence_count INTEGER NOT NULL,
+                    page_count INTEGER NOT NULL,object_count INTEGER NOT NULL,generation_count INTEGER NOT NULL,
+                    grade_count INTEGER NOT NULL,wave_count INTEGER NOT NULL,public_eligible INTEGER NOT NULL,
+                    PRIMARY KEY(t1,t2)) WITHOUT ROWID;
+                CREATE TABLE trigrams(
+                    t1 INTEGER NOT NULL,t2 INTEGER NOT NULL,t3 INTEGER NOT NULL,occurrence_count INTEGER NOT NULL,
+                    page_count INTEGER NOT NULL,object_count INTEGER NOT NULL,generation_count INTEGER NOT NULL,
+                    grade_count INTEGER NOT NULL,wave_count INTEGER NOT NULL,public_eligible INTEGER NOT NULL,
+                    PRIMARY KEY(t1,t2,t3)) WITHOUT ROWID;
+                CREATE INDEX idx_bigrams_public ON bigrams(public_eligible,occurrence_count DESC);
+                CREATE INDEX idx_trigrams_public ON trigrams(public_eligible,occurrence_count DESC);
+                """)
+                _insert_rows(out, "bigrams", bagg)
+                _insert_rows(out, "trigrams", tagg)
+                counts = {
+                    "nonempty_tokenized_pages": nonempty_pages,
+                    "raw_bigram_instances": raw_bigram_instances,
+                    "raw_trigram_instances": raw_trigram_instances,
+                    "unique_bigrams_before_private_floor": bagg[-2],
+                    "unique_trigrams_before_private_floor": tagg[-2],
+                    "unique_bigram_page_relations": bagg[-1],
+                    "unique_trigram_page_relations": tagg[-1],
+                    "bigram_rows": int(len(bagg[0])),
+                    "trigram_rows": int(len(tagg[0])),
+                    "bigram_public_eligible_rows": int(bagg[7].sum()),
+                    "trigram_public_eligible_rows": int(tagg[7].sum()),
+                }
+                metadata = {
+                    "builder_version": BUILDER_VERSION,
+                    "artifact_version": ARTIFACT_VERSION,
+                    "source_lexical_version": SOURCE_VERSION,
+                    "page_bounded": True,
+                    "thresholds_preregistered_before_result_inspection": True,
+                    "private_retention": PRIVATE_RETENTION,
+                    "public_suppression": PUBLIC_SUPPRESSION,
+                    **counts,
+                    "private": True,
+                    "text_verified": False,
+                    "semantic_ready": False,
+                    "default_result_state": "exploratory_signal",
+                    "frequency_is_semantic_claim": False,
+                }
+                for k, v in metadata.items():
+                    out.execute("INSERT INTO meta VALUES(?,?)", (k, json.dumps(v, ensure_ascii=False, sort_keys=True)))
+                out.commit()
+                if out.execute("PRAGMA quick_check").fetchone()[0] != "ok":
+                    raise RuntimeError("n-gram artifact quick_check failed")
+                out.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+                out.execute("PRAGMA journal_mode=DELETE")
+                out.commit()
+            finally:
+                out.close()
+    finally:
+        source.close()
+
+    return {
+        "builder_version": BUILDER_VERSION,
+        "artifact_version": ARTIFACT_VERSION,
+        "source_lexical_version": SOURCE_VERSION,
+        "counts": counts,
+        "method": {
+            "page_bounded": True,
+            "thresholds_preregistered_before_result_inspection": True,
+            "private_retention": PRIVATE_RETENTION,
+            "public_suppression": PUBLIC_SUPPRESSION,
+        },
+        "private_artifact": {"bytes": output_path.stat().st_size, "sha256": sha256_file(output_path), "publish": False},
+        "privacy": {
+            "term_values_emitted_publicly": False,
+            "sequence_values_emitted_publicly": False,
+            "page_identifiers_emitted_publicly": False,
+            "ocr_text_emitted_publicly": False,
+        },
+        "scientific_state": {
+            "text_verified": False,
+            "semantic_ready": False,
+            "default_result_state": "exploratory_signal",
+            "frequency_is_semantic_claim": False,
+        },
+        "source_meta_cardinality": {
+            "unique_pages": source_meta.get("unique_pages"),
+            "unique_objects": source_meta.get("unique_objects", source_meta.get("unique_canonical_objects")),
+        },
+    }
+
+
+def run(source_path: Path, output_path: Path, *, expected_source_sha256: str | None = None, overwrite: bool = False) -> dict:
+    verified = verify_source(source_path, expected_source_sha256)
+    summary = build(source_path, output_path, overwrite=overwrite)
+    summary["source_lexical_sha256"] = verified
+    return summary
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--source", required=True, help="Private LTMD_U1_LEXICAL_POSITIONS_0.1 SQLite")
+    p.add_argument("--output", required=True, help="Private n-gram SQLite output")
+    p.add_argument("--summary", help="Optional public-safe aggregate JSON summary")
+    p.add_argument("--expected-source-sha256")
+    p.add_argument("--overwrite", action="store_true")
+    a = p.parse_args(argv)
+    result = run(Path(a.source), Path(a.output), expected_source_sha256=a.expected_source_sha256, overwrite=a.overwrite)
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if a.summary:
+        Path(a.summary).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_u1_cooccurrences.py
+++ b/tests/test_build_u1_cooccurrences.py
@@ -1,0 +1,85 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / 'scripts' / 'build_u1_cooccurrences.py'
+SPEC = importlib.util.spec_from_file_location('build_u1_cooccurrences', SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_source(path: Path):
+    c = sqlite3.connect(path)
+    c.executescript('''
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL);
+    CREATE TABLE terms(term_id INTEGER PRIMARY KEY,term TEXT,page_count INTEGER,occurrence_count INTEGER);
+    CREATE TABLE pages(page_rowid INTEGER PRIMARY KEY,object_id INTEGER,generation INTEGER,grade_code INTEGER,wave TEXT);
+    CREATE TABLE token_positions(term_id INTEGER,page_rowid INTEGER,token_offset INTEGER);
+    CREATE TABLE term_stats(term_id INTEGER PRIMARY KEY,page_count INTEGER,occurrence_count INTEGER,object_count INTEGER,generation_count INTEGER,grade_count INTEGER,wave_count INTEGER);
+    ''')
+    for k, v in {'artifact_version': mod.SOURCE_VERSION, 'unique_pages': 3, 'unique_objects': 2}.items():
+        c.execute('INSERT INTO meta VALUES(?,?)', (k, json.dumps(v)))
+    c.executemany('INSERT INTO terms VALUES(?,?,?,?)', [(1,'secretAlpha',3,6),(2,'secretBeta',3,6),(3,'secretGamma',3,6),(4,'secretDelta',2,2)])
+    c.executemany('INSERT INTO pages VALUES(?,?,?,?,?)', [(1,1,1993,5,'W1'),(2,1,1993,5,'W1'),(3,2,2014,6,'W3')])
+    seqs = {1:[1,2,3,1,2,3], 2:[1,2,3,1,2,3], 3:[1,2,4,3]}
+    rows=[]
+    for page, seq in seqs.items(): rows.extend((term,page,offset) for offset,term in enumerate(seq))
+    c.executemany('INSERT INTO token_positions VALUES(?,?,?)', rows)
+    c.executemany('INSERT INTO term_stats VALUES(?,?,?,?,?,?,?)', [
+        (1,3,5,2,2,2,2),(2,3,5,2,2,2,2),(3,3,5,2,2,2,2),(4,1,1,1,1,1,1)])
+    c.commit(); c.close()
+    return seqs
+
+
+def naive_raw(seqs):
+    total=0
+    pair_counts={}
+    pair_pages={}
+    for page, seq in seqs.items():
+        for i,x in enumerate(seq):
+            for j in range(i+1, min(len(seq), i+1+mod.WINDOW_MAX_TOKENS)):
+                y=seq[j]
+                if x==y: continue
+                pair=tuple(sorted((x,y)))
+                total+=1
+                pair_counts[pair]=pair_counts.get(pair,0)+1
+                pair_pages.setdefault(pair,set()).add(page)
+    return total,pair_counts,pair_pages
+
+
+def test_windowed_unordered_distinct_same_page(tmp_path):
+    src, out = tmp_path/'source.sqlite', tmp_path/'cooc.sqlite'
+    seqs=make_source(src); expected_total, counts, pages=naive_raw(seqs)
+    summary=mod.run(src,out)
+    assert summary['counts']['raw_pair_occurrences']==expected_total
+    c=sqlite3.connect(out)
+    row=c.execute('SELECT occurrence_count,page_count,object_count FROM cooccurrences WHERE t1=1 AND t2=2').fetchone()
+    assert row==(counts[(1,2)],len(pages[(1,2)]),2)
+    assert c.execute('SELECT 1 FROM cooccurrences WHERE t1>=t2').fetchone() is None
+    assert c.execute('SELECT 1 FROM cooccurrences WHERE t1=t2').fetchone() is None
+    assert c.execute('PRAGMA quick_check').fetchone()[0]=='ok'
+    c.close()
+
+
+def test_protocol_fixed_and_summary_private(tmp_path):
+    src,out=tmp_path/'source.sqlite',tmp_path/'cooc.sqlite'; make_source(src)
+    rendered=json.dumps(mod.run(src,out),sort_keys=True)
+    assert mod.WINDOW_MAX_TOKENS==5
+    assert mod.PRIVATE_RETENTION=={'min_occurrences':3,'min_pages':2}
+    assert mod.PUBLIC_SUPPRESSION=={'min_occurrences':75,'min_pages':25,'min_objects':10,'each_term_min_pages':20,'each_term_min_objects':10}
+    assert 'secretAlpha' not in rendered and 'secretBeta' not in rendered
+    assert 'page_rowid' not in rendered
+    assert 'cooccurrence_is_semantic_relation' in rendered
+
+
+def test_sha_gate(tmp_path):
+    src=tmp_path/'source.sqlite'; make_source(src); sha=mod.sha256_file(src)
+    assert mod.run(src,tmp_path/'good.sqlite',expected_source_sha256=sha)['source_lexical_sha256']==sha
+    try:
+        mod.run(src,tmp_path/'bad.sqlite',expected_source_sha256='f'*64)
+    except RuntimeError as exc:
+        assert str(exc)=='lexical-position SHA-256 mismatch'
+    else:
+        raise AssertionError('expected mismatch')

--- a/tests/test_build_u1_ngrams.py
+++ b/tests/test_build_u1_ngrams.py
@@ -1,0 +1,70 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / 'scripts' / 'build_u1_ngrams.py'
+SPEC = importlib.util.spec_from_file_location('build_u1_ngrams', SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_source(path: Path):
+    c = sqlite3.connect(path)
+    c.executescript('''
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL);
+    CREATE TABLE terms(term_id INTEGER PRIMARY KEY,term TEXT,page_count INTEGER,occurrence_count INTEGER);
+    CREATE TABLE pages(page_rowid INTEGER PRIMARY KEY,object_id INTEGER,generation INTEGER,grade_code INTEGER,wave TEXT);
+    CREATE TABLE token_positions(term_id INTEGER,page_rowid INTEGER,token_offset INTEGER);
+    CREATE TABLE term_stats(term_id INTEGER PRIMARY KEY,page_count INTEGER,occurrence_count INTEGER,object_count INTEGER,generation_count INTEGER,grade_count INTEGER,wave_count INTEGER);
+    ''')
+    for k, v in {'artifact_version': mod.SOURCE_VERSION, 'unique_pages': 3, 'unique_objects': 2}.items():
+        c.execute('INSERT INTO meta VALUES(?,?)', (k, json.dumps(v)))
+    c.executemany('INSERT INTO terms VALUES(?,?,?,?)', [(1,'uno',3,6),(2,'dos',3,6),(3,'tres',3,6),(4,'cuatro',1,1)])
+    c.executemany('INSERT INTO pages VALUES(?,?,?,?,?)', [(1,1,1993,5,'W1'),(2,1,1993,5,'W1'),(3,2,2014,6,'W3')])
+    seqs = {1:[1,2,3,1,2,3,4], 2:[1,2,3,1,2,3], 3:[1,2,3]}
+    rows=[]
+    for page, seq in seqs.items():
+        rows.extend((term,page,offset) for offset,term in enumerate(seq))
+    c.executemany('INSERT INTO token_positions VALUES(?,?,?)', rows)
+    c.executemany('INSERT INTO term_stats VALUES(?,?,?,?,?,?,?)', [
+        (1,3,5,2,2,2,2),(2,3,5,2,2,2,2),(3,3,5,2,2,2,2),(4,1,1,1,1,1,1)])
+    c.commit(); c.close()
+
+
+def test_page_bounded_counts_and_retention(tmp_path):
+    src, out = tmp_path/'source.sqlite', tmp_path/'ngrams.sqlite'
+    make_source(src)
+    summary = mod.run(src, out)
+    assert summary['counts']['raw_bigram_instances'] == 13
+    assert summary['counts']['raw_trigram_instances'] == 10
+    c = sqlite3.connect(out)
+    assert c.execute('SELECT occurrence_count,page_count,object_count FROM bigrams WHERE t1=1 AND t2=2').fetchone() == (5,3,2)
+    assert c.execute('SELECT occurrence_count,page_count,object_count FROM trigrams WHERE t1=1 AND t2=2 AND t3=3').fetchone() == (5,3,2)
+    assert c.execute('SELECT 1 FROM bigrams WHERE t1=4 AND t2=1').fetchone() is None
+    assert c.execute('PRAGMA quick_check').fetchone()[0] == 'ok'
+    c.close()
+
+
+def test_thresholds_are_fixed_and_summary_private(tmp_path):
+    src, out = tmp_path/'source.sqlite', tmp_path/'ngrams.sqlite'
+    make_source(src)
+    rendered = json.dumps(mod.run(src, out), sort_keys=True)
+    assert mod.PRIVATE_RETENTION == {'bigram_min_occurrences':2,'bigram_min_pages':2,'trigram_min_occurrences':3,'trigram_min_pages':2}
+    assert mod.PUBLIC_SUPPRESSION == {'bigram_min_occurrences':50,'bigram_min_pages':20,'bigram_min_objects':10,'trigram_min_occurrences':75,'trigram_min_pages':25,'trigram_min_objects':10}
+    assert 'uno' not in rendered and 'dos' not in rendered and 'tres' not in rendered
+    assert 'page_rowid' not in rendered
+    assert 'exploratory_signal' in rendered
+
+
+def test_sha_gate(tmp_path):
+    src = tmp_path/'source.sqlite'; make_source(src)
+    sha = mod.sha256_file(src)
+    assert mod.run(src, tmp_path/'good.sqlite', expected_source_sha256=sha)['source_lexical_sha256'] == sha
+    try:
+        mod.run(src, tmp_path/'bad.sqlite', expected_source_sha256='0'*64)
+    except RuntimeError as exc:
+        assert str(exc) == 'lexical-position SHA-256 mismatch'
+    else:
+        raise AssertionError('expected mismatch')


### PR DESCRIPTION
## Summary

Closes the LTMD-U1 corpus-wide lexical/co-occurrence lane after the already merged lexical-position and dimensional layers. Adds reproducible private builders for page-bounded bigrams/trigrams and five-token windowed co-occurrences, plus tests, public-safe materialization contracts, exact cardinality/hash records, and CI validation of those records.

### Canonical real-corpus materialization

**N-grams**
- 13,184,868 raw bigram instances
- 13,104,392 raw trigram instances
- 2,455,883 unique bigrams before private floor
- 5,796,137 unique trigrams before private floor
- 1,008,422 retained bigram rows
- 908,179 retained trigram rows
- 28,886 / 8,096 computationally public-eligible rows under preregistered suppression thresholds
- private SQLite SHA-256 `459a69ce856d68855272adfc481bcf631c7631ba2a91410f54edf25c35ad5c9f`
- gzip SHA-256 `ec5b5c92c65e18cc5a00611c87f1d9620153938b903000a6d72be723c6e95556`

**Co-occurrences**
- unordered distinct-term pairs, same page only, max window 5 tokens
- 64,208,256 raw positional pairs
- 10,426,262 unique pairs before private floor
- 52,653,670 unique pair-page relations
- 2,540,432 retained rows
- 81,451 computationally public-eligible rows under preregistered suppression thresholds
- private SQLite SHA-256 `ec6a6126ac425d2fffdcd92732c6abe62ab4f0bd8c360bc32da072674a5eccde`
- gzip SHA-256 `1694bbec7645821ceaccd9a135e4a1718944c8ab190d6b901930dcf536de488a`

Both compressed private artifacts were preserved in the canonical Drive Analytics vault and redownloaded with matching hashes.

### Methodological guards
- no OCR reread, no retokenization, no FTS5 rescan
- n-grams never cross page boundaries
- suppression thresholds were fixed before inspecting concrete phrase/pair values
- full term/sequence/pair values remain private
- eligibility is computational only and does not itself authorize literal publication
- `text_verified=false`, `semantic_ready=false`, default state `exploratory_signal`
- frequency is not semantic meaning; co-occurrence is not a semantic relation claim

### Contract correction caught before PR
Local preflight found that the first prepared public records did not match their JSON Schemas. This PR normalizes those as separate materialization records and CI now validates both records against their schemas, in addition to builder fixtures.

## Next canonical lane
After merge, move the project to **cross-corpus reuse/similarity** before additional verticals, staging or UI.