### PR TITLE
Analytics: consolidate U1 reuse and similarity layer

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -17,6 +17,7 @@ on:
       - 'scripts/build_u1_lexical_dimensions.py'
       - 'scripts/build_u1_ngrams.py'
       - 'scripts/build_u1_cooccurrences.py'
+      - 'scripts/build_u1_reuse_similarity.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
@@ -25,8 +26,10 @@ on:
       - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
       - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
       - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
+      - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
       - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -37,6 +40,7 @@ on:
       - 'tests/test_build_u1_lexical_dimensions.py'
       - 'tests/test_build_u1_ngrams.py'
       - 'tests/test_build_u1_cooccurrences.py'
+      - 'tests/test_build_u1_reuse_similarity.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -54,6 +58,7 @@ on:
       - 'scripts/build_u1_lexical_dimensions.py'
       - 'scripts/build_u1_ngrams.py'
       - 'scripts/build_u1_cooccurrences.py'
+      - 'scripts/build_u1_reuse_similarity.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
@@ -62,8 +67,10 @@ on:
       - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
       - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
       - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
+      - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
       - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -74,6 +81,7 @@ on:
       - 'tests/test_build_u1_lexical_dimensions.py'
       - 'tests/test_build_u1_ngrams.py'
       - 'tests/test_build_u1_cooccurrences.py'
+      - 'tests/test_build_u1_reuse_similarity.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -102,6 +110,7 @@ jobs:
           tests/test_build_u1_lexical_dimensions.py
           tests/test_build_u1_ngrams.py
           tests/test_build_u1_cooccurrences.py
+          tests/test_build_u1_reuse_similarity.py
       - name: Validate Analytics JSON schemas and materialization records
         run: |
           python - <<'PY'
@@ -116,6 +125,7 @@ jobs:
               'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json',
               'schemas/ltmd_u1_ngrams_public_summary.schema.json',
               'schemas/ltmd_u1_cooccurrences_public_summary.schema.json',
+              'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))
@@ -127,6 +137,8 @@ jobs:
                'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'),
               ('schemas/ltmd_u1_cooccurrences_public_summary.schema.json',
                'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'),
+              ('schemas/ltmd_u1_reuse_similarity_public_summary.schema.json',
+               'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'),
           ]
           for schema_path, data_path in validations:
               schema = json.load(open(schema_path, encoding='utf-8'))

--- a/data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json
@@ -1,0 +1,82 @@
+{
+  "artifact_version": "LTMD_U1_REUSE_SIMILARITY_0.1",
+  "builder_version": "LTMD_U1_REUSE_SIMILARITY_BUILDER_0.1",
+  "counts": {
+    "canonical_objects": 492,
+    "corpus_pages": 86549,
+    "exact_source_cross_generation_groups": 3150,
+    "exact_source_cross_object_groups": 3330,
+    "exact_source_object_pairs": 23,
+    "exact_source_repeated_groups": 3347,
+    "exact_text_cross_generation_groups": 2758,
+    "exact_text_cross_object_groups": 3001,
+    "exact_text_object_pairs": 998,
+    "exact_text_repeated_groups": 3013,
+    "lsh_distinct_nonexact_cross_object_candidates": 13965,
+    "lsh_raw_band_pair_occurrences": 105476,
+    "near_exact_candidates": 2994,
+    "similarity_candidates": 6152,
+    "similarity_cross_generation_pairs": 5138,
+    "similarity_cross_grade_pairs": 2577,
+    "similarity_cross_wave_pairs": 2706,
+    "similarity_object_pairs": 3867,
+    "similarity_shingle_eligible_pages": 65488,
+    "text_admissible_pages": 71274,
+    "text_excluded_low_information_pages": 15275,
+    "verified_similarity_candidates": 9146
+  },
+  "private_artifact": {
+    "bytes": 2101248,
+    "sha256": "4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301",
+    "gzip_bytes": 627270,
+    "gzip_sha256": "55deb1d63fd1299dc97f1b241522015ac8e1e11f119d8d43ead0bd9dea66b5f9",
+    "preserved_private": true,
+    "redownload_verified": true
+  },
+  "protocol": {
+    "exact_source_reuse": {
+      "basis": "source_sha256 equality",
+      "low_information_gate": false
+    },
+    "exact_text_representation_reuse": {
+      "basis": "search_text_sha256 equality",
+      "low_information_gate": true
+    },
+    "similarity": {
+      "cross_object_only": true,
+      "exact_jaccard_min": 0.8,
+      "exclude_exact_text_equality": true,
+      "lsh_bands": 12,
+      "lsh_rows": 8,
+      "min_distinct_shingles": 50,
+      "min_shared_shingles": 40,
+      "minhash_components": 96,
+      "near_exact_jaccard_min": 0.95,
+      "shingle_n": 5,
+      "thresholds_preregistered_before_candidate_inspection": true
+    },
+    "text_admissibility": {
+      "min_ocr_chars": 200,
+      "min_ocr_words": 30
+    }
+  },
+  "privacy": {
+    "candidate_pairs_emitted_publicly": false,
+    "object_identifiers_emitted_publicly": false,
+    "ocr_text_emitted_publicly": false,
+    "page_identifiers_emitted_publicly": false,
+    "source_hash_values_emitted_publicly": false,
+    "text_hash_values_emitted_publicly": false
+  },
+  "scientific_state": {
+    "default_result_state": "exploratory_signal",
+    "semantic_ready": false,
+    "similarity_creates_alias": false,
+    "similarity_is_semantic_equivalence": false,
+    "text_verified": false
+  },
+  "sources": {
+    "lexical_positions_sha256": "c57b30bf69acc0f38e406e45d23f37e5de59a4ec90f0fa9294de4c067512fd02",
+    "universal_index_sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2"
+  }
+}

