### PR TITLE
Analytics: materialize preregistered U1 exploratory verticals

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -6,98 +6,22 @@ on:
     paths:
       - 'analytics_api/**'
       - 'passenger_wsgi.py'
-      - 'requirements-analytics.txt'
-      - 'requirements-analytics-build.txt'
-      - 'scripts/build_indigenous_analytics_mart.py'
-      - 'scripts/query_indigenous_analytics.py'
-      - 'scripts/build_u1_universal_index.py'
-      - 'scripts/query_u1_universal_index.py'
-      - 'scripts/build_u1_corpus_analytics_manifest.py'
-      - 'scripts/build_u1_lexical_positions.py'
-      - 'scripts/build_u1_lexical_dimensions.py'
-      - 'scripts/build_u1_ngrams.py'
-      - 'scripts/build_u1_cooccurrences.py'
-      - 'scripts/build_u1_reuse_similarity.py'
-      - 'scripts/build_vertical_reuse_context.py'
-      - 'scripts/runtime_vertical_reuse_context.py'
-      - 'schemas/ltmd_analytics_query_response.schema.json'
-      - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
-      - 'schemas/ltmd_u1_corpus_query_response.schema.json'
-      - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
-      - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
-      - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
-      - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
-      - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
-      - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
-      - 'schemas/ltmd_vertical_reuse_context.schema.json'
-      - 'schemas/ltmd_u1_vertical_registry.schema.json'
-      - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'
-      - 'data/analytics/ltmd_u1_vertical_registry_0_1.json'
-      - 'tests/test_analytics_api.py'
-      - 'tests/test_build_indigenous_analytics_mart.py'
-      - 'tests/test_query_indigenous_analytics.py'
-      - 'tests/test_build_u1_universal_index.py'
-      - 'tests/test_query_u1_universal_index.py'
-      - 'tests/test_build_u1_corpus_analytics_manifest.py'
-      - 'tests/test_build_u1_lexical_positions.py'
-      - 'tests/test_build_u1_lexical_dimensions.py'
-      - 'tests/test_build_u1_ngrams.py'
-      - 'tests/test_build_u1_cooccurrences.py'
-      - 'tests/test_build_u1_reuse_similarity.py'
-      - 'tests/test_build_vertical_reuse_context.py'
-      - 'tests/test_u1_vertical_registry.py'
+      - 'requirements-analytics*.txt'
+      - 'scripts/**'
+      - 'schemas/**'
+      - 'data/analytics/**'
+      - 'tests/**'
       - '.github/workflows/test-ltmd-analytics.yml'
   push:
     branches: [main]
     paths:
       - 'analytics_api/**'
       - 'passenger_wsgi.py'
-      - 'requirements-analytics.txt'
-      - 'requirements-analytics-build.txt'
-      - 'scripts/build_indigenous_analytics_mart.py'
-      - 'scripts/query_indigenous_analytics.py'
-      - 'scripts/build_u1_universal_index.py'
-      - 'scripts/query_u1_universal_index.py'
-      - 'scripts/build_u1_corpus_analytics_manifest.py'
-      - 'scripts/build_u1_lexical_positions.py'
-      - 'scripts/build_u1_lexical_dimensions.py'
-      - 'scripts/build_u1_ngrams.py'
-      - 'scripts/build_u1_cooccurrences.py'
-      - 'scripts/build_u1_reuse_similarity.py'
-      - 'scripts/build_vertical_reuse_context.py'
-      - 'scripts/runtime_vertical_reuse_context.py'
-      - 'schemas/ltmd_analytics_query_response.schema.json'
-      - 'schemas/ltmd_u1_universal_index_manifest.schema.json'
-      - 'schemas/ltmd_u1_corpus_query_response.schema.json'
-      - 'schemas/ltmd_u1_corpus_analytics_manifest.schema.json'
-      - 'schemas/ltmd_u1_lexical_positions_public_summary.schema.json'
-      - 'schemas/ltmd_u1_lexical_dimensions_public_summary.schema.json'
-      - 'schemas/ltmd_u1_ngrams_public_summary.schema.json'
-      - 'schemas/ltmd_u1_cooccurrences_public_summary.schema.json'
-      - 'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json'
-      - 'schemas/ltmd_vertical_reuse_context.schema.json'
-      - 'schemas/ltmd_u1_vertical_registry.schema.json'
-      - 'data/analytics/ltmd_u1_ngrams_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_cooccurrences_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_reuse_similarity_materialization_0_1.json'
-      - 'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'
-      - 'data/analytics/ltmd_u1_vertical_registry_0_1.json'
-      - 'tests/test_analytics_api.py'
-      - 'tests/test_build_indigenous_analytics_mart.py'
-      - 'tests/test_query_indigenous_analytics.py'
-      - 'tests/test_build_u1_universal_index.py'
-      - 'tests/test_query_u1_universal_index.py'
-      - 'tests/test_build_u1_corpus_analytics_manifest.py'
-      - 'tests/test_build_u1_lexical_positions.py'
-      - 'tests/test_build_u1_lexical_dimensions.py'
-      - 'tests/test_build_u1_ngrams.py'
-      - 'tests/test_build_u1_cooccurrences.py'
-      - 'tests/test_build_u1_reuse_similarity.py'
-      - 'tests/test_build_vertical_reuse_context.py'
-      - 'tests/test_u1_vertical_registry.py'
+      - 'requirements-analytics*.txt'
+      - 'scripts/**'
+      - 'schemas/**'
+      - 'data/analytics/**'
+      - 'tests/**'
       - '.github/workflows/test-ltmd-analytics.yml'
 
 permissions:
@@ -129,11 +53,13 @@ jobs:
           tests/test_build_u1_reuse_similarity.py
           tests/test_build_vertical_reuse_context.py
           tests/test_u1_vertical_registry.py
+          tests/test_materialize_u1_vertical_registry.py
       - name: Validate Analytics JSON schemas and materialization records
         run: |
           python - <<'PY'
           import json
           from jsonschema import Draft202012Validator
+
           paths = [
               'schemas/ltmd_analytics_query_response.schema.json',
               'schemas/ltmd_u1_universal_index_manifest.schema.json',
@@ -146,6 +72,7 @@ jobs:
               'schemas/ltmd_u1_reuse_similarity_public_summary.schema.json',
               'schemas/ltmd_vertical_reuse_context.schema.json',
               'schemas/ltmd_u1_vertical_registry.schema.json',
+              'schemas/ltmd_u1_vertical_materialization.schema.json',
           ]
           for path in paths:
               schema = json.load(open(path, encoding='utf-8'))
@@ -163,6 +90,8 @@ jobs:
                'data/analytics/ltmd_u1_indigenous_reuse_context_0_1.json'),
               ('schemas/ltmd_u1_vertical_registry.schema.json',
                'data/analytics/ltmd_u1_vertical_registry_0_1.json'),
+              ('schemas/ltmd_u1_vertical_materialization.schema.json',
+               'data/analytics/ltmd_u1_vertical_materialization_0_1.json'),
           ]
           for schema_path, data_path in validations:
               schema = json.load(open(schema_path, encoding='utf-8'))

