### PR TITLE
Analytics: connect verticals to corpus-wide reuse context

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -18,6 +18,7 @@ on:
       - 'scripts/build_u1_ngrams.py'
       - 'scripts/build_u1_cooccurrences.py'
       - 'scripts/build_u1_reuse_similarity.py'
+      - 'scripts/build_vertical_reuse_context.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
@@ -27,9 +28,11 @@ on:
       - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
       - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
       - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
+      - 'schemas/ltmd_vertical_reuse_context.schema.json'
       - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -41,6 +44,7 @@ on:
       - 'tests/test_build_u1_ngrams.py'
       - 'tests/test_build_u1_cooccurrences.py'
       - 'tests/test_build_u1_reuse_similarity.py'
+      - 'tests/test_build_vertical_reuse_context.py'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
@@ -59,6 +63,7 @@ on:
       - 'scripts/build_u1_ngrams.py'
       - 'scripts/build_u1_cooccurrences.py'
       - 'scripts/build_u1_reuse_similarity.py'
+      - 'scripts/build_vertical_reuse_context.py'
       - 'schemas/ltmd_analytics_query_response.schema.json'
       - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
       - 'schemas/ltmd_u1_corpus_query_response.schema.json'
@@ -68,9 +73,11 @@ on:
       - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
       - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
       - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
+      - 'schemas/ltmd_vertical_reuse_context.schema.json'
       - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
       - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
+      - 'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'
       - 'tests/test_analytics_api.py'
       - 'tests/test_build_indigenous_analytics_mart.py'
       - 'tests/test_query_indigenous_analytics.py'
@@ -82,6 +89,7 @@ on:
       - 'tests/test_build_u1_ngrams.py'
       - 'tests/test_build_u1_cooccurrences.py'
       - 'tests/test_build_u1_reuse_similarity.py'
+      - 'tests/test_build_vertical_reuse_context.py'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -111,6 +119,7 @@ jobs:
           tests/test_build_u1_ngrams.py
           tests/test_build_u1_cooccurrences.py
           tests/test_build_u1_reuse_similarity.py
+          tests/test_build_vertical_reuse_context.py
       - name: Validate Analytics JSON schemas and materialization records
         run: |
           python - <<'PY'
@@ -126,6 +135,7 @@ jobs:
               'schemas/ltmd_u1_ngrams_public_summary.schema.json',
               'schemas/ltmd_u1_cooccurrences_public_summary.schema.json',
               'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json',
+              'schemas/ltmd_vertical_reuse_context.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))
@@ -139,6 +149,8 @@ jobs:
                'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'),
               ('schemas/ltmd_u1_reuse_similarity_public_summary.schema.json',
                'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'),
+              ('schemas/ltmd_vertical_reuse_context.schema.json',
+               'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'),
           ]
           for schema_path, data_path in validations:
               schema = json.load(open(schema_path, encoding='utf-8'))

--- a/data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json
+++ b/data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json
@@ -1,0 +1,40 @@
+{
+  "builder_version": "LTMD_VERTICAL_REUSE_CONTEXT_BUILDER_0.1",
+  "context_version": "LTMD_VERTICAL_REUSE_CONTEXT_0.1",
+  "metrics": {
+    "candidate_pages": 1151,
+    "candidate_pages_with_any_reuse_similarity_signal": 136,
+    "candidate_pages_with_cross_generation_reuse_similarity_signal": 124,
+    "candidate_pages_with_cross_generation_similarity_signal": 90,
+    "candidate_pages_with_exact_source_cross_generation_reuse": 24,
+    "candidate_pages_with_exact_source_cross_object_reuse": 28,
+    "candidate_pages_with_exact_text_cross_generation_reuse": 36,
+    "candidate_pages_with_exact_text_cross_object_reuse": 40,
+    "candidate_pages_with_near_exact_signal": 18,
+    "candidate_pages_with_similarity_signal": 98,
+    "candidate_pages_without_reuse_similarity_signal": 1015,
+    "internal_near_exact_pairs": 9,
+    "internal_similarity_pairs": 49,
+    "mapped_candidate_pages": 1151,
+    "share_candidate_pages_with_any_reuse_similarity_signal": 0.11815812337098175,
+    "unmapped_candidate_pages": 0
+  },
+  "privacy": {
+    "object_identifiers_emitted": false,
+    "ocr_text_emitted": false,
+    "page_identifiers_emitted": false,
+    "pair_identifiers_emitted": false
+  },
+  "provenance": {
+    "candidate_ledger_sha256": "efa77793479c8a5d4704aaee77f1047938c84c2aa9b5ea9550131fd09a6531bb",
+    "human_validation_complete": false,
+    "reuse_similarity_sha256": "4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301",
+    "universal_index_sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2"
+  },
+  "result_state": "exploratory_signal",
+  "vertical_id": "indigenous_languages",
+  "warnings": [
+    "Reuse/similarity context is computational evidence and does not create aliases or establish semantic equivalence.",
+    "Counts describe candidate pages touched by corpus-wide reuse/similarity signals; they do not invalidate or validate the vertical selection."
+  ]
+}