--- a/docs/LTMD_U1_REUSE_SIMILARITY_0_1.md
+++ b/docs/LTMD_U1_REUSE_SIMILARITY_0_1.md
@@ -1,0 +1,34 @@
+# LTMD-U1 — reutilización y similitud transversal 0.1
+
+Versión: `LTMD_U1_REUSE_SIMILARITY_0.1`.
+
+Esta capa consolida señales corpus-wide para evitar confundir **repetición técnica/editorial** con cambio histórico. La jerarquía es deliberadamente estricta: igualdad criptográfica de fuente, igualdad de una representación textual técnica y similitud aproximada son evidencias distintas y nunca generan aliases por sí mismas.
+
+## Protocolo fijado antes de inspeccionar candidatos aproximados
+
+- `exact_source_reuse`: igualdad de `source_sha256`. Prueba igualdad de los bytes fuente representados por ese hash; no identidad bibliográfica ni equivalencia curricular.
+- `exact_text_representation_reuse`: igualdad de `search_text_sha256`, sólo en páginas con `ocr_char_count >= 200` y `ocr_word_count >= 30`. Las páginas vacías o de información insuficiente no cuentan como reutilización textual.
+- `similarity_candidate`: shingles de 5 tokens normalizados ya materializados en `LTMD_U1_LEXICAL_POSITIONS_0.1`; mínimo 50 shingles distintos; MinHash determinista de 96 componentes; LSH 12×8; sólo pares entre objetos canónicos distintos; igualdad textual exacta excluida; verificación exacta posterior de Jaccard ≥0.80 y al menos 40 shingles compartidos.
+- `near_exact_candidate`: mismo protocolo, con Jaccard ≥0.95.
+
+Los umbrales se fijaron antes de observar candidatos concretos y no se ajustan retrospectivamente.
+
+## Materialización U1 real
+
+Universo: 86,549 páginas y 492 objetos canónicos. 71,274 páginas superan el filtro de información textual y 15,275 quedan excluidas de las comparaciones textuales. 65,488 páginas tienen además al menos 50 shingles distintos para la capa aproximada.
+
+La capa exacta contiene 3,347 grupos repetidos de fuente, de los cuales 3,330 cruzan objetos canónicos; y 3,013 grupos repetidos de representación textual, de los cuales 3,001 cruzan objetos. La agregación por objetos produce 23 pares con igualdad de bytes fuente y 998 pares con alguna igualdad textual admisible.
+
+La búsqueda aproximada generó 13,965 pares LSH distintos, no exactos y entre objetos diferentes. La verificación exacta dejó 9,146 señales: 6,152 `similarity_candidate` y 2,994 `near_exact_candidate`, distribuidas entre 3,867 pares de objetos. Estas cifras describen señales computacionales, no equivalencias semánticas.
+
+## Privacidad y estado científico
+
+El SQLite privado contiene hashes, membresías de grupos, páginas y pares necesarios para que Analytics pueda advertir reutilización. GitHub no publica esos valores: sólo código, protocolo, cardinalidades, hashes del artefacto y estados epistemológicos.
+
+`text_verified=false`, `semantic_ready=false`, estado por defecto `exploratory_signal`. `similarity_candidate` nunca crea aliases y no implica identidad bibliográfica, equivalencia curricular, relación pedagógica, relación semántica ni afirmación histórica.
+
+El artefacto privado pasó `quick_check=ok`, fue comprimido, archivado en la bóveda Analytics canónica de Drive y redescargado; el SHA-256 de la copia coincide tanto en su gzip como al descomprimir el SQLite lógico.
+
+## Reentrada
+
+Con esta capa cerrada, la ruta corpus-wide pasa a **verticales exploratorios**. Staging real continúa después de esa integración, no antes.

--- a/schemas/ltmd_u1_reuse_similarity_public_summary.schema.json
+++ b/schemas/ltmd_u1_reuse_similarity_public_summary.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LTMD-U1 reuse/similarity public-safe materialization record 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["artifact_version","builder_version","counts","private_artifact","protocol","privacy","scientific_state","sources"],
+  "properties": {
+    "artifact_version": {"const":"LTMD_U1_REUSE_SIMILARITY_0.1"},
+    "builder_version": {"const":"LTMD_U1_REUSE_SIMILARITY_BUILDER_0.1"},
+    "counts": {"type":"object","additionalProperties":{"type":"integer","minimum":0}},
+    "private_artifact": {
+      "type":"object","additionalProperties":false,
+      "required":["bytes","sha256","gzip_bytes","gzip_sha256","preserved_private","redownload_verified"],
+      "properties": {
+        "bytes":{"type":"integer","minimum":1},
+        "sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "gzip_bytes":{"type":"integer","minimum":1},
+        "gzip_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "preserved_private":{"const":true},
+        "redownload_verified":{"const":true}
+      }
+    },
+    "protocol": {
+      "type":"object","additionalProperties":false,
+      "required":["exact_source_reuse","exact_text_representation_reuse","similarity","text_admissibility"],
+      "properties": {
+        "exact_source_reuse":{"type":"object","additionalProperties":false,"required":["basis","low_information_gate"],"properties":{"basis":{"const":"source_sha256 equality"},"low_information_gate":{"const":false}}},
+        "exact_text_representation_reuse":{"type":"object","additionalProperties":false,"required":["basis","low_information_gate"],"properties":{"basis":{"const":"search_text_sha256 equality"},"low_information_gate":{"const":true}}},
+        "text_admissibility":{"type":"object","additionalProperties":false,"required":["min_ocr_chars","min_ocr_words"],"properties":{"min_ocr_chars":{"const":200},"min_ocr_words":{"const":30}}},
+        "similarity": {
+          "type":"object","additionalProperties":false,
+          "required":["cross_object_only","exact_jaccard_min","exclude_exact_text_equality","lsh_bands","lsh_rows","min_distinct_shingles","min_shared_shingles","minhash_components","near_exact_jaccard_min","shingle_n","thresholds_preregistered_before_candidate_inspection"],
+          "properties": {
+            "cross_object_only":{"const":true},"exact_jaccard_min":{"const":0.8},"exclude_exact_text_equality":{"const":true},
+            "lsh_bands":{"const":12},"lsh_rows":{"const":8},"min_distinct_shingles":{"const":50},"min_shared_shingles":{"const":40},
+            "minhash_components":{"const":96},"near_exact_jaccard_min":{"const":0.95},"shingle_n":{"const":5},
+            "thresholds_preregistered_before_candidate_inspection":{"const":true}
+          }
+        }
+      }
+    },
+    "privacy": {
+      "type":"object","additionalProperties":false,
+      "required":["candidate_pairs_emitted_publicly","object_identifiers_emitted_publicly","ocr_text_emitted_publicly","page_identifiers_emitted_publicly","source_hash_values_emitted_publicly","text_hash_values_emitted_publicly"],
+      "properties": {
+        "candidate_pairs_emitted_publicly":{"const":false},"object_identifiers_emitted_publicly":{"const":false},"ocr_text_emitted_publicly":{"const":false},
+        "page_identifiers_emitted_publicly":{"const":false},"source_hash_values_emitted_publicly":{"const":false},"text_hash_values_emitted_publicly":{"const":false}
+      }
+    },
+    "scientific_state": {
+      "type":"object","additionalProperties":false,
+      "required":["default_result_state","semantic_ready","similarity_creates_alias","similarity_is_semantic_equivalence","text_verified"],
+      "properties": {
+        "default_result_state":{"const":"exploratory_signal"},"semantic_ready":{"const":false},"similarity_creates_alias":{"const":false},
+        "similarity_is_semantic_equivalence":{"const":false},"text_verified":{"const":false}
+      }
+    },
+    "sources": {
+      "type":"object","additionalProperties":false,"required":["lexical_positions_sha256","universal_index_sha256"],
+      "properties":{"lexical_positions_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"}}
+    }
+  }
+}