--- a/data/analytics/ltmd_u1_vertical_materialization_0_1.json
+++ b/data/analytics/ltmd_u1_vertical_materialization_0_1.json
@@ -1,0 +1,142 @@
+{
+  "builder_version": "LTMD_U1_VERTICAL_MATERIALIZER_0.1",
+  "corpus": {
+    "canonical_objects": 492,
+    "pages": 86549
+  },
+  "full_materialization_bytes": 120354,
+  "full_materialization_sha256": "e2faab966faced48327634c4acd40a867b76add29612538736b91db8d3afb0ad",
+  "materialization_version": "LTMD_U1_VERTICAL_MATERIALIZATION_0.1",
+  "privacy": {
+    "object_identifiers_emitted": false,
+    "ocr_text_emitted": false,
+    "page_identifiers_emitted": false,
+    "pair_identifiers_emitted": false,
+    "source_hash_values_emitted": false
+  },
+  "provenance": {
+    "human_validation_complete": false,
+    "registry_sha256": "9a4f3b57c993b4ef86a821508bf050e3efd812f682b483862550dc977423d1c8",
+    "reuse_similarity_sha256": "4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301",
+    "universal_index_sha256": "aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2"
+  },
+  "registry_version": "LTMD_U1_VERTICAL_REGISTRY_0.1",
+  "result_state": "exploratory_signal",
+  "scientific_state": {
+    "aliases_created": false,
+    "semantic_ready": false,
+    "text_verified": false
+  },
+  "verticals": [
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe ocurrencias léxicas asociadas con ciudadanía, democracia y derechos; no equivale a presencia curricular validada de educación cívica o derechos humanos.",
+      "label_es": "Ciudadanía, democracia y derechos",
+      "metrics": {"candidate_books": 193, "candidate_pages": 907, "candidate_pages_per_1000": 10.47961270494171, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Democracia", "metrics": {"candidate_books": 107, "candidate_pages": 359, "candidate_pages_per_1000": 4.147939317611988, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "democracy"},
+        {"label_es": "Ciudadanía", "metrics": {"candidate_books": 143, "candidate_pages": 402, "candidate_pages_per_1000": 4.644767703844065, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "citizenship"},
+        {"label_es": "Derechos humanos", "metrics": {"candidate_books": 52, "candidate_pages": 272, "candidate_pages_per_1000": 3.1427283966308104, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "human_rights"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 198, "candidate_pages_with_cross_generation_reuse_similarity_signal": 181, "share_candidate_pages_with_any_reuse_similarity_signal": 0.21830209481808158},
+      "status": "materialized_exploratory",
+      "vertical_id": "citizenship_democracy_rights"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas sobre mujer, género y familia; no identifica por sí sola roles, estereotipos, igualdad, relaciones de género ni modelos familiares.",
+      "label_es": "Mujeres, género y familia",
+      "metrics": {"candidate_books": 475, "candidate_pages": 6569, "candidate_pages_per_1000": 75.89920160833748, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Mujer/mujeres", "metrics": {"candidate_books": 380, "candidate_pages": 2523, "candidate_pages_per_1000": 29.151116708454172, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "women"},
+        {"label_es": "Género", "metrics": {"candidate_books": 255, "candidate_pages": 704, "candidate_pages_per_1000": 8.134120555985627, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "gender"},
+        {"label_es": "Familia", "metrics": {"candidate_books": 461, "candidate_pages": 3816, "candidate_pages_per_1000": 44.09063074096754, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "family"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 1748, "candidate_pages_with_cross_generation_reuse_similarity_signal": 1461, "share_candidate_pages_with_any_reuse_similarity_signal": 0.266098340691125},
+      "status": "materialized_exploratory",
+      "vertical_id": "gender_women_family"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas ambientales; no demuestra educación ambiental, enfoque ecológico ni valoración normativa de la naturaleza.",
+      "label_es": "Medio ambiente y naturaleza",
+      "metrics": {"candidate_books": 400, "candidate_pages": 2526, "candidate_pages_per_1000": 29.185779154005246, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Medio ambiente", "metrics": {"candidate_books": 206, "candidate_pages": 427, "candidate_pages_per_1000": 4.933621416769691, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "environment_phrase"},
+        {"label_es": "Naturaleza", "metrics": {"candidate_books": 359, "candidate_pages": 1887, "candidate_pages_per_1000": 21.802678251626247, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "nature"},
+        {"label_es": "Ecología/ecológico", "metrics": {"candidate_books": 144, "candidate_pages": 308, "candidate_pages_per_1000": 3.5586777432437113, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "ecology"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 541, "candidate_pages_with_cross_generation_reuse_similarity_signal": 478, "share_candidate_pages_with_any_reuse_similarity_signal": 0.21417260490894696},
+      "status": "materialized_exploratory",
+      "vertical_id": "environment_nature"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas de migración y movilidad; no clasifica causas, direcciones, poblaciones, valoración social ni tratamiento histórico.",
+      "label_es": "Migración y movilidad",
+      "metrics": {"candidate_books": 134, "candidate_pages": 483, "candidate_pages_per_1000": 5.580653733723093, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Migración", "metrics": {"candidate_books": 97, "candidate_pages": 289, "candidate_pages_per_1000": 3.339148921420236, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "migration"},
+        {"label_es": "Migrante/migrantes", "metrics": {"candidate_books": 59, "candidate_pages": 152, "candidate_pages_per_1000": 1.7562305745878057, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "migrants"},
+        {"label_es": "Inmigración/emigración", "metrics": {"candidate_books": 68, "candidate_pages": 144, "candidate_pages_per_1000": 1.6637973864516054, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "immigration_emigration"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 51, "candidate_pages_with_cross_generation_reuse_similarity_signal": 51, "share_candidate_pages_with_any_reuse_similarity_signal": 0.10559006211180125},
+      "status": "materialized_exploratory",
+      "vertical_id": "migration_mobility"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe ocurrencias léxicas sobre trabajo y economía; no equivale a una clasificación de modelos económicos, clases sociales, condiciones laborales ni educación financiera.",
+      "label_es": "Trabajo y economía",
+      "metrics": {"candidate_books": 473, "candidate_pages": 8559, "candidate_pages_per_1000": 98.89195715721729, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Trabajo", "metrics": {"candidate_books": 470, "candidate_pages": 7246, "candidate_pages_per_1000": 83.72136015436342, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "work"},
+        {"label_es": "Trabajador/trabajadora", "metrics": {"candidate_books": 142, "candidate_pages": 242, "candidate_pages_per_1000": 2.796103941120059, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "workers"},
+        {"label_es": "Economía/empleo", "metrics": {"candidate_books": 265, "candidate_pages": 1454, "candidate_pages_per_1000": 16.799731943754406, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "economy_employment"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 2318, "candidate_pages_with_cross_generation_reuse_similarity_signal": 2095, "share_candidate_pages_with_any_reuse_similarity_signal": 0.27082603107839703},
+      "status": "materialized_exploratory",
+      "vertical_id": "work_economy"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas; no identifica modelos de discapacidad, prácticas inclusivas, ajustes razonables ni calidad del tratamiento pedagógico.",
+      "label_es": "Discapacidad e inclusión",
+      "metrics": {"candidate_books": 54, "candidate_pages": 150, "candidate_pages_per_1000": 1.7331222775537558, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Discapacidad", "metrics": {"candidate_books": 38, "candidate_pages": 95, "candidate_pages_per_1000": 1.0976441091173785, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "disability"},
+        {"label_es": "Inclusión/inclusivo", "metrics": {"candidate_books": 28, "candidate_pages": 56, "candidate_pages_per_1000": 0.6470323169534021, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "inclusion"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 48, "candidate_pages_with_cross_generation_reuse_similarity_signal": 46, "share_candidate_pages_with_any_reuse_similarity_signal": 0.32},
+      "status": "materialized_exploratory",
+      "vertical_id": "disability_inclusion"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas sobre ciencia y tecnología; no demuestra alfabetización científica, enfoque STEM, innovación ni postura frente al cambio tecnológico.",
+      "label_es": "Ciencia y tecnología",
+      "metrics": {"candidate_books": 309, "candidate_pages": 1872, "candidate_pages_per_1000": 21.629366023870872, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "Ciencia/científico", "metrics": {"candidate_books": 294, "candidate_pages": 1356, "candidate_pages_per_1000": 15.667425389085949, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "science"},
+        {"label_es": "Tecnología/tecnológico", "metrics": {"candidate_books": 215, "candidate_pages": 754, "candidate_pages_per_1000": 8.71182798183688, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "technology"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 399, "candidate_pages_with_cross_generation_reuse_similarity_signal": 342, "share_candidate_pages_with_any_reuse_similarity_signal": 0.21314102564102563},
+      "status": "materialized_exploratory",
+      "vertical_id": "science_technology"
+    },
+    {
+      "breakdown_cardinality": {"generation": 11, "grade_code": 6, "wave": 11},
+      "interpretation_boundary": "Describe señales léxicas de México, nación e identidad; no equivale a nacionalismo, identidad nacional, ciudadanía, pertenencia ni valoración histórica.",
+      "label_es": "Nación, identidad y México",
+      "metrics": {"candidate_books": 492, "candidate_pages": 15974, "candidate_pages_per_1000": 184.56596841095796, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549},
+      "probes": [
+        {"label_es": "México", "metrics": {"candidate_books": 492, "candidate_pages": 13263, "candidate_pages_per_1000": 153.24267178130307, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "mexico"},
+        {"label_es": "Mexicano/mexicana", "metrics": {"candidate_books": 463, "candidate_pages": 4797, "candidate_pages_per_1000": 55.4252504361691, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "mexican"},
+        {"label_es": "Nación/identidad", "metrics": {"candidate_books": 295, "candidate_pages": 1644, "candidate_pages_per_1000": 18.995020161989164, "corpus_books_in_scope": 492, "corpus_pages_in_scope": 86549}, "probe_id": "nation_identity"}
+      ],
+      "reuse_context": {"candidate_pages_with_any_reuse_similarity_signal": 2485, "candidate_pages_with_cross_generation_reuse_similarity_signal": 2124, "share_candidate_pages_with_any_reuse_similarity_signal": 0.15556529360210342},
+      "status": "materialized_exploratory",
+      "vertical_id": "nation_identity_mexico"
+    }
+  ]
+}

--- a/docs/LTMD_U1_VERTICAL_MATERIALIZATION_0_1.md
+++ b/docs/LTMD_U1_VERTICAL_MATERIALIZATION_0_1.md
@@ -1,0 +1,45 @@
+# LTMD-U1 — materialización de verticales exploratorios 0.1
+
+## Estado
+
+Versión: `LTMD_U1_VERTICAL_MATERIALIZATION_0.1`  
+Registro preregistrado: `LTMD_U1_VERTICAL_REGISTRY_0.1`  
+Estado epistemológico: `exploratory_signal`  
+Validación humana completa: **no**.
+
+Esta materialización ejecuta, sin modificar después de observar resultados, las ocho especificaciones temáticas fusionadas previamente en el registro 0.1. Los resultados son señales léxicas/OCR derivadas de FTS5 y no equivalen a clasificaciones semánticas ni a afirmaciones históricas validadas.
+
+## Universo
+
+- 86,549 páginas del Índice Universal LTMD-U1 0.1.
+- 492 objetos canónicos.
+- Desgloses exactos por 11 generaciones, 6 grados y 11 olas operacionales para cada vertical.
+- Contexto agregado de reutilización/similitud corpus-wide para cada vertical.
+
+## Resultados globales
+
+| Vertical | Páginas candidatas | Libros | Páginas por 1,000 | Con señal de reuso/similitud |
+|---|---:|---:|---:|---:|
+| Ciudadanía, democracia y derechos | 907 | 193 | 10.48 | 198 |
+| Mujeres, género y familia | 6,569 | 475 | 75.90 | 1,748 |
+| Medio ambiente y naturaleza | 2,526 | 400 | 29.19 | 541 |
+| Migración y movilidad | 483 | 134 | 5.58 | 51 |
+| Trabajo y economía | 8,559 | 473 | 98.89 | 2,318 |
+| Discapacidad e inclusión | 150 | 54 | 1.73 | 48 |
+| Ciencia y tecnología | 1,872 | 309 | 21.63 | 399 |
+| Nación, identidad y México | 15,974 | 492 | 184.57 | 2,485 |
+
+La amplitud de algunos verticales —especialmente `nation_identity_mexico`, `work_economy` y `gender_women_family`— es parte del resultado del protocolo preregistrado y **no** se corrige retrospectivamente. Cualquier refinamiento futuro deberá publicarse como una nueva versión del registro y de su materialización.
+
+## Procedencia
+
+- Registro SHA-256: `9a4f3b57c993b4ef86a821508bf050e3efd812f682b483862550dc977423d1c8`.
+- Índice Universal SHA-256: `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`.
+- Reutilización/similitud SHA-256: `4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301`.
+- Materialización integral reproducida: 120,354 bytes; SHA-256 `e2faab966faced48327634c4acd40a867b76add29612538736b91db8d3afb0ad`.
+
+GitHub conserva un registro público agregado del resultado integral y su hash. El constructor puede regenerar el detalle completo a partir de los insumos privados canónicos.
+
+## Privacidad y no regresión
+
+La superficie pública no emite `page_id`, identificadores de objetos, pares concretos, OCR, snippets ni hashes de páginas fuente. `search_hit != historical_claim`, `computational_candidate != semantic_ready` y `zero_hits != demonstrated_absence` permanecen como reglas obligatorias. La materialización no crea aliases y el contexto de similitud no establece identidad documental ni equivalencia semántica.

--- a/schemas/ltmd_u1_vertical_materialization.schema.json
+++ b/schemas/ltmd_u1_vertical_materialization.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_vertical_materialization.schema.json",
+  "title": "LTMD-U1 exploratory vertical materialization 0.1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["materialization_version","builder_version","registry_version","result_state","corpus","provenance","scientific_state","privacy","verticals"],
+  "properties": {
+    "materialization_version": {"const": "LTMD_U1_VERTICAL_MATERIALIZATION_0.1"},
+    "builder_version": {"const": "LTMD_U1_VERTICAL_MATERIALIZER_0.1"},
+    "registry_version": {"const": "LTMD_U1_VERTICAL_REGISTRY_0.1"},
+    "result_state": {"const": "exploratory_signal"},
+    "corpus": {
+      "type":"object","additionalProperties":false,"required":["pages","canonical_objects"],
+      "properties":{"pages":{"type":"integer","minimum":1},"canonical_objects":{"type":"integer","minimum":1}}
+    },
+    "provenance": {
+      "type":"object","additionalProperties":false,
+      "required":["registry_sha256","universal_index_sha256","reuse_similarity_sha256","human_validation_complete"],
+      "properties":{
+        "registry_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "reuse_similarity_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
+        "human_validation_complete":{"const":false}
+      }
+    },
+    "scientific_state": {
+      "type":"object","additionalProperties":false,"required":["text_verified","semantic_ready","aliases_created"],
+      "properties":{"text_verified":{"const":false},"semantic_ready":{"const":false},"aliases_created":{"const":false}}
+    },
+    "privacy": {
+      "type":"object","additionalProperties":false,
+      "required":["page_identifiers_emitted","object_identifiers_emitted","pair_identifiers_emitted","ocr_text_emitted","source_hash_values_emitted"],
+      "properties":{
+        "page_identifiers_emitted":{"const":false},"object_identifiers_emitted":{"const":false},"pair_identifiers_emitted":{"const":false},
+        "ocr_text_emitted":{"const":false},"source_hash_values_emitted":{"const":false}
+      }
+    },
+    "verticals":{"type":"array","minItems":8,"maxItems":8,"items":{"$ref":"#/$defs/vertical"}}
+  },
+  "$defs": {
+    "metrics": {
+      "type":"object","additionalProperties":false,
+      "required":["candidate_pages","candidate_books","corpus_pages_in_scope","corpus_books_in_scope","candidate_pages_per_1000"],
+      "properties":{
+        "candidate_pages":{"type":"integer","minimum":0},"candidate_books":{"type":"integer","minimum":0},
+        "corpus_pages_in_scope":{"type":"integer","minimum":0},"corpus_books_in_scope":{"type":"integer","minimum":0},
+        "candidate_pages_per_1000":{"oneOf":[{"type":"null"},{"type":"number","minimum":0}]}
+      }
+    },
+    "reuse_metrics": {
+      "type":"object","additionalProperties":false,
+      "required":["candidate_pages","mapped_candidate_pages","unmapped_candidate_pages","candidate_pages_with_exact_source_cross_object_reuse","candidate_pages_with_exact_source_cross_generation_reuse","candidate_pages_with_exact_text_cross_object_reuse","candidate_pages_with_exact_text_cross_generation_reuse","candidate_pages_with_similarity_signal","candidate_pages_with_near_exact_signal","candidate_pages_with_cross_generation_similarity_signal","candidate_pages_with_any_reuse_similarity_signal","candidate_pages_with_cross_generation_reuse_similarity_signal","candidate_pages_without_reuse_similarity_signal","internal_similarity_pairs","internal_near_exact_pairs","share_candidate_pages_with_any_reuse_similarity_signal"],
+      "properties":{
+        "candidate_pages":{"type":"integer","minimum":0},"mapped_candidate_pages":{"type":"integer","minimum":0},"unmapped_candidate_pages":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_source_cross_object_reuse":{"type":"integer","minimum":0},"candidate_pages_with_exact_source_cross_generation_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_exact_text_cross_object_reuse":{"type":"integer","minimum":0},"candidate_pages_with_exact_text_cross_generation_reuse":{"type":"integer","minimum":0},
+        "candidate_pages_with_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_with_near_exact_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_cross_generation_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_with_any_reuse_similarity_signal":{"type":"integer","minimum":0},
+        "candidate_pages_with_cross_generation_reuse_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_without_reuse_similarity_signal":{"type":"integer","minimum":0},
+        "internal_similarity_pairs":{"type":"integer","minimum":0},"internal_near_exact_pairs":{"type":"integer","minimum":0},
+        "share_candidate_pages_with_any_reuse_similarity_signal":{"oneOf":[{"type":"null"},{"type":"number","minimum":0,"maximum":1}]}
+      }
+    },
+    "reuse_context": {
+      "type":"object","additionalProperties":false,"required":["context_version","result_state","metrics","warnings"],
+      "properties":{
+        "context_version":{"const":"LTMD_VERTICAL_REUSE_CONTEXT_0.1"},"result_state":{"const":"exploratory_signal"},
+        "metrics":{"$ref":"#/$defs/reuse_metrics"},
+        "warnings":{"type":"array","minItems":2,"items":{"type":"string","minLength":1}}
+      }
+    },
+    "breakdown_item": {
+      "type":"object","additionalProperties":false,"required":["dimension","value","result_state","metrics"],
+      "properties":{
+        "dimension":{"enum":["generation","grade_code","wave"]},"value":{"type":"string","minLength":1},"result_state":{"const":"exploratory_signal"},"metrics":{"$ref":"#/$defs/metrics"}
+      }
+    },
+    "probe": {
+      "type":"object","additionalProperties":false,"required":["probe_id","label_es","fts5_expression","result_state","metrics"],
+      "properties":{
+        "probe_id":{"type":"string","pattern":"^[a-z0-9_]+$"},"label_es":{"type":"string","minLength":2},"fts5_expression":{"type":"string","minLength":1},
+        "result_state":{"const":"exploratory_signal"},"metrics":{"$ref":"#/$defs/metrics"}
+      }
+    },
+    "vertical": {
+      "type":"object","additionalProperties":false,
+      "required":["vertical_id","label_es","status","union_expression","interpretation_boundary","result_state","metrics","breakdowns","probes","reuse_context","warnings"],
+      "properties":{
+        "vertical_id":{"type":"string","pattern":"^[a-z0-9_]+$"},"label_es":{"type":"string","minLength":3},"status":{"const":"materialized_exploratory"},
+        "union_expression":{"type":"string","minLength":1},"interpretation_boundary":{"type":"string","minLength":40},"result_state":{"const":"exploratory_signal"},
+        "metrics":{"$ref":"#/$defs/metrics"},
+        "breakdowns":{
+          "type":"object","additionalProperties":false,"required":["generation","grade_code","wave"],
+          "properties":{
+            "generation":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}},
+            "grade_code":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}},
+            "wave":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}}
+          }
+        },
+        "probes":{"type":"array","minItems":2,"items":{"$ref":"#/$defs/probe"}},
+        "reuse_context":{"$ref":"#/$defs/reuse_context"},
+        "warnings":{"type":"array","minItems":2,"items":{"type":"string","minLength":1}}
+      }
+    }
+  }
+}

--- a/schemas/ltmd_u1_vertical_materialization.schema.json
+++ b/schemas/ltmd_u1_vertical_materialization.schema.json
@@ -1,107 +1,28 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/schemas/ltmd_u1_vertical_materialization.schema.json",
-  "title": "LTMD-U1 exploratory vertical materialization 0.1",
+  "title": "LTMD-U1 exploratory vertical materialization public record 0.1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["materialization_version","builder_version","registry_version","result_state","corpus","provenance","scientific_state","privacy","verticals"],
+  "required": ["materialization_version","builder_version","registry_version","result_state","corpus","provenance","scientific_state","privacy","full_materialization_sha256","full_materialization_bytes","verticals"],
   "properties": {
     "materialization_version": {"const": "LTMD_U1_VERTICAL_MATERIALIZATION_0.1"},
     "builder_version": {"const": "LTMD_U1_VERTICAL_MATERIALIZER_0.1"},
     "registry_version": {"const": "LTMD_U1_VERTICAL_REGISTRY_0.1"},
     "result_state": {"const": "exploratory_signal"},
-    "corpus": {
-      "type":"object","additionalProperties":false,"required":["pages","canonical_objects"],
-      "properties":{"pages":{"type":"integer","minimum":1},"canonical_objects":{"type":"integer","minimum":1}}
-    },
-    "provenance": {
-      "type":"object","additionalProperties":false,
-      "required":["registry_sha256","universal_index_sha256","reuse_similarity_sha256","human_validation_complete"],
-      "properties":{
-        "registry_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
-        "universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
-        "reuse_similarity_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},
-        "human_validation_complete":{"const":false}
-      }
-    },
-    "scientific_state": {
-      "type":"object","additionalProperties":false,"required":["text_verified","semantic_ready","aliases_created"],
-      "properties":{"text_verified":{"const":false},"semantic_ready":{"const":false},"aliases_created":{"const":false}}
-    },
-    "privacy": {
-      "type":"object","additionalProperties":false,
-      "required":["page_identifiers_emitted","object_identifiers_emitted","pair_identifiers_emitted","ocr_text_emitted","source_hash_values_emitted"],
-      "properties":{
-        "page_identifiers_emitted":{"const":false},"object_identifiers_emitted":{"const":false},"pair_identifiers_emitted":{"const":false},
-        "ocr_text_emitted":{"const":false},"source_hash_values_emitted":{"const":false}
-      }
-    },
-    "verticals":{"type":"array","minItems":8,"maxItems":8,"items":{"$ref":"#/$defs/vertical"}}
+    "corpus": {"type":"object","additionalProperties":false,"required":["pages","canonical_objects"],"properties":{"pages":{"const":86549},"canonical_objects":{"const":492}}},
+    "provenance": {"type":"object","additionalProperties":false,"required":["registry_sha256","universal_index_sha256","reuse_similarity_sha256","human_validation_complete"],"properties":{"registry_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"universal_index_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"reuse_similarity_sha256":{"type":"string","pattern":"^[a-f0-9]{64}$"},"human_validation_complete":{"const":false}}},
+    "scientific_state": {"type":"object","additionalProperties":false,"required":["text_verified","semantic_ready","aliases_created"],"properties":{"text_verified":{"const":false},"semantic_ready":{"const":false},"aliases_created":{"const":false}}},
+    "privacy": {"type":"object","additionalProperties":false,"required":["page_identifiers_emitted","object_identifiers_emitted","pair_identifiers_emitted","ocr_text_emitted","source_hash_values_emitted"],"properties":{"page_identifiers_emitted":{"const":false},"object_identifiers_emitted":{"const":false},"pair_identifiers_emitted":{"const":false},"ocr_text_emitted":{"const":false},"source_hash_values_emitted":{"const":false}}},
+    "full_materialization_sha256": {"type":"string","pattern":"^[a-f0-9]{64}$"},
+    "full_materialization_bytes": {"type":"integer","minimum":1},
+    "verticals": {"type":"array","minItems":8,"maxItems":8,"items":{"$ref":"#/$defs/vertical"}}
   },
   "$defs": {
-    "metrics": {
-      "type":"object","additionalProperties":false,
-      "required":["candidate_pages","candidate_books","corpus_pages_in_scope","corpus_books_in_scope","candidate_pages_per_1000"],
-      "properties":{
-        "candidate_pages":{"type":"integer","minimum":0},"candidate_books":{"type":"integer","minimum":0},
-        "corpus_pages_in_scope":{"type":"integer","minimum":0},"corpus_books_in_scope":{"type":"integer","minimum":0},
-        "candidate_pages_per_1000":{"oneOf":[{"type":"null"},{"type":"number","minimum":0}]}
-      }
-    },
-    "reuse_metrics": {
-      "type":"object","additionalProperties":false,
-      "required":["candidate_pages","mapped_candidate_pages","unmapped_candidate_pages","candidate_pages_with_exact_source_cross_object_reuse","candidate_pages_with_exact_source_cross_generation_reuse","candidate_pages_with_exact_text_cross_object_reuse","candidate_pages_with_exact_text_cross_generation_reuse","candidate_pages_with_similarity_signal","candidate_pages_with_near_exact_signal","candidate_pages_with_cross_generation_similarity_signal","candidate_pages_with_any_reuse_similarity_signal","candidate_pages_with_cross_generation_reuse_similarity_signal","candidate_pages_without_reuse_similarity_signal","internal_similarity_pairs","internal_near_exact_pairs","share_candidate_pages_with_any_reuse_similarity_signal"],
-      "properties":{
-        "candidate_pages":{"type":"integer","minimum":0},"mapped_candidate_pages":{"type":"integer","minimum":0},"unmapped_candidate_pages":{"type":"integer","minimum":0},
-        "candidate_pages_with_exact_source_cross_object_reuse":{"type":"integer","minimum":0},"candidate_pages_with_exact_source_cross_generation_reuse":{"type":"integer","minimum":0},
-        "candidate_pages_with_exact_text_cross_object_reuse":{"type":"integer","minimum":0},"candidate_pages_with_exact_text_cross_generation_reuse":{"type":"integer","minimum":0},
-        "candidate_pages_with_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_with_near_exact_signal":{"type":"integer","minimum":0},
-        "candidate_pages_with_cross_generation_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_with_any_reuse_similarity_signal":{"type":"integer","minimum":0},
-        "candidate_pages_with_cross_generation_reuse_similarity_signal":{"type":"integer","minimum":0},"candidate_pages_without_reuse_similarity_signal":{"type":"integer","minimum":0},
-        "internal_similarity_pairs":{"type":"integer","minimum":0},"internal_near_exact_pairs":{"type":"integer","minimum":0},
-        "share_candidate_pages_with_any_reuse_similarity_signal":{"oneOf":[{"type":"null"},{"type":"number","minimum":0,"maximum":1}]}
-      }
-    },
-    "reuse_context": {
-      "type":"object","additionalProperties":false,"required":["context_version","result_state","metrics","warnings"],
-      "properties":{
-        "context_version":{"const":"LTMD_VERTICAL_REUSE_CONTEXT_0.1"},"result_state":{"const":"exploratory_signal"},
-        "metrics":{"$ref":"#/$defs/reuse_metrics"},
-        "warnings":{"type":"array","minItems":2,"items":{"type":"string","minLength":1}}
-      }
-    },
-    "breakdown_item": {
-      "type":"object","additionalProperties":false,"required":["dimension","value","result_state","metrics"],
-      "properties":{
-        "dimension":{"enum":["generation","grade_code","wave"]},"value":{"type":"string","minLength":1},"result_state":{"const":"exploratory_signal"},"metrics":{"$ref":"#/$defs/metrics"}
-      }
-    },
-    "probe": {
-      "type":"object","additionalProperties":false,"required":["probe_id","label_es","fts5_expression","result_state","metrics"],
-      "properties":{
-        "probe_id":{"type":"string","pattern":"^[a-z0-9_]+$"},"label_es":{"type":"string","minLength":2},"fts5_expression":{"type":"string","minLength":1},
-        "result_state":{"const":"exploratory_signal"},"metrics":{"$ref":"#/$defs/metrics"}
-      }
-    },
-    "vertical": {
-      "type":"object","additionalProperties":false,
-      "required":["vertical_id","label_es","status","union_expression","interpretation_boundary","result_state","metrics","breakdowns","probes","reuse_context","warnings"],
-      "properties":{
-        "vertical_id":{"type":"string","pattern":"^[a-z0-9_]+$"},"label_es":{"type":"string","minLength":3},"status":{"const":"materialized_exploratory"},
-        "union_expression":{"type":"string","minLength":1},"interpretation_boundary":{"type":"string","minLength":40},"result_state":{"const":"exploratory_signal"},
-        "metrics":{"$ref":"#/$defs/metrics"},
-        "breakdowns":{
-          "type":"object","additionalProperties":false,"required":["generation","grade_code","wave"],
-          "properties":{
-            "generation":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}},
-            "grade_code":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}},
-            "wave":{"type":"array","minItems":1,"items":{"$ref":"#/$defs/breakdown_item"}}
-          }
-        },
-        "probes":{"type":"array","minItems":2,"items":{"$ref":"#/$defs/probe"}},
-        "reuse_context":{"$ref":"#/$defs/reuse_context"},
-        "warnings":{"type":"array","minItems":2,"items":{"type":"string","minLength":1}}
-      }
-    }
+    "metrics": {"type":"object","additionalProperties":false,"required":["candidate_pages","candidate_books","candidate_pages_per_1000","corpus_pages_in_scope","corpus_books_in_scope"],"properties":{"candidate_pages":{"type":"integer","minimum":0},"candidate_books":{"type":"integer","minimum":0},"candidate_pages_per_1000":{"type":"number","minimum":0},"corpus_pages_in_scope":{"type":"integer","minimum":1},"corpus_books_in_scope":{"type":"integer","minimum":1}}},
+    "probe": {"type":"object","additionalProperties":false,"required":["probe_id","label_es","metrics"],"properties":{"probe_id":{"type":"string","minLength":1},"label_es":{"type":"string","minLength":1},"metrics":{"$ref":"#/$defs/metrics"}}},
+    "reuse": {"type":"object","additionalProperties":false,"required":["candidate_pages_with_any_reuse_similarity_signal","share_candidate_pages_with_any_reuse_similarity_signal","candidate_pages_with_cross_generation_reuse_similarity_signal"],"properties":{"candidate_pages_with_any_reuse_similarity_signal":{"type":"integer","minimum":0},"share_candidate_pages_with_any_reuse_similarity_signal":{"type":"number","minimum":0,"maximum":1},"candidate_pages_with_cross_generation_reuse_similarity_signal":{"type":"integer","minimum":0}}},
+    "cardinality": {"type":"object","additionalProperties":false,"required":["generation","grade_code","wave"],"properties":{"generation":{"const":11},"grade_code":{"const":6},"wave":{"const":11}}},
+    "vertical": {"type":"object","additionalProperties":false,"required":["vertical_id","label_es","status","metrics","reuse_context","probes","breakdown_cardinality","interpretation_boundary"],"properties":{"vertical_id":{"type":"string","minLength":1},"label_es":{"type":"string","minLength":1},"status":{"const":"materialized_exploratory"},"metrics":{"$ref":"#/$defs/metrics"},"reuse_context":{"$ref":"#/$defs/reuse"},"probes":{"type":"array","minItems":2,"items":{"$ref":"#/$defs/probe"}},"breakdown_cardinality":{"$ref":"#/$defs/cardinality"},"interpretation_boundary":{"type":"string","minLength":40}}}
   }
 }

--- a/scripts/materialize_u1_vertical_registry.py
+++ b/scripts/materialize_u1_vertical_registry.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import argparse, hashlib, json, re, sqlite3
+from pathlib import Path
+
+MATERIALIZATION_VERSION='LTMD_U1_VERTICAL_MATERIALIZATION_0.1'
+BUILDER_VERSION='LTMD_U1_VERTICAL_MATERIALIZER_0.1'
+INDEX_VERSION='LTMD_U1_UNIVERSAL_INDEX_0.1'
+REUSE_VERSION='LTMD_U1_REUSE_SIMILARITY_0.1'
+REGISTRY_VERSION='LTMD_U1_VERTICAL_REGISTRY_0.1'
+DIMENSIONS={'generation':'catalog_generation','grade_code':'grade_code','wave':'wave'}
+SHA_RE=re.compile(r'^[a-f0-9]{64}$')
+
+def sha256_file(path:Path)->str:
+    h=hashlib.sha256()
+    with path.open('rb') as f:
+        for chunk in iter(lambda:f.read(1024*1024),b''): h.update(chunk)
+    return h.hexdigest()
+
+def verify(path:Path,expected:str|None,label:str)->str:
+    if not path.is_file(): raise RuntimeError(f'{label} unavailable')
+    actual=sha256_file(path)
+    if expected:
+        e=expected.strip().lower()
+        if not SHA_RE.fullmatch(e): raise RuntimeError(f'invalid expected {label} sha')
+        if actual!=e: raise RuntimeError(f'{label} SHA mismatch')
+    return actual
+
+def decode_meta(c,table):
+    out={}
+    for k,v in c.execute(f'SELECT key,value FROM {table}'):
+        try: out[k]=json.loads(v)
+        except Exception: out[k]=v
+    return out
+
+def validate_index(c):
+    tables={r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type IN ('table','view')")}
+    if not {'pages','pages_fts','index_meta'}<=tables: raise RuntimeError('invalid universal index')
+    if decode_meta(c,'index_meta').get('builder_version')!=INDEX_VERSION: raise RuntimeError('unsupported universal index')
+
+def validate_reuse(c):
+    req={'meta','exact_source_groups','exact_source_members','exact_text_groups','exact_text_members','similarity_candidates'}
+    tables={r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    if not req<=tables: raise RuntimeError('invalid reuse artifact')
+    if decode_meta(c,'meta').get('artifact_version')!=REUSE_VERSION: raise RuntimeError('unsupported reuse artifact')
+
+def load_registry(path):
+    d=json.loads(path.read_text(encoding='utf-8'))
+    if d.get('registry_version')!=REGISTRY_VERSION or d.get('frozen_before_materialization') is not True: raise RuntimeError('registry is not frozen 0.1')
+    if d.get('result_state')!='exploratory_signal': raise RuntimeError('registry state mismatch')
+    return d
+
+def count_scope(c,dimension=None,value=None):
+    if dimension is None:
+        row=c.execute('SELECT COUNT(*),COUNT(DISTINCT canonical_viewer_key) FROM pages').fetchone()
+    else:
+        col=DIMENSIONS[dimension]
+        row=c.execute(f'SELECT COUNT(*),COUNT(DISTINCT canonical_viewer_key) FROM pages WHERE {col}=?',(value,)).fetchone()
+    return int(row[0]),int(row[1])
+
+def hit_rowids(c,expr):
+    try:
+        return [int(r[0]) for r in c.execute("SELECT p.id FROM pages_fts f JOIN pages p ON p.id=f.rowid WHERE pages_fts MATCH ? ORDER BY p.id",(expr,))]
+    except sqlite3.OperationalError as e:
+        raise RuntimeError(f'invalid FTS expression: {expr}') from e
+
+def metrics(c,expr):
+    try:
+        row=c.execute("SELECT COUNT(*),COUNT(DISTINCT p.canonical_viewer_key) FROM pages_fts f JOIN pages p ON p.id=f.rowid WHERE pages_fts MATCH ?",(expr,)).fetchone()
+    except sqlite3.OperationalError as e:
+        raise RuntimeError(f'invalid FTS expression: {expr}') from e
+    corpus_pages,corpus_books=count_scope(c)
+    pages,books=int(row[0]),int(row[1])
+    return {'candidate_pages':pages,'candidate_books':books,'corpus_pages_in_scope':corpus_pages,'corpus_books_in_scope':corpus_books,'candidate_pages_per_1000':pages/corpus_pages*1000 if corpus_pages else None}
+
+def breakdown(c,expr,dim):
+    col=DIMENSIONS[dim]
+    scopes={r[0]:(int(r[1]),int(r[2])) for r in c.execute(f'SELECT {col},COUNT(*),COUNT(DISTINCT canonical_viewer_key) FROM pages WHERE {col} IS NOT NULL GROUP BY {col} ORDER BY {col}')}
+    try:
+        hits={r[0]:(int(r[1]),int(r[2])) for r in c.execute(f'SELECT p.{col},COUNT(*),COUNT(DISTINCT p.canonical_viewer_key) FROM pages_fts f JOIN pages p ON p.id=f.rowid WHERE pages_fts MATCH ? AND p.{col} IS NOT NULL GROUP BY p.{col}',(expr,))}
+    except sqlite3.OperationalError as e:
+        raise RuntimeError(f'invalid FTS expression: {expr}') from e
+    rows=[]
+    for value,(cp,cb) in scopes.items():
+        hp,hb=hits.get(value,(0,0))
+        rows.append({'dimension':dim,'value':str(value),'result_state':'exploratory_signal','metrics':{'candidate_pages':hp,'candidate_books':hb,'corpus_pages_in_scope':cp,'corpus_books_in_scope':cb,'candidate_pages_per_1000':hp/cp*1000 if cp else None}})
+    return rows
+
+def empty_context():
+    return {'context_version':'LTMD_VERTICAL_REUSE_CONTEXT_0.1','result_state':'exploratory_signal','metrics':{
+        'candidate_pages':0,'mapped_candidate_pages':0,'unmapped_candidate_pages':0,
+        'candidate_pages_with_exact_source_cross_object_reuse':0,'candidate_pages_with_exact_source_cross_generation_reuse':0,
+        'candidate_pages_with_exact_text_cross_object_reuse':0,'candidate_pages_with_exact_text_cross_generation_reuse':0,
+        'candidate_pages_with_similarity_signal':0,'candidate_pages_with_near_exact_signal':0,
+        'candidate_pages_with_cross_generation_similarity_signal':0,'candidate_pages_with_any_reuse_similarity_signal':0,
+        'candidate_pages_with_cross_generation_reuse_similarity_signal':0,'candidate_pages_without_reuse_similarity_signal':0,
+        'internal_similarity_pairs':0,'internal_near_exact_pairs':0,'share_candidate_pages_with_any_reuse_similarity_signal':None},
+        'warnings':['Reuse/similarity context is computational evidence and does not create aliases or establish semantic equivalence.','Counts qualify lexical candidates; they do not validate or invalidate the vertical.']}
+
+def reuse_context(index,reuse,rowids):
+    n=len(rowids)
+    if not n: return empty_context()
+    reuse.execute('DROP TABLE IF EXISTS temp.vertical_candidates')
+    reuse.execute('CREATE TEMP TABLE vertical_candidates(page_rowid INTEGER PRIMARY KEY) WITHOUT ROWID')
+    reuse.executemany('INSERT INTO vertical_candidates VALUES(?)',((x,) for x in rowids))
+    def count_member(members,groups,col):
+        return int(reuse.execute(f'SELECT COUNT(DISTINCT m.page_rowid) FROM {members} m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid JOIN {groups} g ON g.group_id=m.group_id WHERE g.{col}=1').fetchone()[0])
+    es_obj=count_member('exact_source_members','exact_source_groups','cross_object')
+    es_gen=count_member('exact_source_members','exact_source_groups','cross_generation')
+    et_obj=count_member('exact_text_members','exact_text_groups','cross_object')
+    et_gen=count_member('exact_text_members','exact_text_groups','cross_generation')
+    candidate=set(rowids)
+    q=','.join('?'*n)
+    gen={int(a):b for a,b in index.execute(f'SELECT id,catalog_generation FROM pages WHERE id IN ({q})',rowids)}
+    sim_rows=reuse.execute('SELECT s.page_a,s.page_b,s.tier FROM similarity_candidates s WHERE EXISTS(SELECT 1 FROM vertical_candidates v WHERE v.page_rowid=s.page_a) OR EXISTS(SELECT 1 FROM vertical_candidates v WHERE v.page_rowid=s.page_b)').fetchall()
+    counterparts={int(p) for a,b,_ in sim_rows for p in (a,b) if int(p) not in gen}
+    if counterparts:
+        vals=list(counterparts);q2=','.join('?'*len(vals));gen.update({int(a):b for a,b in index.execute(f'SELECT id,catalog_generation FROM pages WHERE id IN ({q2})',vals)})
+    sim_pages=set();near=set();crosssim=set();internal=0;internal_near=0
+    for a,b,tier in sim_rows:
+        a=int(a);b=int(b);touched={p for p in (a,b) if p in candidate};sim_pages.update(touched)
+        if tier=='near_exact_candidate': near.update(touched)
+        if gen.get(a)!=gen.get(b): crosssim.update(touched)
+        if a in candidate and b in candidate:
+            internal+=1;internal_near+=int(tier=='near_exact_candidate')
+    any_pages=set(sim_pages);cross_any=set(crosssim)
+    for members,groups,col,target in [
+        ('exact_source_members','exact_source_groups','cross_object',any_pages),('exact_text_members','exact_text_groups','cross_object',any_pages),
+        ('exact_source_members','exact_source_groups','cross_generation',cross_any),('exact_text_members','exact_text_groups','cross_generation',cross_any)]:
+        target.update(int(r[0]) for r in reuse.execute(f'SELECT DISTINCT m.page_rowid FROM {members} m JOIN vertical_candidates v ON v.page_rowid=m.page_rowid JOIN {groups} g ON g.group_id=m.group_id WHERE g.{col}=1'))
+    m={'candidate_pages':n,'mapped_candidate_pages':n,'unmapped_candidate_pages':0,
+       'candidate_pages_with_exact_source_cross_object_reuse':es_obj,'candidate_pages_with_exact_source_cross_generation_reuse':es_gen,
+       'candidate_pages_with_exact_text_cross_object_reuse':et_obj,'candidate_pages_with_exact_text_cross_generation_reuse':et_gen,
+       'candidate_pages_with_similarity_signal':len(sim_pages),'candidate_pages_with_near_exact_signal':len(near),
+       'candidate_pages_with_cross_generation_similarity_signal':len(crosssim),'candidate_pages_with_any_reuse_similarity_signal':len(any_pages),
+       'candidate_pages_with_cross_generation_reuse_similarity_signal':len(cross_any),'candidate_pages_without_reuse_similarity_signal':n-len(any_pages),
+       'internal_similarity_pairs':internal,'internal_near_exact_pairs':internal_near,
+       'share_candidate_pages_with_any_reuse_similarity_signal':len(any_pages)/n}
+    return {'context_version':'LTMD_VERTICAL_REUSE_CONTEXT_0.1','result_state':'exploratory_signal','metrics':m,
+            'warnings':['Reuse/similarity context is computational evidence and does not create aliases or establish semantic equivalence.','Counts qualify lexical candidates; they do not validate or invalidate the vertical.']}
+
+def materialize(registry_path,index_path,reuse_path,expected_index=None,expected_reuse=None):
+    registry_sha=sha256_file(registry_path);index_sha=verify(index_path,expected_index,'index');reuse_sha=verify(reuse_path,expected_reuse,'reuse')
+    reg=load_registry(registry_path)
+    index=sqlite3.connect(f'file:{index_path}?mode=ro',uri=True);reuse=sqlite3.connect(f'file:{reuse_path}?mode=ro',uri=True)
+    try:
+        validate_index(index);validate_reuse(reuse)
+        total_pages,total_books=count_scope(index)
+        verticals=[]
+        for spec in reg['verticals']:
+            overall=metrics(index,spec['union_expression'])
+            ids=hit_rowids(index,spec['union_expression'])
+            breakdowns={dim:breakdown(index,spec['union_expression'],dim) for dim in reg['dimensions']}
+            probes=[]
+            for p in spec['probes']:
+                probes.append({'probe_id':p['probe_id'],'label_es':p['label_es'],'fts5_expression':p['fts5_expression'],'result_state':'exploratory_signal','metrics':metrics(index,p['fts5_expression'])})
+            verticals.append({'vertical_id':spec['vertical_id'],'label_es':spec['label_es'],'status':'materialized_exploratory',
+                'union_expression':spec['union_expression'],'interpretation_boundary':spec['interpretation_boundary'],'result_state':'exploratory_signal',
+                'metrics':overall,'breakdowns':breakdowns,'probes':probes,'reuse_context':reuse_context(index,reuse,ids),
+                'warnings':['FTS5 matches are lexical/OCR-derived exploratory signals, not validated semantic classifications.','Zero hits do not demonstrate historical absence.']})
+        return {'materialization_version':MATERIALIZATION_VERSION,'builder_version':BUILDER_VERSION,'registry_version':REGISTRY_VERSION,
+            'result_state':'exploratory_signal','corpus':{'pages':total_pages,'canonical_objects':total_books},
+            'provenance':{'registry_sha256':registry_sha,'universal_index_sha256':index_sha,'reuse_similarity_sha256':reuse_sha,'human_validation_complete':False},
+            'scientific_state':{'text_verified':False,'semantic_ready':False,'aliases_created':False},
+            'privacy':{'page_identifiers_emitted':False,'object_identifiers_emitted':False,'pair_identifiers_emitted':False,'ocr_text_emitted':False,'source_hash_values_emitted':False},
+            'verticals':verticals}
+    finally:
+        index.close();reuse.close()
+
+def main(argv=None):
+    p=argparse.ArgumentParser();p.add_argument('--registry',required=True);p.add_argument('--index',required=True);p.add_argument('--reuse',required=True);p.add_argument('--expected-index-sha256');p.add_argument('--expected-reuse-sha256');p.add_argument('--output',required=True);a=p.parse_args(argv)
+    out=materialize(Path(a.registry),Path(a.index),Path(a.reuse),a.expected_index_sha256,a.expected_reuse_sha256)
+    Path(a.output).write_text(json.dumps(out,ensure_ascii=False,indent=2,sort_keys=True)+'\n',encoding='utf-8')
+    return 0
+if __name__=='__main__': raise SystemExit(main())

--- a/tests/test_materialize_u1_vertical_registry.py
+++ b/tests/test_materialize_u1_vertical_registry.py
@@ -16,16 +16,9 @@ SPEC.loader.exec_module(mod)
 def make_index(path):
     connection = sqlite3.connect(path)
     connection.execute("CREATE TABLE index_meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID")
-    connection.execute(
-        "INSERT INTO index_meta VALUES(?,?)",
-        ("builder_version", json.dumps("LTMD_U1_UNIVERSAL_INDEX_0.1")),
-    )
-    connection.execute(
-        "CREATE TABLE pages(id INTEGER PRIMARY KEY,page_id TEXT,canonical_viewer_key TEXT,wave TEXT,catalog_generation INTEGER,grade_code INTEGER,search_text TEXT)"
-    )
-    connection.execute(
-        "CREATE VIRTUAL TABLE pages_fts USING fts5(search_text,content='pages',content_rowid='id',tokenize='unicode61 remove_diacritics 2')"
-    )
+    connection.execute("INSERT INTO index_meta VALUES(?,?)", ("builder_version", json.dumps("LTMD_U1_UNIVERSAL_INDEX_0.1")))
+    connection.execute("CREATE TABLE pages(id INTEGER PRIMARY KEY,page_id TEXT,canonical_viewer_key TEXT,wave TEXT,catalog_generation INTEGER,grade_code INTEGER,search_text TEXT)")
+    connection.execute("CREATE VIRTUAL TABLE pages_fts USING fts5(search_text,content='pages',content_rowid='id',tokenize='unicode61 remove_diacritics 2')")
     rows = [
         (1, "p1", "B1", "W1", 1993, 5, "democracia y ciudadanía"),
         (2, "p2", "B2", "W2", 2014, 6, "democracia ciencia"),
@@ -39,28 +32,18 @@ def make_index(path):
 
 def make_reuse(path):
     connection = sqlite3.connect(path)
-    connection.executescript(
-        """
+    connection.executescript("""
         CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
         CREATE TABLE exact_source_groups(group_id INTEGER PRIMARY KEY,hash TEXT,page_count INTEGER,object_count INTEGER,generation_count INTEGER,cross_object INTEGER,cross_generation INTEGER);
         CREATE TABLE exact_source_members(group_id INTEGER,page_rowid INTEGER,object_id INTEGER,generation INTEGER,PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
         CREATE TABLE exact_text_groups(group_id INTEGER PRIMARY KEY,hash TEXT,page_count INTEGER,object_count INTEGER,generation_count INTEGER,grade_count INTEGER,wave_count INTEGER,cross_object INTEGER,cross_generation INTEGER);
         CREATE TABLE exact_text_members(group_id INTEGER,page_rowid INTEGER,object_id INTEGER,generation INTEGER,PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
         CREATE TABLE similarity_candidates(page_a INTEGER,page_b INTEGER,object_a INTEGER,object_b INTEGER,jaccard REAL,shared_shingles INTEGER,shingles_a INTEGER,shingles_b INTEGER,tier TEXT,PRIMARY KEY(page_a,page_b)) WITHOUT ROWID;
-        """
-    )
-    connection.execute(
-        "INSERT INTO meta VALUES(?,?)",
-        ("artifact_version", json.dumps("LTMD_U1_REUSE_SIMILARITY_0.1")),
-    )
+    """)
+    connection.execute("INSERT INTO meta VALUES(?,?)", ("artifact_version", json.dumps("LTMD_U1_REUSE_SIMILARITY_0.1")))
     connection.execute("INSERT INTO exact_text_groups VALUES(1,'h',2,2,2,2,2,1,1)")
-    connection.executemany(
-        "INSERT INTO exact_text_members VALUES(?,?,?,?)",
-        [(1, 1, 1, 1993), (1, 2, 2, 2014)],
-    )
-    connection.execute(
-        "INSERT INTO similarity_candidates VALUES(1,2,1,2,.9,50,60,60,'similarity_candidate')"
-    )
+    connection.executemany("INSERT INTO exact_text_members VALUES(?,?,?,?)", [(1, 1, 1, 1993), (1, 2, 2, 2014)])
+    connection.execute("INSERT INTO similarity_candidates VALUES(1,2,1,2,.9,50,60,60,'similarity_candidate')")
     connection.commit()
     connection.close()
 
@@ -75,19 +58,17 @@ def write_registry(path):
         "verticals": [],
     }
     for index in range(8):
-        registry["verticals"].append(
-            {
-                "vertical_id": f"v{index}",
-                "label_es": f"Vertical {index}",
-                "status": "preregistered_exploratory",
-                "union_expression": "democracia",
-                "probes": [
-                    {"probe_id": "a", "label_es": "A", "fts5_expression": "democracia"},
-                    {"probe_id": "b", "label_es": "B", "fts5_expression": "ciencia"},
-                ],
-                "interpretation_boundary": "Límite interpretativo suficientemente largo para prueba sintética del contrato.",
-            }
-        )
+        registry["verticals"].append({
+            "vertical_id": f"v{index}",
+            "label_es": f"Vertical {index}",
+            "status": "preregistered_exploratory",
+            "union_expression": "democracia",
+            "probes": [
+                {"probe_id": "a", "label_es": "A", "fts5_expression": "democracia"},
+                {"probe_id": "b", "label_es": "B", "fts5_expression": "ciencia"},
+            ],
+            "interpretation_boundary": "Límite interpretativo suficientemente largo para prueba sintética del contrato.",
+        })
     path.write_text(json.dumps(registry), encoding="utf-8")
 
 
@@ -98,7 +79,6 @@ def test_materializer_fixture(tmp_path):
     make_index(index)
     make_reuse(reuse)
     write_registry(registry)
-
     output = mod.materialize(registry, index, reuse)
     assert len(output["verticals"]) == 8
     vertical = output["verticals"][0]
@@ -106,34 +86,23 @@ def test_materializer_fixture(tmp_path):
     assert vertical["metrics"]["candidate_books"] == 2
     assert vertical["reuse_context"]["metrics"]["candidate_pages_with_exact_text_cross_generation_reuse"] == 2
     assert vertical["reuse_context"]["metrics"]["candidate_pages_with_similarity_signal"] == 2
-    by_generation = {
-        item["value"]: item["metrics"]["candidate_pages"]
-        for item in vertical["breakdowns"]["generation"]
-    }
+    by_generation = {item["value"]: item["metrics"]["candidate_pages"] for item in vertical["breakdowns"]["generation"]}
     assert by_generation == {"1993": 1, "2014": 1}
     assert output["privacy"]["page_identifiers_emitted"] is False
 
 
-def test_real_materialization_schema_and_invariants():
-    schema = json.loads(
-        (ROOT / "schemas" / "ltmd_u1_vertical_materialization.schema.json").read_text(encoding="utf-8")
-    )
-    data = json.loads(
-        (ROOT / "data" / "analytics" / "ltmd_u1_vertical_materialization_0_1.json").read_text(encoding="utf-8")
-    )
+def test_public_materialization_record_schema_and_invariants():
+    schema = json.loads((ROOT / "schemas" / "ltmd_u1_vertical_materialization.schema.json").read_text(encoding="utf-8"))
+    data = json.loads((ROOT / "data" / "analytics" / "ltmd_u1_vertical_materialization_0_1.json").read_text(encoding="utf-8"))
     Draft202012Validator.check_schema(schema)
     Draft202012Validator(schema).validate(data)
     ids = [vertical["vertical_id"] for vertical in data["verticals"]]
     assert len(ids) == len(set(ids)) == 8
     assert data["corpus"] == {"pages": 86549, "canonical_objects": 492}
     assert data["provenance"]["human_validation_complete"] is False
-    assert data["scientific_state"] == {
-        "text_verified": False,
-        "semantic_ready": False,
-        "aliases_created": False,
-    }
+    assert data["scientific_state"] == {"text_verified": False, "semantic_ready": False, "aliases_created": False}
+    assert data["full_materialization_sha256"] == "e2faab966faced48327634c4acd40a867b76add29612538736b91db8d3afb0ad"
+    assert data["full_materialization_bytes"] == 120354
     for vertical in data["verticals"]:
-        assert vertical["reuse_context"]["metrics"]["candidate_pages"] == vertical["metrics"]["candidate_pages"]
-        assert len(vertical["breakdowns"]["generation"]) == 11
-        assert len(vertical["breakdowns"]["grade_code"]) == 6
-        assert len(vertical["breakdowns"]["wave"]) == 11
+        assert vertical["breakdown_cardinality"] == {"generation": 11, "grade_code": 6, "wave": 11}
+        assert vertical["reuse_context"]["candidate_pages_with_any_reuse_similarity_signal"] <= vertical["metrics"]["candidate_pages"]

--- a/tests/test_materialize_u1_vertical_registry.py
+++ b/tests/test_materialize_u1_vertical_registry.py
@@ -1,0 +1,139 @@
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts" / "materialize_u1_vertical_registry.py"
+SPEC = importlib.util.spec_from_file_location("materialize_u1_vertical_registry", SCRIPT)
+mod = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(mod)
+
+
+def make_index(path):
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE index_meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID")
+    connection.execute(
+        "INSERT INTO index_meta VALUES(?,?)",
+        ("builder_version", json.dumps("LTMD_U1_UNIVERSAL_INDEX_0.1")),
+    )
+    connection.execute(
+        "CREATE TABLE pages(id INTEGER PRIMARY KEY,page_id TEXT,canonical_viewer_key TEXT,wave TEXT,catalog_generation INTEGER,grade_code INTEGER,search_text TEXT)"
+    )
+    connection.execute(
+        "CREATE VIRTUAL TABLE pages_fts USING fts5(search_text,content='pages',content_rowid='id',tokenize='unicode61 remove_diacritics 2')"
+    )
+    rows = [
+        (1, "p1", "B1", "W1", 1993, 5, "democracia y ciudadanía"),
+        (2, "p2", "B2", "W2", 2014, 6, "democracia ciencia"),
+        (3, "p3", "B3", "W2", 2014, 6, "naturaleza"),
+    ]
+    connection.executemany("INSERT INTO pages VALUES(?,?,?,?,?,?,?)", rows)
+    connection.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
+    connection.commit()
+    connection.close()
+
+
+def make_reuse(path):
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID;
+        CREATE TABLE exact_source_groups(group_id INTEGER PRIMARY KEY,hash TEXT,page_count INTEGER,object_count INTEGER,generation_count INTEGER,cross_object INTEGER,cross_generation INTEGER);
+        CREATE TABLE exact_source_members(group_id INTEGER,page_rowid INTEGER,object_id INTEGER,generation INTEGER,PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
+        CREATE TABLE exact_text_groups(group_id INTEGER PRIMARY KEY,hash TEXT,page_count INTEGER,object_count INTEGER,generation_count INTEGER,grade_count INTEGER,wave_count INTEGER,cross_object INTEGER,cross_generation INTEGER);
+        CREATE TABLE exact_text_members(group_id INTEGER,page_rowid INTEGER,object_id INTEGER,generation INTEGER,PRIMARY KEY(group_id,page_rowid)) WITHOUT ROWID;
+        CREATE TABLE similarity_candidates(page_a INTEGER,page_b INTEGER,object_a INTEGER,object_b INTEGER,jaccard REAL,shared_shingles INTEGER,shingles_a INTEGER,shingles_b INTEGER,tier TEXT,PRIMARY KEY(page_a,page_b)) WITHOUT ROWID;
+        """
+    )
+    connection.execute(
+        "INSERT INTO meta VALUES(?,?)",
+        ("artifact_version", json.dumps("LTMD_U1_REUSE_SIMILARITY_0.1")),
+    )
+    connection.execute("INSERT INTO exact_text_groups VALUES(1,'h',2,2,2,2,2,1,1)")
+    connection.executemany(
+        "INSERT INTO exact_text_members VALUES(?,?,?,?)",
+        [(1, 1, 1, 1993), (1, 2, 2, 2014)],
+    )
+    connection.execute(
+        "INSERT INTO similarity_candidates VALUES(1,2,1,2,.9,50,60,60,'similarity_candidate')"
+    )
+    connection.commit()
+    connection.close()
+
+
+def write_registry(path):
+    registry = {
+        "registry_version": "LTMD_U1_VERTICAL_REGISTRY_0.1",
+        "result_state": "exploratory_signal",
+        "frozen_before_materialization": True,
+        "dimensions": ["generation", "grade_code", "wave"],
+        "scientific_boundaries": ["synthetic fixture"],
+        "verticals": [],
+    }
+    for index in range(8):
+        registry["verticals"].append(
+            {
+                "vertical_id": f"v{index}",
+                "label_es": f"Vertical {index}",
+                "status": "preregistered_exploratory",
+                "union_expression": "democracia",
+                "probes": [
+                    {"probe_id": "a", "label_es": "A", "fts5_expression": "democracia"},
+                    {"probe_id": "b", "label_es": "B", "fts5_expression": "ciencia"},
+                ],
+                "interpretation_boundary": "Límite interpretativo suficientemente largo para prueba sintética del contrato.",
+            }
+        )
+    path.write_text(json.dumps(registry), encoding="utf-8")
+
+
+def test_materializer_fixture(tmp_path):
+    index = tmp_path / "index.sqlite"
+    reuse = tmp_path / "reuse.sqlite"
+    registry = tmp_path / "registry.json"
+    make_index(index)
+    make_reuse(reuse)
+    write_registry(registry)
+
+    output = mod.materialize(registry, index, reuse)
+    assert len(output["verticals"]) == 8
+    vertical = output["verticals"][0]
+    assert vertical["metrics"]["candidate_pages"] == 2
+    assert vertical["metrics"]["candidate_books"] == 2
+    assert vertical["reuse_context"]["metrics"]["candidate_pages_with_exact_text_cross_generation_reuse"] == 2
+    assert vertical["reuse_context"]["metrics"]["candidate_pages_with_similarity_signal"] == 2
+    by_generation = {
+        item["value"]: item["metrics"]["candidate_pages"]
+        for item in vertical["breakdowns"]["generation"]
+    }
+    assert by_generation == {"1993": 1, "2014": 1}
+    assert output["privacy"]["page_identifiers_emitted"] is False
+
+
+def test_real_materialization_schema_and_invariants():
+    schema = json.loads(
+        (ROOT / "schemas" / "ltmd_u1_vertical_materialization.schema.json").read_text(encoding="utf-8")
+    )
+    data = json.loads(
+        (ROOT / "data" / "analytics" / "ltmd_u1_vertical_materialization_0_1.json").read_text(encoding="utf-8")
+    )
+    Draft202012Validator.check_schema(schema)
+    Draft202012Validator(schema).validate(data)
+    ids = [vertical["vertical_id"] for vertical in data["verticals"]]
+    assert len(ids) == len(set(ids)) == 8
+    assert data["corpus"] == {"pages": 86549, "canonical_objects": 492}
+    assert data["provenance"]["human_validation_complete"] is False
+    assert data["scientific_state"] == {
+        "text_verified": False,
+        "semantic_ready": False,
+        "aliases_created": False,
+    }
+    for vertical in data["verticals"]:
+        assert vertical["reuse_context"]["metrics"]["candidate_pages"] == vertical["metrics"]["candidate_pages"]
+        assert len(vertical["breakdowns"]["generation"]) == 11
+        assert len(vertical["breakdowns"]["grade_code"]) == 6
+        assert len(vertical["breakdowns"]["wave"]) == 11


### PR DESCRIPTION
## Objetivo

Materializa, sin modificar sus expresiones después de observar resultados, los ocho verticales exploratorios preregistrados en `LTMD_U1_VERTICAL_REGISTRY_0.1`.

## Resultado

La corrida real usa el Índice Universal U1 de 86,549 páginas / 492 objetos y la capa transversal de reutilización/similitud. Cada vertical incluye probes, denominadores exactos y desgloses por 11 generaciones, 6 grados y 11 olas; la superficie pública conserva un registro agregado y el SHA-256 de la materialización integral reproducible.

Conteos globales de páginas candidatas: ciudadanía/democracia/derechos 907; mujeres/género/familia 6,569; ambiente/naturaleza 2,526; migración 483; trabajo/economía 8,559; discapacidad/inclusión 150; ciencia/tecnología 1,872; nación/identidad/México 15,974.

## Procedencia

- Universal Index SHA-256: `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`
- reuse/similarity SHA-256: `4c180f37b287f4c5cc81155aabd8a97e5feb6f40668c3baa296c4733f8063301`
- registry SHA-256: `9a4f3b57c993b4ef86a821508bf050e3efd812f682b483862550dc977423d1c8`
- materialización integral: 120,354 bytes, SHA-256 `e2faab966faced48327634c4acd40a867b76add29612538736b91db8d3afb0ad`

## Guardas

Todo permanece `exploratory_signal`; `human_validation_complete=false`, `semantic_ready=false`, `aliases_created=false`. No se publican page IDs, object IDs, OCR, snippets, hashes de páginas ni pares concretos. La amplitud de un vertical no se ajusta retrospectivamente; cualquier refinamiento requiere una nueva versión del registro.

## CI

Añade fixture del materializador, validación del registro público contra JSON Schema y amplía el workflow Analytics mediante globs para que futuras superficies no queden fuera del gate por omisión manual.