--- a/docs/LTMD_VERTICAL_REUSE_CONTEXT_0_1.md
+++ b/docs/LTMD_VERTICAL_REUSE_CONTEXT_0_1.md
@@ -1,0 +1,42 @@
+# LTMD — contexto transversal de reutilización para verticales 0.1
+
+Versión: `LTMD_VERTICAL_REUSE_CONTEXT_0.1`.
+
+Esta capa conecta un vertical temático ya definido con la infraestructura corpus-wide de LTMD-U1 **sin volver a seleccionar ni reclasificar sus páginas**. El insumo mínimo es un ledger privado con `page_id`; el builder exige mapeo completo contra el Índice Universal y calcula únicamente agregados seguros a partir de `LTMD_U1_REUSE_SIMILARITY_0.1`.
+
+## Propósito
+
+Los conteos temáticos longitudinales pueden incluir contenido repetido entre libros o generaciones. El contexto transversal permite advertir ese hecho sin confundir:
+
+- igualdad de bytes fuente;
+- igualdad de representación textual OCR/search;
+- similitud aproximada;
+- identidad documental, equivalencia curricular o significado histórico.
+
+Ninguna señal crea aliases ni modifica el estado epistemológico del vertical.
+
+## Primer caso real — lenguas indígenas
+
+El ledger preregistrado 0.2 conserva 1,151 páginas candidatas. Las 1,151 se mapearon exactamente al Índice Universal; no hubo candidatas huérfanas.
+
+El cruce corpus-wide identifica 136 páginas candidatas con alguna señal de reutilización o similitud, equivalentes a 11.8158% del ledger. De ellas, 124 tienen alguna señal que cruza generaciones. En las capas específicas:
+
+- 28 páginas participan en reutilización exacta de fuente entre objetos; 24 cruzan generaciones;
+- 40 participan en igualdad exacta de representación textual entre objetos; 36 cruzan generaciones;
+- 98 participan en una señal aproximada de similitud; 18 alcanzan `near_exact_candidate`;
+- 90 páginas candidatas participan en similitud aproximada que cruza generaciones;
+- existen 49 pares de similitud en los que ambas páginas pertenecen al propio vertical, 9 de ellos `near_exact_candidate`.
+
+Estas cifras **no corrigen ni validan** las 1,151 candidatas. Añaden contexto para interpretar tendencias y para que LTMD Analytics pueda advertir cuando una señal temática está parcialmente asociada con material repetido.
+
+## Privacidad
+
+El registro público no contiene `page_id`, IDs de objetos, pares concretos, OCR, snippets ni hashes por página. Publica únicamente cardinalidades, hashes de los tres artefactos de entrada y el estado científico.
+
+## Estado científico
+
+`result_state=exploratory_signal`, `human_validation_complete=false`. La selección indígena permanece `not_visually_validated` y la nueva capa de contexto no promueve resultados a `human_validated` ni `semantic_ready`.
+
+## Reutilización futura
+
+El builder es vertical-agnóstico: cualquier vertical posterior con un ledger privado de páginas puede reutilizar el mismo contrato. Esto evita duplicar lógica temática y convierte la advertencia de reutilización en una capacidad común de LTMD Research.