--- a/scripts/build_u1_reuse_similarity.py
+++ b/scripts/build_u1_reuse_similarity.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python3
+"""Build LTMD-U1 cross-corpus reuse/similarity private analytics layer.
+
+Version: LTMD_U1_REUSE_SIMILARITY_BUILDER_0.1
+
+Evidence hierarchy is deliberately separated:
+- exact_source_reuse: equality of source_sha256 (byte-representation evidence)
+- exact_text_representation_reuse: equality of search_text_sha256 after fixed low-information gate
+- similarity_candidate: approximate normalized-token resemblance, verified by exact 5-shingle Jaccard
+
+No layer creates aliases or establishes bibliographic, curricular, pedagogical, historical,
+or semantic equivalence.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sqlite3
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+BUILDER_VERSION = "LTMD_U1_REUSE_SIMILARITY_BUILDER_0.1"
+ARTIFACT_VERSION = "LTMD_U1_REUSE_SIMILARITY_0.1"
+INDEX_VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+LEXICAL_VERSION = "LTMD_U1_LEXICAL_POSITIONS_0.1"
+SHA256_RE = re.compile(r"^[a-f0-9]{64}$")
+
+TEXT_MIN_CHARS = 200
+TEXT_MIN_WORDS = 30
+SHINGLE_N = 5
+MIN_DISTINCT_SHINGLES = 50
+MINHASH_COMPONENTS = 96
+LSH_BANDS = 12
+LSH_ROWS = 8
+SIMILARITY_MIN_JACCARD = 0.80
+NEAR_EXACT_MIN_JACCARD = 0.95
+SIMILARITY_MIN_SHARED_SHINGLES = 40
+
+TERM_BITS = 18
+SHINGLE_COEFF = np.array([
+    0x9E3779B185EBCA87,
+    0xC2B2AE3D27D4EB4F,
+    0x165667B19E3779F9,
+    0x85EBCA77C2B2AE63,
+    0x27D4EB2F165667C5,
+], dtype=np.uint64)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_sha(path: Path, expected: str | None, label: str) -> str | None:
+    if not path.is_file():
+        raise RuntimeError(f"{label} artifact is unavailable")
+    if expected is None:
+        return None
+    exp = expected.strip().lower()
+    if not SHA256_RE.fullmatch(exp):
+        raise RuntimeError(f"expected {label} SHA-256 is invalid")
+    actual = sha256_file(path)
+    if actual != exp:
+        raise RuntimeError(f"{label} SHA-256 mismatch")
+    return actual
+
+
+def _decode_json(raw: str):
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def load_index_meta(c: sqlite3.Connection) -> dict:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")}
+    if not {"pages", "index_meta"}.issubset(tables):
+        raise RuntimeError("not an LTMD Universal Index")
+    meta = {k: _decode_json(v) for k, v in c.execute("SELECT key,value FROM index_meta")}
+    if meta.get("builder_version") != INDEX_VERSION:
+        raise RuntimeError("unsupported Universal Index version")
+    return meta
+
+
+def load_lexical_meta(c: sqlite3.Connection) -> dict:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    required = {"meta", "pages", "terms", "token_positions"}
+    if not required.issubset(tables):
+        raise RuntimeError("not an LTMD lexical-position artifact")
+    meta = {k: _decode_json(v) for k, v in c.execute("SELECT key,value FROM meta")}
+    version = meta.get("artifact_version", meta.get("version"))
+    if version != LEXICAL_VERSION:
+        raise RuntimeError("unsupported lexical-position artifact version")
+    return meta
+
+
+def _splitmix64(x):
+    x = np.asarray(x, dtype=np.uint64)
+    z = x + np.uint64(0x9E3779B97F4A7C15)
+    z = (z ^ (z >> np.uint64(30))) * np.uint64(0xBF58476D1CE4E5B9)
+    z = (z ^ (z >> np.uint64(27))) * np.uint64(0x94D049BB133111EB)
+    return z ^ (z >> np.uint64(31))
+
+
+MINHASH_SALTS = _splitmix64(np.arange(MINHASH_COMPONENTS, dtype=np.uint64) + np.uint64(0x1234ABCD))
+
+
+def shingle_hashes(terms, offsets) -> np.ndarray:
+    a = np.asarray(terms, dtype=np.uint64)
+    o = np.asarray(offsets, dtype=np.int64)
+    if a.size < SHINGLE_N:
+        return np.empty(0, dtype=np.uint64)
+    valid = (
+        (o[1:-3] == o[:-4] + 1)
+        & (o[2:-2] == o[:-4] + 2)
+        & (o[3:-1] == o[:-4] + 3)
+        & (o[4:] == o[:-4] + 4)
+    )
+    if not np.any(valid):
+        return np.empty(0, dtype=np.uint64)
+    x = (
+        (a[:-4] * SHINGLE_COEFF[0])
+        ^ (a[1:-3] * SHINGLE_COEFF[1])
+        ^ (a[2:-2] * SHINGLE_COEFF[2])
+        ^ (a[3:-1] * SHINGLE_COEFF[3])
+        ^ (a[4:] * SHINGLE_COEFF[4])
+    )
+    return np.unique(_splitmix64(x[valid]))
+
+
+def minhash_signature(shingles: np.ndarray) -> np.ndarray:
+    sig = np.empty(MINHASH_COMPONENTS, dtype=np.uint64)
+    for start in range(0, MINHASH_COMPONENTS, 12):
+        salts = MINHASH_SALTS[start : start + 12, None]
+        sig[start : start + 12] = _splitmix64(shingles[None, :] ^ salts).min(axis=1)
+    return sig
+
+
+def _remove_sqlite_family(path: Path) -> None:
+    for p in (path, Path(str(path) + "-wal"), Path(str(path) + "-shm")):
+        if p.exists():
+            p.unlink()
+
+
+def _create_output(path: Path) -> sqlite3.Connection:
+    out = sqlite3.connect(path, timeout=120)
+    out.executescript("""
+    PRAGMA journal_mode=WAL;
+    PRAGMA synchronous=NORMAL;
+    PRAGMA cache_size=-200000;
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
+    CREATE TABLE objects(object_id INTEGER PRIMARY KEY, canonical_viewer_key TEXT NOT NULL UNIQUE);
+    CREATE TABLE exact_source_groups(
+        group_id INTEGER PRIMARY KEY, hash TEXT NOT NULL UNIQUE, page_count INTEGER NOT NULL,
+        object_count INTEGER NOT NULL, generation_count INTEGER NOT NULL,
+        cross_object INTEGER NOT NULL, cross_generation INTEGER NOT NULL);
+    CREATE TABLE exact_source_members(
+        group_id INTEGER NOT NULL,page_rowid INTEGER NOT NULL,object_id INTEGER NOT NULL,generation INTEGER,
+        PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
+    CREATE TABLE exact_text_groups(
+        group_id INTEGER PRIMARY KEY, hash TEXT NOT NULL UNIQUE, page_count INTEGER NOT NULL,
+        object_count INTEGER NOT NULL, generation_count INTEGER NOT NULL,grade_count INTEGER NOT NULL,
+        wave_count INTEGER NOT NULL,cross_object INTEGER NOT NULL,cross_generation INTEGER NOT NULL);
+    CREATE TABLE exact_text_members(
+        group_id INTEGER NOT NULL,page_rowid INTEGER NOT NULL,object_id INTEGER NOT NULL,generation INTEGER,
+        PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
+    CREATE TABLE exact_object_pairs(
+        evidence_type TEXT NOT NULL,object_a INTEGER NOT NULL,object_b INTEGER NOT NULL,
+        shared_groups INTEGER NOT NULL,PRIMARY KEY(evidence_type,object_a,object_b)) WITHOUT ROWID;
+    CREATE TABLE similarity_candidates(
+        page_a INTEGER NOT NULL,page_b INTEGER NOT NULL,object_a INTEGER NOT NULL,object_b INTEGER NOT NULL,
+        jaccard REAL NOT NULL,shared_shingles INTEGER NOT NULL,shingles_a INTEGER NOT NULL,shingles_b INTEGER NOT NULL,
+        tier TEXT NOT NULL,PRIMARY KEY(page_a,page_b)) WITHOUT ROWID;
+    CREATE TABLE similarity_object_pairs(
+        object_a INTEGER NOT NULL,object_b INTEGER NOT NULL,candidate_pairs INTEGER NOT NULL,
+        near_exact_pairs INTEGER NOT NULL,max_jaccard REAL NOT NULL,
+        PRIMARY KEY(object_a,object_b)) WITHOUT ROWID;
+    """)
+    return out
+
+
+def _object_maps(index: sqlite3.Connection):
+    keys = [r[0] for r in index.execute("SELECT DISTINCT canonical_viewer_key FROM pages ORDER BY canonical_viewer_key")]
+    key_to_id = {k: i + 1 for i, k in enumerate(keys)}
+    return keys, key_to_id
+
+
+def _materialize_exact(index, out, key_to_id):
+    source_groups = list(index.execute("""
+        SELECT source_sha256,COUNT(*),COUNT(DISTINCT canonical_viewer_key),COUNT(DISTINCT catalog_generation)
+        FROM pages GROUP BY source_sha256 HAVING COUNT(*)>=2 ORDER BY source_sha256
+    """))
+    source_gid = {h: gid for gid,(h,*_) in enumerate(source_groups,1)}
+    out.executemany(
+        "INSERT INTO exact_source_groups VALUES(?,?,?,?,?,?,?)",
+        ((gid,h,pages,objects,generations,int(objects>=2),int(generations>=2))
+         for gid,(h,pages,objects,generations) in enumerate(source_groups,1))
+    )
+    rows = index.execute("""
+        WITH repeated AS (
+          SELECT source_sha256 h FROM pages GROUP BY source_sha256 HAVING COUNT(*)>=2
+        )
+        SELECT p.source_sha256,p.id,p.canonical_viewer_key,p.catalog_generation
+        FROM pages p JOIN repeated r ON r.h=p.source_sha256
+        ORDER BY p.source_sha256,p.id
+    """)
+    out.executemany(
+        "INSERT INTO exact_source_members VALUES(?,?,?,?)",
+        ((source_gid[h],pid,key_to_id[obj],gen) for h,pid,obj,gen in rows)
+    )
+    out.commit()
+
+    text_groups = list(index.execute(f"""
+        SELECT search_text_sha256,COUNT(*),COUNT(DISTINCT canonical_viewer_key),COUNT(DISTINCT catalog_generation),
+               COUNT(DISTINCT grade_code),COUNT(DISTINCT wave)
+        FROM pages
+        WHERE ocr_char_count>={TEXT_MIN_CHARS} AND ocr_word_count>={TEXT_MIN_WORDS}
+        GROUP BY search_text_sha256 HAVING COUNT(*)>=2 ORDER BY search_text_sha256
+    """))
+    text_gid = {h: gid for gid,(h,*_) in enumerate(text_groups,1)}
+    out.executemany(
+        "INSERT INTO exact_text_groups VALUES(?,?,?,?,?,?,?,?,?)",
+        ((gid,h,pages,objects,generations,grades,waves,int(objects>=2),int(generations>=2))
+         for gid,(h,pages,objects,generations,grades,waves) in enumerate(text_groups,1))
+    )
+    rows = index.execute(f"""
+        WITH repeated AS (
+          SELECT search_text_sha256 h
+          FROM pages
+          WHERE ocr_char_count>={TEXT_MIN_CHARS} AND ocr_word_count>={TEXT_MIN_WORDS}
+          GROUP BY search_text_sha256 HAVING COUNT(*)>=2
+        )
+        SELECT p.search_text_sha256,p.id,p.canonical_viewer_key,p.catalog_generation
+        FROM pages p JOIN repeated r ON r.h=p.search_text_sha256
+        WHERE p.ocr_char_count>={TEXT_MIN_CHARS} AND p.ocr_word_count>={TEXT_MIN_WORDS}
+        ORDER BY p.search_text_sha256,p.id
+    """)
+    out.executemany(
+        "INSERT INTO exact_text_members VALUES(?,?,?,?)",
+        ((text_gid[h],pid,key_to_id[obj],gen) for h,pid,obj,gen in rows)
+    )
+    out.commit()
+
+    for evidence, table in (("exact_source_reuse","exact_source_members"),("exact_text_representation_reuse","exact_text_members")):
+        out.execute(f"""
+            INSERT INTO exact_object_pairs
+            SELECT ?,a.object_id,b.object_id,COUNT(DISTINCT a.group_id)
+            FROM {table} a JOIN {table} b ON a.group_id=b.group_id AND a.object_id<b.object_id
+            GROUP BY a.object_id,b.object_id
+        """, (evidence,))
+    out.commit()
+
+def _similarity_inputs(index, lexical, key_to_id):
+    max_page = int(index.execute("SELECT MAX(id) FROM pages").fetchone()[0])
+    eligible = np.zeros(max_page + 1, dtype=bool)
+    search_hash = np.empty(max_page + 1, dtype=object)
+    page_object = np.zeros(max_page + 1, dtype=np.uint16)
+    page_generation = np.zeros(max_page + 1, dtype=np.int16)
+    page_grade = np.full(max_page + 1, -1, dtype=np.int16)
+    wave_values = sorted({r[0] for r in index.execute("SELECT DISTINCT wave FROM pages WHERE wave IS NOT NULL")})
+    wave_code_map = {v:i for i,v in enumerate(wave_values)}
+    page_wave = np.full(max_page + 1, -1, dtype=np.int16)
+    for pid,obj,gen,grade,wave,h in index.execute(f"""
+        SELECT id,canonical_viewer_key,catalog_generation,grade_code,wave,search_text_sha256
+        FROM pages WHERE ocr_char_count>={TEXT_MIN_CHARS} AND ocr_word_count>={TEXT_MIN_WORDS}
+    """):
+        eligible[pid] = True
+        page_object[pid] = key_to_id[obj]
+        page_generation[pid] = gen if gen is not None else -1
+        page_grade[pid] = grade if grade is not None else -1
+        page_wave[pid] = wave_code_map.get(wave,-1)
+        search_hash[pid] = h
+
+    page_ids=[]; objects=[]; shingle_sets=[]; signatures=[]
+    last=None; terms=[]; offsets=[]
+    def flush(pid, terms, offsets):
+        if pid is None or not eligible[pid]:
+            return
+        sh = shingle_hashes(terms, offsets)
+        if sh.size < MIN_DISTINCT_SHINGLES:
+            return
+        page_ids.append(pid); objects.append(int(page_object[pid])); shingle_sets.append(sh); signatures.append(minhash_signature(sh))
+    for pid,term,offset in lexical.execute("SELECT page_rowid,term_id,token_offset FROM token_positions ORDER BY page_rowid,token_offset"):
+        if last is None: last=pid
+        if pid!=last:
+            flush(last,terms,offsets); last=pid; terms=[]; offsets=[]
+        terms.append(term); offsets.append(offset)
+    flush(last,terms,offsets)
+    return (
+        np.asarray(page_ids,dtype=np.uint32),np.asarray(objects,dtype=np.uint16),shingle_sets,
+        np.vstack(signatures) if signatures else np.empty((0,MINHASH_COMPONENTS),dtype=np.uint64),
+        search_hash,page_generation,page_grade,page_wave,
+    )
+
+
+def _lsh_candidates(page_ids, objects, signatures, search_hash):
+    candidates=set(); raw_band_pair_occurrences=0
+    for band in range(LSH_BANDS):
+        arr=np.ascontiguousarray(signatures[:,band*LSH_ROWS:(band+1)*LSH_ROWS])
+        keys=arr.view(np.dtype((np.void,arr.dtype.itemsize*LSH_ROWS))).ravel()
+        order=np.argsort(keys,kind="stable"); sorted_keys=keys[order]
+        starts=np.r_[0,np.flatnonzero(sorted_keys[1:]!=sorted_keys[:-1])+1]
+        ends=np.r_[starts[1:],len(sorted_keys)]
+        for start,end in zip(starts,ends):
+            if end-start<2: continue
+            inds=order[start:end]
+            for i in range(len(inds)-1):
+                a=inds[i]
+                for j in range(i+1,len(inds)):
+                    b=inds[j]; raw_band_pair_occurrences+=1
+                    if objects[a]==objects[b]: continue
+                    pa,pb=int(page_ids[a]),int(page_ids[b])
+                    if search_hash[pa] == search_hash[pb]:
+                        continue
+                    if pa>pb: pa,pb=pb,pa
+                    candidates.add((pa,pb))
+    return raw_band_pair_occurrences, sorted(candidates)
+
+
+def _verify_similarity(page_ids, objects, shingle_sets, candidates, page_generation, page_grade, page_wave):
+    page_index={int(pid):i for i,pid in enumerate(page_ids)}
+    results=[]
+    cross_generation=cross_grade=cross_wave=0
+    for pa,pb in candidates:
+        ia,ib=page_index[pa],page_index[pb]
+        a,b=shingle_sets[ia],shingle_sets[ib]
+        if min(len(a),len(b))/max(len(a),len(b)) < SIMILARITY_MIN_JACCARD:
+            continue
+        shared=int(np.intersect1d(a,b,assume_unique=True).size)
+        union=len(a)+len(b)-shared
+        jaccard=shared/union if union else 0.0
+        if jaccard < SIMILARITY_MIN_JACCARD or shared < SIMILARITY_MIN_SHARED_SHINGLES:
+            continue
+        tier="near_exact_candidate" if jaccard>=NEAR_EXACT_MIN_JACCARD else "similarity_candidate"
+        oa,ob=int(objects[ia]),int(objects[ib])
+        results.append((pa,pb,oa,ob,jaccard,shared,len(a),len(b),tier))
+        cross_generation += int(page_generation[pa]!=page_generation[pb])
+        cross_grade += int(page_grade[pa]!=page_grade[pb])
+        cross_wave += int(page_wave[pa]!=page_wave[pb])
+    return results,cross_generation,cross_grade,cross_wave
+
+
+def build(index_path: Path, lexical_path: Path, output_path: Path, *, overwrite=False):
+    index_path=index_path.expanduser().resolve(); lexical_path=lexical_path.expanduser().resolve(); output_path=output_path.expanduser().resolve()
+    if output_path.exists() and not overwrite:
+        raise RuntimeError("output already exists; pass --overwrite to replace it")
+    if overwrite: _remove_sqlite_family(output_path)
+    output_path.parent.mkdir(parents=True,exist_ok=True)
+    index=sqlite3.connect(f"file:{index_path}?mode=ro",uri=True,timeout=120)
+    lexical=sqlite3.connect(f"file:{lexical_path}?mode=ro",uri=True,timeout=120)
+    try:
+        imeta=load_index_meta(index); lmeta=load_lexical_meta(lexical)
+        if int(imeta.get("unique_pages",0)) != int(lmeta.get("unique_pages",0)):
+            raise RuntimeError("Universal Index and lexical artifact page counts differ")
+        keys,key_to_id=_object_maps(index)
+        out=_create_output(output_path)
+        try:
+            out.executemany("INSERT INTO objects VALUES(?,?)",((i+1,k) for i,k in enumerate(keys))); out.commit()
+            _materialize_exact(index,out,key_to_id)
+            page_ids,objects,shingles,signatures,search_hash,pgen,pgrade,pwave=_similarity_inputs(index,lexical,key_to_id)
+            raw_band_pairs,candidates=_lsh_candidates(page_ids,objects,signatures,search_hash)
+            verified,cross_gen,cross_grade,cross_wave=_verify_similarity(page_ids,objects,shingles,candidates,pgen,pgrade,pwave)
+            out.executemany("INSERT INTO similarity_candidates VALUES(?,?,?,?,?,?,?,?,?)",verified); out.commit()
+            pair_agg=defaultdict(lambda:[0,0,0.0])
+            for _,_,oa,ob,j,_,_,_,tier in verified:
+                if oa>ob: oa,ob=ob,oa
+                rec=pair_agg[(oa,ob)]; rec[0]+=1; rec[1]+=int(tier=="near_exact_candidate"); rec[2]=max(rec[2],j)
+            out.executemany("INSERT INTO similarity_object_pairs VALUES(?,?,?,?,?)",
+                            ((oa,ob,v[0],v[1],v[2]) for (oa,ob),v in sorted(pair_agg.items()))); out.commit()
+
+            admitted_pages=int(index.execute(f"SELECT COUNT(*) FROM pages WHERE ocr_char_count>={TEXT_MIN_CHARS} AND ocr_word_count>={TEXT_MIN_WORDS}").fetchone()[0])
+            counts={
+                "corpus_pages":int(index.execute("SELECT COUNT(*) FROM pages").fetchone()[0]),
+                "canonical_objects":len(keys),
+                "text_admissible_pages":admitted_pages,
+                "text_excluded_low_information_pages":int(index.execute("SELECT COUNT(*) FROM pages").fetchone()[0])-admitted_pages,
+                "exact_source_repeated_groups":int(out.execute("SELECT COUNT(*) FROM exact_source_groups").fetchone()[0]),
+                "exact_source_cross_object_groups":int(out.execute("SELECT COUNT(*) FROM exact_source_groups WHERE cross_object=1").fetchone()[0]),
+                "exact_source_cross_generation_groups":int(out.execute("SELECT COUNT(*) FROM exact_source_groups WHERE cross_generation=1").fetchone()[0]),
+                "exact_source_object_pairs":int(out.execute("SELECT COUNT(*) FROM exact_object_pairs WHERE evidence_type='exact_source_reuse'").fetchone()[0]),
+                "exact_text_repeated_groups":int(out.execute("SELECT COUNT(*) FROM exact_text_groups").fetchone()[0]),
+                "exact_text_cross_object_groups":int(out.execute("SELECT COUNT(*) FROM exact_text_groups WHERE cross_object=1").fetchone()[0]),
+                "exact_text_cross_generation_groups":int(out.execute("SELECT COUNT(*) FROM exact_text_groups WHERE cross_generation=1").fetchone()[0]),
+                "exact_text_object_pairs":int(out.execute("SELECT COUNT(*) FROM exact_object_pairs WHERE evidence_type='exact_text_representation_reuse'").fetchone()[0]),
+                "similarity_shingle_eligible_pages":len(page_ids),
+                "lsh_raw_band_pair_occurrences":raw_band_pairs,
+                "lsh_distinct_nonexact_cross_object_candidates":len(candidates),
+                "verified_similarity_candidates":len(verified),
+                "similarity_candidates":sum(v[-1]=="similarity_candidate" for v in verified),
+                "near_exact_candidates":sum(v[-1]=="near_exact_candidate" for v in verified),
+                "similarity_object_pairs":len(pair_agg),
+                "similarity_cross_generation_pairs":cross_gen,
+                "similarity_cross_grade_pairs":cross_grade,
+                "similarity_cross_wave_pairs":cross_wave,
+            }
+            protocol={
+                "text_admissibility":{"min_ocr_chars":TEXT_MIN_CHARS,"min_ocr_words":TEXT_MIN_WORDS},
+                "exact_source_reuse":{"basis":"source_sha256 equality","low_information_gate":False},
+                "exact_text_representation_reuse":{"basis":"search_text_sha256 equality","low_information_gate":True},
+                "similarity":{"shingle_n":SHINGLE_N,"min_distinct_shingles":MIN_DISTINCT_SHINGLES,
+                    "minhash_components":MINHASH_COMPONENTS,"lsh_bands":LSH_BANDS,"lsh_rows":LSH_ROWS,
+                    "exact_jaccard_min":SIMILARITY_MIN_JACCARD,"near_exact_jaccard_min":NEAR_EXACT_MIN_JACCARD,
+                    "min_shared_shingles":SIMILARITY_MIN_SHARED_SHINGLES,"cross_object_only":True,
+                    "exclude_exact_text_equality":True,"thresholds_preregistered_before_candidate_inspection":True},
+            }
+            metadata={"builder_version":BUILDER_VERSION,"artifact_version":ARTIFACT_VERSION,**counts,
+                      "protocol":protocol,"private":True,"text_verified":False,"semantic_ready":False,
+                      "default_result_state":"exploratory_signal","similarity_creates_alias":False,
+                      "similarity_is_semantic_equivalence":False}
+            for k,v in metadata.items(): out.execute("INSERT INTO meta VALUES(?,?)",(k,json.dumps(v,ensure_ascii=False,sort_keys=True)))
+            out.commit()
+            if out.execute("PRAGMA quick_check").fetchone()[0] != "ok": raise RuntimeError("reuse/similarity artifact quick_check failed")
+            out.execute("PRAGMA wal_checkpoint(TRUNCATE)"); out.execute("PRAGMA journal_mode=DELETE"); out.commit()
+        finally: out.close()
+    finally: index.close(); lexical.close()
+    return {"builder_version":BUILDER_VERSION,"artifact_version":ARTIFACT_VERSION,"counts":counts,"protocol":protocol,
+            "private_artifact":{"bytes":output_path.stat().st_size,"sha256":sha256_file(output_path),"publish":False},
+            "privacy":{"source_hash_values_emitted_publicly":False,"text_hash_values_emitted_publicly":False,
+                       "page_identifiers_emitted_publicly":False,"object_identifiers_emitted_publicly":False,
+                       "candidate_pairs_emitted_publicly":False,"ocr_text_emitted_publicly":False},
+            "scientific_state":{"text_verified":False,"semantic_ready":False,"default_result_state":"exploratory_signal",
+                                "similarity_creates_alias":False,"similarity_is_semantic_equivalence":False}}
+
+
+def run(index_path,lexical_path,output_path,*,expected_index_sha256=None,expected_lexical_sha256=None,overwrite=False):
+    idx_sha=verify_sha(index_path,expected_index_sha256,"Universal Index")
+    lex_sha=verify_sha(lexical_path,expected_lexical_sha256,"lexical-position")
+    result=build(index_path,lexical_path,output_path,overwrite=overwrite)
+    result["sources"]={"universal_index_sha256":idx_sha,"lexical_positions_sha256":lex_sha}
+    return result
+
+
+def main(argv=None):
+    p=argparse.ArgumentParser(); p.add_argument("--index",required=True); p.add_argument("--lexical",required=True); p.add_argument("--output",required=True)
+    p.add_argument("--summary"); p.add_argument("--expected-index-sha256"); p.add_argument("--expected-lexical-sha256"); p.add_argument("--overwrite",action="store_true")
+    a=p.parse_args(argv)
+    result=run(Path(a.index),Path(a.lexical),Path(a.output),expected_index_sha256=a.expected_index_sha256,expected_lexical_sha256=a.expected_lexical_sha256,overwrite=a.overwrite)
+    payload=json.dumps(result,ensure_ascii=False,indent=2,sort_keys=True)+"\n"
+    if a.summary: Path(a.summary).write_text(payload,encoding="utf-8")
+    else: print(payload,end="")
+    return 0
+
+if __name__=="__main__": raise SystemExit(main())

--- a/tests/test_build_u1_reuse_similarity.py
+++ b/tests/test_build_u1_reuse_similarity.py
@@ -1,0 +1,72 @@
+import importlib.util, json, sqlite3
+from pathlib import Path
+
+SCRIPT=Path(__file__).parents[1] / 'scripts' / 'build_u1_reuse_similarity.py'
+SPEC=importlib.util.spec_from_file_location('reuse',SCRIPT); mod=importlib.util.module_from_spec(SPEC); SPEC.loader.exec_module(mod)
+
+def make_fixture(root:Path):
+    idx=root/'idx.sqlite'; lex=root/'lex.sqlite'
+    c=sqlite3.connect(idx)
+    c.executescript('''
+    CREATE TABLE index_meta(key TEXT PRIMARY KEY,value TEXT NOT NULL);
+    CREATE TABLE pages(
+      id INTEGER PRIMARY KEY,page_id TEXT,viewer_key TEXT,canonical_viewer_key TEXT,wave TEXT,catalog_generation INTEGER,grade_code INTEGER,title_core TEXT,page_index INTEGER,viewer_page INTEGER,
+      source_asset_url TEXT,source_sha256 TEXT,source_byte_size INTEGER,ocr_engine TEXT,ocr_engine_version TEXT,ocr_language TEXT,ocr_psm INTEGER,ocr_sha256 TEXT,search_text TEXT,search_text_sha256 TEXT,
+      ocr_confidence_mean REAL,ocr_char_count INTEGER,ocr_word_count INTEGER,generated_at TEXT);
+    ''')
+    c.execute('INSERT INTO index_meta VALUES(?,?)',('builder_version',json.dumps(mod.INDEX_VERSION)))
+    c.execute('INSERT INTO index_meta VALUES(?,?)',('unique_pages',json.dumps(5)))
+    rows=[]
+    specs=[
+      (1,'A',1993,5,'W1','src1','txtExact',400,80),
+      (2,'B',2014,6,'W2','src2','txtExact',410,82),
+      (3,'A',1993,5,'W1','src3','txt3',500,100),
+      (4,'B',2014,6,'W2','src4','txt4',510,101),
+      (5,'B',2014,6,'W2','src5','emptyHash',0,0),
+    ]
+    for pid,obj,gen,grade,wave,src,txt,chars,words in specs:
+      rows.append((pid,f'p{pid}',f'v{pid}',obj,wave,gen,grade,'T',pid,pid,'u',src,1,'e','1','spa',6,'ocr'+str(pid),'x',txt,1.0,chars,words,'now'))
+    c.executemany('INSERT INTO pages VALUES('+','.join('?'*24)+')',rows); c.commit(); c.close()
+
+    c=sqlite3.connect(lex)
+    c.executescript('''
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL);
+    CREATE TABLE terms(term_id INTEGER PRIMARY KEY,term TEXT,page_count INTEGER,occurrence_count INTEGER);
+    CREATE TABLE pages(page_rowid INTEGER PRIMARY KEY,object_id INTEGER,generation INTEGER,grade_code INTEGER,wave TEXT);
+    CREATE TABLE token_positions(term_id INTEGER,page_rowid INTEGER,token_offset INTEGER);
+    ''')
+    for k,v in {'artifact_version':mod.LEXICAL_VERSION,'unique_pages':5}.items(): c.execute('INSERT INTO meta VALUES(?,?)',(k,json.dumps(v)))
+    c.executemany('INSERT INTO terms VALUES(?,?,?,?)',[(i,f't{i}',5,10) for i in range(1,201)])
+    c.executemany('INSERT INTO pages VALUES(?,?,?,?,?)',[(1,1,1993,5,'W1'),(2,2,2014,6,'W2'),(3,1,1993,5,'W1'),(4,2,2014,6,'W2'),(5,2,2014,6,'W2')])
+    seq1=list(range(1,81)); seq2=list(range(1,81)); seq3=list(range(1,101)); seq4=list(range(1,91))+list(range(101,111)); seq5=list(range(1,10))
+    pos=[]
+    for pid,seq in enumerate([seq1,seq2,seq3,seq4,seq5],1): pos.extend((t,pid,o) for o,t in enumerate(seq))
+    c.executemany('INSERT INTO token_positions VALUES(?,?,?)',pos); c.commit(); c.close()
+    return idx,lex
+
+def test_hierarchy_and_privacy(tmp_path):
+    idx,lex=make_fixture(tmp_path); out=tmp_path/'out.sqlite'
+    summary=mod.run(idx,lex,out)
+    assert summary['counts']['text_admissible_pages']==4
+    c=sqlite3.connect(out)
+    assert c.execute("SELECT COUNT(*) FROM exact_text_groups WHERE cross_object=1").fetchone()[0]==1
+    assert c.execute("SELECT COUNT(*) FROM similarity_candidates WHERE object_a!=object_b").fetchone()[0]>=1
+    assert c.execute('SELECT COUNT(*) FROM similarity_candidates s JOIN exact_text_members a ON s.page_a=a.page_rowid JOIN exact_text_members b ON s.page_b=b.page_rowid AND a.group_id=b.group_id').fetchone()[0]==0
+    assert c.execute('PRAGMA quick_check').fetchone()[0]=='ok'; c.close()
+    rendered=json.dumps(summary)
+    assert 'txtExact' not in rendered and 'page_rowid' not in rendered
+    assert summary['scientific_state']['similarity_creates_alias'] is False
+
+def test_protocol_frozen():
+    assert (mod.TEXT_MIN_CHARS,mod.TEXT_MIN_WORDS)==(200,30)
+    assert (mod.SHINGLE_N,mod.MIN_DISTINCT_SHINGLES)==(5,50)
+    assert (mod.MINHASH_COMPONENTS,mod.LSH_BANDS,mod.LSH_ROWS)==(96,12,8)
+    assert mod.SIMILARITY_MIN_JACCARD==0.80 and mod.NEAR_EXACT_MIN_JACCARD==0.95
+    assert mod.SIMILARITY_MIN_SHARED_SHINGLES==40
+
+def test_sha_gates(tmp_path):
+    idx,lex=make_fixture(tmp_path)
+    assert mod.run(idx,lex,tmp_path/'good.sqlite',expected_index_sha256=mod.sha256_file(idx),expected_lexical_sha256=mod.sha256_file(lex))['sources']['universal_index_sha256']==mod.sha256_file(idx)
+    try: mod.run(idx,lex,tmp_path/'bad.sqlite',expected_index_sha256='0'*64)
+    except RuntimeError as e: assert str(e)=='Universal Index SHA-256 mismatch'
+    else: raise AssertionError('expected mismatch')


### PR DESCRIPTION
## Qué cierra

Consolida el carril corpus-wide de reutilización/similitud LTMD-U1 0.1 sin publicar OCR, hashes de páginas, IDs de páginas/objetos ni pares candidatos concretos.

## Jerarquía de evidencia

- `exact_source_reuse`: igualdad criptográfica de `source_sha256`.
- `exact_text_representation_reuse`: igualdad de `search_text_sha256` sólo tras el gate fijo `ocr_char_count >= 200` y `ocr_word_count >= 30`.
- `similarity_candidate`: shingles de 5 tokens, mínimo 50 shingles distintos, MinHash 96, LSH 12x8, Jaccard exacto >= 0.80 y >= 40 shingles compartidos, sólo entre objetos distintos.
- `near_exact_candidate`: Jaccard >= 0.95.

Los umbrales fueron fijados antes de inspeccionar candidatos y la similitud nunca crea aliases ni implica equivalencia bibliográfica, curricular, pedagógica o semántica.

## Materialización U1 preservada

- 86,549 páginas / 492 objetos.
- 71,274 páginas textualmente admisibles.
- 65,488 páginas aptas para shingles.
- 3,347 grupos exactos de fuente.
- 3,013 grupos exactos de representación textual.
- 9,146 señales aproximadas verificadas: 6,152 `similarity_candidate` + 2,994 `near_exact_candidate`.
- SQLite privado preservado y redescargado desde Drive; SHA lógico `4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301`.

## Superficie pública

Añade builder reproducible, tests, JSON Schema, materialization record agregado, documentación metodológica y validación en CI. El artefacto privado permanece fuera de GitHub.

## Estado científico

`text_verified=false`, `semantic_ready=false`, `default_result_state=exploratory_signal`.