--- a/schemas/ltmd_vertical_reuse_context.schema.json
+++ b/schemas/ltmd_vertical_reuse_context.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "LTMD vertical reuse/similarity context 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["builder_version","context_version","vertical_id","result_state","metrics","provenance","warnings","privacy"],
+  "properties": {
+    "builder_version": {"const":"LTMD_VERTICAL_REUSE_CONTEXT_BUILDER_0.1"},
+    "context_version": {"const":"LTMD_VERTICAL_REUSE_CONTEXT_0.1"},
+    "vertical_id": {"type":"string","pattern":"^[a-z0-9_]+$"},
+    "result_state": {"const":"exploratory_signal"},
+    "metrics": {
+      "type":"object","additionalProperties":false,
+      "required":[
+        "candidate_pages","mapped_candidate_pages","unmapped_candidate_pages",
+        "candidate_pages_with_exact_source_cross_object_reuse","candidate_pages_with_exact_source_cross_generation_reuse",
+        "candidate_pages_with_exact_text_cross_object_reuse","candidate_pages_with_exact_text_cross_generation_reuse",
+        "candidate_pages_with_similarity_signal","candidate_pages_with_near_exact_signal",
+        "candidate_pages_with_cross_generation_similarity_signal","candidate_pages_with_any_reuse_similarity_signal",
+        "candidate_pages_with_cross_generation_reuse_similarity_signal","candidate_pages_without_reuse_similarity_signal",
+        "internal_similarity_pairs","internal_near_exact_pairs","share_candidate_pages_with_any_reuse_similarity_signal"
+      ],
+      "properties": {
+        "candidate_pages":{"type":"integer","minimum":0},
+        "mapped_candidate_pages":{"type":"integer","minimum":0},
+        "unmapped_candidate_pages":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_source_cross_object_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_source_cross_generation_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_text_cross_object_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_text_cross_generation_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_similarity_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_near_exact_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_cross_generation_similarity_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_any_reuse_similarity_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_cross_generation_reuse_similarity_signal":{"type":"integer","minimum":0},
+        "candidate_pages_without_reuse_similarity_signal":{"type":"integer","minimum":0},
+        "internal_similarity_pairs":{"type":"integer","minimum":0},
+        "internal_near_exact_pairs":{"type":"integer","minimum":0},
+        "share_candidate_pages_with_any_reuse_similarity_signal":{"oneOf":[{"type":"null"},{"type":"number","minimum":0,"maximum":1}]}
+      }
+    },
+    "provenance": {
+      "type":"object","additionalProperties":false,
+      "required":["candidate_ledger_sha256","universal_index_sha256","reuse_similarity_sha256","human_validation_complete"],
+      "properties": {
+        "candidate_ledger_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "reuse_similarity_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "human_validation_complete":{"const":false}
+      }
+    },
+    "warnings":{"type":"array","minItems":2,"items":{"type":"string","minLength":1}},
+    "privacy": {
+      "type":"object","additionalProperties":false,
+      "required":["page_identifiers_emitted","object_identifiers_emitted","pair_identifiers_emitted","ocr_text_emitted"],
+      "properties": {
+        "page_identifiers_emitted":{"const":false},
+        "object_identifiers_emitted":{"const":false},
+        "pair_identifiers_emitted":{"const":false},
+        "ocr_text_emitted":{"const":false}
+      }
+    }
+  }
+}

--- a/scripts/build_vertical_reuse_context.py
+++ b/scripts/build_vertical_reuse_context.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Build aggregate-only reuse/similarity context for an LTMD vertical candidate ledger.
+
+Version: LTMD_VERTICAL_REUSE_CONTEXT_BUILDER_0.1
+
+The vertical selection itself is not recomputed. Candidate page_ids are mapped to the
+private LTMD-U1 Universal Index and contextualized against the private U1 reuse/similarity
+artifact. Only aggregate counts are emitted.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+BUILDER_VERSION = "LTMD_VERTICAL_REUSE_CONTEXT_BUILDER_0.1"
+CONTEXT_VERSION = "LTMD_VERTICAL_REUSE_CONTEXT_0.1"
+INDEX_VERSION = "LTMD_U1_UNIVERSAL_INDEX_0.1"
+REUSE_VERSION = "LTMD_U1_REUSE_SIMILARITY_0.1"
+SHA_RE = re.compile(r"^[a-f0-9]{64}$")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def verify_sha(path: Path, expected: str | None, label: str) -> str:
+    if not path.is_file():
+        raise RuntimeError(f"{label} is unavailable")
+    actual = sha256_file(path)
+    if expected is not None:
+        exp = expected.strip().lower()
+        if not SHA_RE.fullmatch(exp):
+            raise RuntimeError(f"expected {label} SHA-256 is invalid")
+        if actual != exp:
+            raise RuntimeError(f"{label} SHA-256 mismatch")
+    return actual
+
+
+def decode_meta(c: sqlite3.Connection, table: str) -> dict:
+    meta = {}
+    for key, raw in c.execute(f"SELECT key,value FROM {table}"):
+        try:
+            meta[key] = json.loads(raw)
+        except json.JSONDecodeError:
+            meta[key] = raw
+    return meta
+
+
+def validate_index(c: sqlite3.Connection) -> None:
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")}
+    if not {"pages", "index_meta"}.issubset(tables):
+        raise RuntimeError("not an LTMD Universal Index")
+    meta = decode_meta(c, "index_meta")
+    if meta.get("builder_version") != INDEX_VERSION:
+        raise RuntimeError("unsupported Universal Index version")
+
+
+def validate_reuse(c: sqlite3.Connection) -> None:
+    required = {
+        "meta", "exact_source_groups", "exact_source_members", "exact_text_groups",
+        "exact_text_members", "similarity_candidates",
+    }
+    tables = {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if not required.issubset(tables):
+        raise RuntimeError("not an LTMD reuse/similarity artifact")
+    meta = decode_meta(c, "meta")
+    if meta.get("artifact_version") != REUSE_VERSION:
+        raise RuntimeError("unsupported reuse/similarity artifact version")
+
+
+def load_candidate_page_ids(path: Path) -> list[str]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        if "page_id" not in set(reader.fieldnames or []):
+            raise RuntimeError("candidate ledger missing page_id")
+        page_ids = []
+        seen = set()
+        for row in reader:
+            page_id = str(row.get("page_id") or "").strip()
+            if not page_id:
+                raise RuntimeError("candidate ledger contains blank page_id")
+            if page_id in seen:
+                raise RuntimeError("candidate ledger contains duplicate page_id")
+            seen.add(page_id)
+            page_ids.append(page_id)
+    return page_ids
+
+
+def map_candidates(index: sqlite3.Connection, page_ids: list[str]) -> list[tuple[int, str, int | None]]:
+    index.execute("CREATE TEMP TABLE vertical_page_ids(page_id TEXT PRIMARY KEY) WITHOUT ROWID")
+    index.executemany("INSERT INTO vertical_page_ids VALUES(?)", ((p,) for p in page_ids))
+    rows = index.execute("""
+        SELECT p.id,p.page_id,p.catalog_generation
+        FROM pages p JOIN vertical_page_ids v ON v.page_id=p.page_id
+        ORDER BY p.id
+    """).fetchall()
+    if len(rows) != len(page_ids):
+        mapped = {r[1] for r in rows}
+        missing = [p for p in page_ids if p not in mapped]
+        raise RuntimeError(f"{len(missing)} candidate page_id values are absent from Universal Index")
+    return rows
+
+
+def _count_distinct(reuse: sqlite3.Connection, sql: str, params=()) -> int:
+    return int(reuse.execute(sql, params).fetchone()[0])
+
+
+def aggregate_context(index_path: Path, reuse_path: Path, page_ids: list[str]) -> dict:
+    index = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True)
+    reuse = sqlite3.connect(f"file:{reuse_path}?mode=ro", uri=True)
+    try:
+        validate_index(index)
+        validate_reuse(reuse)
+        mapped = map_candidates(index, page_ids)
+        rowids = [r[0] for r in mapped]
+        generation = {r[0]: r[2] for r in mapped}
+
+        reuse.execute("CREATE TEMP TABLE vertical_candidates(page_rowid INTEGER PRIMARY KEY) WITHOUT ROWID")
+        reuse.executemany("INSERT INTO vertical_candidates VALUES(?)", ((r,) for r in rowids))
+
+        exact_source_cross_object = _count_distinct(reuse, """
+          SELECT COUNT(DISTINCT m.page_rowid)
+          FROM exact_source_members m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid
+          JOIN exact_source_groups g ON g.group_id=m.group_id WHERE g.cross_object=1
+        """)
+        exact_source_cross_generation = _count_distinct(reuse, """
+          SELECT COUNT(DISTINCT m.page_rowid)
+          FROM exact_source_members m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid
+          JOIN exact_source_groups g ON g.group_id=m.group_id WHERE g.cross_generation=1
+        """)
+        exact_text_cross_object = _count_distinct(reuse, """
+          SELECT COUNT(DISTINCT m.page_rowid)
+          FROM exact_text_members m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid
+          JOIN exact_text_groups g ON g.group_id=m.group_id WHERE g.cross_object=1
+        """)
+        exact_text_cross_generation = _count_distinct(reuse, """
+          SELECT COUNT(DISTINCT m.page_rowid)
+          FROM exact_text_members m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid
+          JOIN exact_text_groups g ON g.group_id=m.group_id WHERE g.cross_generation=1
+        """)
+
+        sim_rows = reuse.execute("""
+          SELECT s.page_a,s.page_b,s.tier
+          FROM similarity_candidates s
+          WHERE EXISTS(SELECT 1 FROM vertical_candidates v WHERE v.page_rowid=s.page_a)
+             OR EXISTS(SELECT 1 FROM vertical_candidates v WHERE v.page_rowid=s.page_b)
+        """).fetchall()
+        candidate_set = set(rowids)
+        similarity_pages = set()
+        near_pages = set()
+        cross_gen_similarity_pages = set()
+        internal_pairs = 0
+        internal_near_pairs = 0
+        counterpart_ids = {p for a, b, _ in sim_rows for p in (a, b) if p not in generation}
+        if counterpart_ids:
+            index.execute("CREATE TEMP TABLE counterpart_ids(id INTEGER PRIMARY KEY) WITHOUT ROWID")
+            index.executemany("INSERT INTO counterpart_ids VALUES(?)", ((p,) for p in counterpart_ids))
+            generation.update({r[0]: r[1] for r in index.execute(
+                "SELECT p.id,p.catalog_generation FROM pages p JOIN counterpart_ids c ON c.id=p.id"
+            )})
+        for a, b, tier in sim_rows:
+            touched = {p for p in (a, b) if p in candidate_set}
+            similarity_pages.update(touched)
+            if tier == "near_exact_candidate":
+                near_pages.update(touched)
+            if generation.get(a) != generation.get(b):
+                cross_gen_similarity_pages.update(touched)
+            if a in candidate_set and b in candidate_set:
+                internal_pairs += 1
+                internal_near_pairs += int(tier == "near_exact_candidate")
+
+        any_pages = set()
+        cross_generation_any = set(cross_gen_similarity_pages)
+        for table, groups, cross_col, target in (
+            ("exact_source_members", "exact_source_groups", "cross_object", any_pages),
+            ("exact_text_members", "exact_text_groups", "cross_object", any_pages),
+            ("exact_source_members", "exact_source_groups", "cross_generation", cross_generation_any),
+            ("exact_text_members", "exact_text_groups", "cross_generation", cross_generation_any),
+        ):
+            rows = reuse.execute(f"""
+              SELECT DISTINCT m.page_rowid FROM {table} m
+              JOIN vertical_candidates v ON v.page_rowid=m.page_rowid
+              JOIN {groups} g ON g.group_id=m.group_id WHERE g.{cross_col}=1
+            """)
+            target.update(r[0] for r in rows)
+        any_pages.update(similarity_pages)
+
+        n = len(page_ids)
+        return {
+            "candidate_pages": n,
+            "mapped_candidate_pages": len(mapped),
+            "unmapped_candidate_pages": n - len(mapped),
+            "candidate_pages_with_exact_source_cross_object_reuse": exact_source_cross_object,
+            "candidate_pages_with_exact_source_cross_generation_reuse": exact_source_cross_generation,
+            "candidate_pages_with_exact_text_cross_object_reuse": exact_text_cross_object,
+            "candidate_pages_with_exact_text_cross_generation_reuse": exact_text_cross_generation,
+            "candidate_pages_with_similarity_signal": len(similarity_pages),
+            "candidate_pages_with_near_exact_signal": len(near_pages),
+            "candidate_pages_with_cross_generation_similarity_signal": len(cross_gen_similarity_pages),
+            "candidate_pages_with_any_reuse_similarity_signal": len(any_pages),
+            "candidate_pages_with_cross_generation_reuse_similarity_signal": len(cross_generation_any),
+            "candidate_pages_without_reuse_similarity_signal": n - len(any_pages),
+            "internal_similarity_pairs": internal_pairs,
+            "internal_near_exact_pairs": internal_near_pairs,
+            "share_candidate_pages_with_any_reuse_similarity_signal": (len(any_pages) / n if n else None),
+        }
+    finally:
+        index.close()
+        reuse.close()
+
+
+def run(candidate_ledger: Path, index_path: Path, reuse_path: Path, *, vertical_id: str,
+        expected_ledger_sha256=None, expected_index_sha256=None, expected_reuse_sha256=None) -> dict:
+    ledger_sha = verify_sha(candidate_ledger, expected_ledger_sha256, "candidate ledger")
+    index_sha = verify_sha(index_path, expected_index_sha256, "Universal Index")
+    reuse_sha = verify_sha(reuse_path, expected_reuse_sha256, "reuse/similarity artifact")
+    page_ids = load_candidate_page_ids(candidate_ledger)
+    metrics = aggregate_context(index_path, reuse_path, page_ids)
+    return {
+        "context_version": CONTEXT_VERSION,
+        "builder_version": BUILDER_VERSION,
+        "vertical_id": vertical_id,
+        "result_state": "exploratory_signal",
+        "metrics": metrics,
+        "provenance": {
+            "candidate_ledger_sha256": ledger_sha,
+            "universal_index_sha256": index_sha,
+            "reuse_similarity_sha256": reuse_sha,
+            "human_validation_complete": False,
+        },
+        "warnings": [
+            "Reuse/similarity context is computational evidence and does not create aliases or establish semantic equivalence.",
+            "Counts describe candidate pages touched by corpus-wide reuse/similarity signals; they do not invalidate or validate the vertical selection.",
+        ],
+        "privacy": {
+            "page_identifiers_emitted": False,
+            "object_identifiers_emitted": False,
+            "pair_identifiers_emitted": False,
+            "ocr_text_emitted": False,
+        },
+    }
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument("--candidate-ledger", required=True)
+    p.add_argument("--universal-index", required=True)
+    p.add_argument("--reuse-similarity", required=True)
+    p.add_argument("--vertical-id", required=True)
+    p.add_argument("--expected-ledger-sha256")
+    p.add_argument("--expected-index-sha256")
+    p.add_argument("--expected-reuse-sha256")
+    p.add_argument("--output")
+    a = p.parse_args(argv)
+    result = run(
+        Path(a.candidate_ledger), Path(a.universal_index), Path(a.reuse_similarity),
+        vertical_id=a.vertical_id,
+        expected_ledger_sha256=a.expected_ledger_sha256,
+        expected_index_sha256=a.expected_index_sha256,
+        expected_reuse_sha256=a.expected_reuse_sha256,
+    )
+    payload = json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if a.output:
+        Path(a.output).write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_build_vertical_reuse_context.py
+++ b/tests/test_build_vertical_reuse_context.py
@@ -1,0 +1,98 @@
+import csv
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "build_vertical_reuse_context.py"
+spec = importlib.util.spec_from_file_location("ctx", SCRIPT)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+def fixtures(root):
+    ledger = root / "ledger.csv"
+    with ledger.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["page_id"])
+        w.writeheader()
+        w.writerows([{"page_id": "p1"}, {"page_id": "p2"}])
+
+    idx = root / "idx.sqlite"
+    c = sqlite3.connect(idx)
+    c.executescript("""
+    CREATE TABLE index_meta(key TEXT PRIMARY KEY,value TEXT);
+    CREATE TABLE pages(id INTEGER PRIMARY KEY,page_id TEXT UNIQUE,catalog_generation INTEGER);
+    """)
+    c.execute("INSERT INTO index_meta VALUES(?,?)", ("builder_version", json.dumps(mod.INDEX_VERSION)))
+    c.executemany("INSERT INTO pages VALUES(?,?,?)", [(1, "p1", 1993), (2, "p2", 2014), (3, "p3", 2014)])
+    c.commit()
+    c.close()
+
+    reuse = root / "reuse.sqlite"
+    c = sqlite3.connect(reuse)
+    c.executescript("""
+    CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT);
+    CREATE TABLE exact_source_groups(group_id INTEGER PRIMARY KEY,cross_object INTEGER,cross_generation INTEGER);
+    CREATE TABLE exact_source_members(group_id INTEGER,page_rowid INTEGER);
+    CREATE TABLE exact_text_groups(group_id INTEGER PRIMARY KEY,cross_object INTEGER,cross_generation INTEGER);
+    CREATE TABLE exact_text_members(group_id INTEGER,page_rowid INTEGER);
+    CREATE TABLE similarity_candidates(page_a INTEGER,page_b INTEGER,tier TEXT);
+    """)
+    c.execute("INSERT INTO meta VALUES(?,?)", ("artifact_version", json.dumps(mod.REUSE_VERSION)))
+    c.execute("INSERT INTO exact_source_groups VALUES(1,1,1)")
+    c.executemany("INSERT INTO exact_source_members VALUES(1,?)", [(1,), (3,)])
+    c.execute("INSERT INTO exact_text_groups VALUES(1,1,0)")
+    c.executemany("INSERT INTO exact_text_members VALUES(1,?)", [(2,), (3,)])
+    c.execute("INSERT INTO similarity_candidates VALUES(1,2,'near_exact_candidate')")
+    c.commit()
+    c.close()
+    return ledger, idx, reuse
+
+
+def test_context_counts_and_privacy(tmp_path):
+    ledger, idx, reuse = fixtures(tmp_path)
+    result = mod.run(ledger, idx, reuse, vertical_id="test")
+    m = result["metrics"]
+    assert m["candidate_pages"] == 2
+    assert m["mapped_candidate_pages"] == 2
+    assert m["unmapped_candidate_pages"] == 0
+    assert m["candidate_pages_with_exact_source_cross_object_reuse"] == 1
+    assert m["candidate_pages_with_exact_text_cross_object_reuse"] == 1
+    assert m["candidate_pages_with_similarity_signal"] == 2
+    assert m["candidate_pages_with_near_exact_signal"] == 2
+    assert m["candidate_pages_with_any_reuse_similarity_signal"] == 2
+    assert m["internal_similarity_pairs"] == 1
+    assert m["internal_near_exact_pairs"] == 1
+    assert result["result_state"] == "exploratory_signal"
+    rendered = json.dumps(result)
+    assert "p1" not in rendered and "p2" not in rendered
+    assert result["privacy"]["page_identifiers_emitted"] is False
+
+
+def test_missing_candidate_fails(tmp_path):
+    ledger, idx, reuse = fixtures(tmp_path)
+    with ledger.open("a", encoding="utf-8") as f:
+        f.write("missing\n")
+    try:
+        mod.run(ledger, idx, reuse, vertical_id="test")
+    except RuntimeError as e:
+        assert "absent from Universal Index" in str(e)
+    else:
+        raise AssertionError("expected failure")
+
+
+def test_sha_gates(tmp_path):
+    ledger, idx, reuse = fixtures(tmp_path)
+    result = mod.run(
+        ledger, idx, reuse, vertical_id="test",
+        expected_ledger_sha256=mod.sha256_file(ledger),
+        expected_index_sha256=mod.sha256_file(idx),
+        expected_reuse_sha256=mod.sha256_file(reuse),
+    )
+    assert result["provenance"]["candidate_ledger_sha256"] == mod.sha256_file(ledger)
+    try:
+        mod.run(ledger, idx, reuse, vertical_id="test", expected_reuse_sha256="0" * 64)
+    except RuntimeError as e:
+        assert str(e) == "reuse/similarity artifact SHA-256 mismatch"
+    else:
+        raise AssertionError("expected mismatch")


### PR DESCRIPTION
## Objetivo

Añade un adaptador vertical-agnóstico que conecta un ledger temático ya definido con el Índice Universal U1 y la capa privada de reutilización/similitud, sin volver a seleccionar ni reclasificar páginas.

## Primer caso real: lenguas indígenas

- 1,151/1,151 páginas candidatas del ledger 0.2 mapeadas al Índice Universal.
- 0 candidatas huérfanas.
- 136 páginas con alguna señal corpus-wide de reutilización/similitud (11.8158%).
- 124 con alguna señal que cruza generaciones.
- 28 con reutilización exacta de fuente entre objetos; 24 cruzan generaciones.
- 40 con igualdad exacta de representación textual entre objetos; 36 cruzan generaciones.
- 98 con señal aproximada; 18 `near_exact_candidate`.
- 90 con similitud aproximada que cruza generaciones.

## Guardas

La capa no crea aliases, no invalida/valida el vertical y no cambia `not_visually_validated` / `exploratory_signal`. No publica page IDs, object IDs, pares concretos, OCR ni snippets.

## Superficie

- builder genérico reproducible;
- fixture/tests;
- JSON Schema;
- registro agregado real del vertical indígena;
- documentación metodológica;
- CI para schema + materialization record.