### PR TITLE
Deploy: expose corpus-wide HTTP surface before staging

### DIFF
--- a/analytics_api/app.py
+++ b/analytics_api/app.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 """Read-only HTTP adapter for LTMD Analytics 0.1.
 
-The Indigenous-language vertical preserves its preregistered private candidate ledger.
-Optional corpus-wide reuse/similarity context may be configured with a paired Universal
-Index and reuse/similarity artifact. Private paths and page-level contents are never returned.
+The service exposes aggregate-only corpus-wide search plus the preregistered Indigenous-
+language vertical. Private paths, OCR/search text, page identifiers and source material are
+never returned. Corpus-wide reuse/similarity context is optional and never creates aliases.
 """
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 from pathlib import Path
 from threading import RLock
@@ -28,6 +29,15 @@ from scripts.query_indigenous_analytics import (  # noqa: E402
     query,
     sha256_file,
 )
+from scripts.query_u1_universal_index import (  # noqa: E402
+    ALLOWED_GROUP_BY as CORPUS_ALLOWED_GROUP_BY,
+    ENGINE_VERSION as CORPUS_ENGINE_VERSION,
+    INDEX_VERSION as CORPUS_INDEX_VERSION,
+    SHA256_RE,
+    normalize_filters as normalize_corpus_filters,
+    query_index as query_corpus_index,
+    validate_query_expression as validate_corpus_query_expression,
+)
 from scripts.runtime_vertical_reuse_context import runtime_context  # noqa: E402
 
 DEFAULT_GENERATION_SUMMARY = REPO_ROOT / "data" / "research" / "ltmd_u1_indigenous_languages_generation_summary_0_2.csv"
@@ -47,6 +57,9 @@ _state = {
     "generation_path": None,
     "generation_mtime_ns": None,
     "denominators": None,
+    "corpus_index_path": None,
+    "corpus_index_mtime_ns": None,
+    "corpus_index_sha256": None,
 }
 
 
@@ -60,17 +73,26 @@ def _configured_paths() -> tuple[Path, Path]:
     return ledger_path, generation_path
 
 
-def _configured_reuse_paths() -> tuple[Path, Path] | None:
-    index_value = os.environ.get("LTMD_UNIVERSAL_INDEX_PATH", "").strip()
-    reuse_value = os.environ.get("LTMD_REUSE_SIMILARITY_PATH", "").strip()
-    if bool(index_value) != bool(reuse_value):
-        raise RuntimeError("LTMD corpus-wide reuse context is partially configured")
-    if not index_value:
+def _configured_corpus_index_path() -> Path | None:
+    value = os.environ.get("LTMD_UNIVERSAL_INDEX_PATH", "").strip()
+    if not value:
         return None
-    index_path = Path(index_value).expanduser()
+    path = Path(value).expanduser()
+    if not path.is_file():
+        raise RuntimeError("LTMD Universal Index is unavailable")
+    return path
+
+
+def _configured_reuse_paths() -> tuple[Path, Path] | None:
+    index_path = _configured_corpus_index_path()
+    reuse_value = os.environ.get("LTMD_REUSE_SIMILARITY_PATH", "").strip()
+    if not reuse_value:
+        return None
+    if index_path is None:
+        raise RuntimeError("LTMD reuse context requires the Universal Index")
     reuse_path = Path(reuse_value).expanduser()
-    if not index_path.is_file() or not reuse_path.is_file():
-        raise RuntimeError("LTMD corpus-wide reuse context is unavailable")
+    if not reuse_path.is_file():
+        raise RuntimeError("LTMD reuse/similarity artifact is unavailable")
     return index_path, reuse_path
 
 
@@ -80,6 +102,32 @@ def _reuse_context_resolver():
         return None
     index_path, reuse_path = configured
     return lambda page_ids: runtime_context(index_path, reuse_path, page_ids)
+
+
+def _load_corpus_index_state() -> tuple[Path | None, str | None]:
+    path = _configured_corpus_index_path()
+    if path is None:
+        return None, None
+    mtime = path.stat().st_mtime_ns
+    with _state_lock:
+        changed = (
+            _state["corpus_index_sha256"] is None
+            or _state["corpus_index_path"] != path
+            or _state["corpus_index_mtime_ns"] != mtime
+        )
+        if changed:
+            _state["corpus_index_sha256"] = sha256_file(path)
+            _state["corpus_index_path"] = path
+            _state["corpus_index_mtime_ns"] = mtime
+        actual = _state["corpus_index_sha256"]
+
+    expected = os.environ.get("LTMD_UNIVERSAL_INDEX_SHA256", "").strip().lower()
+    if expected:
+        if not SHA256_RE.fullmatch(expected):
+            raise RuntimeError("configured Universal Index SHA-256 is invalid")
+        if actual != expected:
+            raise RuntimeError("Universal Index SHA-256 mismatch")
+    return path, actual
 
 
 def _load_state() -> tuple[list[dict], dict[str, int], str]:
@@ -128,17 +176,14 @@ def _clean_values(name: str) -> list[str] | None:
 
 
 def _public_error(message: str, status: int):
-    return jsonify({
-        "error": message,
-        "status": status,
-        "service": "LTMD Analytics",
-    }), status
+    return jsonify({"error": message, "status": status, "service": "LTMD Analytics"}), status
 
 
 @app.get("/health")
 def health():
     try:
         rows, denominators, _ = _load_state()
+        corpus_path, _ = _load_corpus_index_state()
         reuse_resolver = _reuse_context_resolver()
     except RuntimeError:
         return jsonify({
@@ -146,19 +191,20 @@ def health():
             "service": "LTMD Analytics",
             "analytics_version": ANALYTICS_VERSION,
             "query_engine_version": ENGINE_VERSION,
+            "corpus_query_engine_version": CORPUS_ENGINE_VERSION,
             "private_ledger_configured": bool(os.environ.get("LTMD_INDIGENOUS_LEDGER_PATH", "").strip()),
-            "reuse_context_configured": bool(
-                os.environ.get("LTMD_UNIVERSAL_INDEX_PATH", "").strip()
-                and os.environ.get("LTMD_REUSE_SIMILARITY_PATH", "").strip()
-            ),
+            "corpus_query_configured": bool(os.environ.get("LTMD_UNIVERSAL_INDEX_PATH", "").strip()),
+            "reuse_context_configured": bool(os.environ.get("LTMD_REUSE_SIMILARITY_PATH", "").strip()),
         }), 503
     return jsonify({
         "status": "ok",
         "service": "LTMD Analytics",
         "analytics_version": ANALYTICS_VERSION,
         "query_engine_version": ENGINE_VERSION,
+        "corpus_query_engine_version": CORPUS_ENGINE_VERSION,
         "candidate_rows_loaded": len(rows),
         "generation_denominators_loaded": len(denominators),
+        "corpus_query_configured": corpus_path is not None,
         "reuse_context_configured": reuse_resolver is not None,
         "human_validation_complete": False,
     })
@@ -168,6 +214,7 @@ def health():
 def metadata():
     try:
         rows, denominators, _ = _load_state()
+        corpus_path, corpus_sha = _load_corpus_index_state()
         reuse_resolver = _reuse_context_resolver()
     except RuntimeError:
         return _public_error("analytics data unavailable", 503)
@@ -175,26 +222,20 @@ def metadata():
     generations = sorted({str(row["generation"]) for row in rows}, key=lambda value: int(value) if value.isdigit() else 10**12)
     grades = sorted({str(row["grade_code"]) for row in rows})
     waves = sorted({str(row["wave"]) for row in rows})
-    languages = sorted({
-        language.strip()
-        for row in rows
-        for language in str(row.get("matched_language_groups") or "").split(";")
-        if language.strip()
-    })
-    explicit_terms = sorted({
-        term.strip()
-        for row in rows
-        for term in str(row.get("matched_explicit_terms") or "").split(";")
-        if term.strip()
-    })
+    languages = sorted({language.strip() for row in rows for language in str(row.get("matched_language_groups") or "").split(";") if language.strip()})
+    explicit_terms = sorted({term.strip() for row in rows for term in str(row.get("matched_explicit_terms") or "").split(";") if term.strip()})
     return jsonify({
         "service": "LTMD Analytics",
         "analytics_version": ANALYTICS_VERSION,
         "query_engine_version": ENGINE_VERSION,
+        "corpus_query_engine_version": CORPUS_ENGINE_VERSION,
+        "corpus_index_version": CORPUS_INDEX_VERSION,
         "source_analysis_version": SOURCE_ANALYSIS_VERSION,
         "result_state": "exploratory_signal",
         "human_validation_complete": False,
         "candidate_rows": len(rows),
+        "corpus_query_configured": corpus_path is not None,
+        "corpus_index_sha256": corpus_sha,
         "reuse_context_configured": reuse_resolver is not None,
         "filters": {
             "generation": generations,
@@ -205,6 +246,43 @@ def metadata():
         },
         "denominator_generations": sorted(denominators, key=lambda value: int(value) if value.isdigit() else 10**12),
     })
+
+
+@app.get("/v1/corpus/query")
+def corpus_query():
+    try:
+        expression = validate_corpus_query_expression(request.args.get("q", ""))
+        group_by = request.args.get("group_by", "").strip() or None
+        if group_by is not None and group_by not in CORPUS_ALLOWED_GROUP_BY:
+            raise RuntimeError("group_by must be one of: " + ", ".join(sorted(CORPUS_ALLOWED_GROUP_BY)))
+        filters = {
+            "generation": _clean_values("generation"),
+            "grade_code": _clean_values("grade_code"),
+            "wave": _clean_values("wave"),
+        }
+        normalize_corpus_filters(filters)
+    except (ValueError, RuntimeError) as exc:
+        return _public_error(str(exc), 400)
+
+    try:
+        index_path, index_sha = _load_corpus_index_state()
+        if index_path is None:
+            return _public_error("corpus analytics data unavailable", 503)
+        connection = sqlite3.connect(f"file:{index_path}?mode=ro", uri=True)
+        try:
+            response = query_corpus_index(
+                connection,
+                query_expression=expression,
+                filters=filters,
+                group_by=group_by,
+                index_sha256=index_sha,
+            )
+        finally:
+            connection.close()
+    except RuntimeError:
+        return _public_error("corpus analytics data unavailable", 503)
+
+    return jsonify(response)
 
 
 @app.get("/v1/indigenous/query")
@@ -239,7 +317,6 @@ def indigenous_query():
         )
     except RuntimeError:
         return _public_error("analytics data unavailable", 503)
-
     return jsonify(response)
 
 

--- a/docs/LTMD_ANALYTICS_HTTP_API_0_1.md
+++ b/docs/LTMD_ANALYTICS_HTTP_API_0_1.md
@@ -1,25 +1,63 @@
 # LTMD Analytics HTTP API 0.1
 
 Versión de transporte: **LTMD Analytics HTTP 0.1**  
-Motor de consulta del vertical indígena: `LTMD_ANALYTICS_QUERY_ENGINE_0.2`
+Motor corpus-wide: `LTMD_U1_CORPUS_QUERY_ENGINE_0.1`  
+Motor del vertical indígena: `LTMD_ANALYTICS_QUERY_ENGINE_0.2`
 
 ## Propósito
 
-Esta capa expone por HTTP el vertical de lenguas indígenas sin convertir el ledger privado en un recurso descargable. La selección preregistrada del estudio 0.2 se conserva. Cuando se configuran los artefactos corpus-wide, la API añade contexto agregado de reutilización/similitud a la selección filtrada y a cada grupo, sin cambiar membresía ni estado epistemológico.
+Esta capa expone por HTTP dos superficies read-only sobre los insumos privados de LTMD-U1:
 
-La API es **read-only** y devuelve únicamente agregados, filtros, metadatos de versión, procedencia criptográfica y advertencias epistemológicas.
+1. **consulta corpus-wide** sobre el Índice Universal de 86,549 páginas mediante FTS5, con filtros y denominadores exactos;
+2. **vertical indígena preregistrado 0.2**, preservando su ledger de 1,151 candidatos y, cuando se configura, añadiendo contexto agregado de reutilización/similitud.
+
+La API devuelve únicamente agregados, filtros, versiones, procedencia criptográfica y advertencias epistemológicas. No devuelve OCR, `page_id`, identificadores de objetos, snippets, URLs fuente, hashes de página ni pares concretos de similitud.
 
 ## Endpoints P0
 
 ### `GET /health`
 
-Comprueba que el servicio está activo y que los insumos privados obligatorios están disponibles. Si el contexto corpus-wide se configura, exige que sus dos artefactos estén presentes. No revela rutas de filesystem.
+Comprueba que el servicio y los insumos obligatorios del vertical están disponibles. Informa además, sin revelar rutas, si la consulta corpus-wide y el contexto de reutilización están configurados.
+
+Campos relevantes:
+
+- `corpus_query_configured`
+- `reuse_context_configured`
+- `corpus_query_engine_version`
+- `human_validation_complete=false`
 
 ### `GET /v1/meta`
 
-Devuelve versiones, estado científico y vocabularios de filtros disponibles para el vertical de lenguas indígenas. Incluye `reuse_context_configured` para indicar si el runtime dispone del contexto corpus-wide.
+Devuelve versiones, estado científico, vocabularios de filtros del vertical indígena y estado de configuración corpus-wide. Si el Índice Universal está configurado, incluye su SHA-256 calculado por el servidor.
+
+### `GET /v1/corpus/query`
+
+Ejecuta una expresión FTS5 directamente sobre el Índice Universal privado y devuelve agregados seguros.
+
+Parámetros repetibles:
+
+- `generation`
+- `grade_code`
+- `wave`
+
+Parámetros simples:
+
+- `q`: expresión FTS5 obligatoria;
+- `group_by`: `generation | grade_code | wave`.
+
+Ejemplo:
+
+```bash
+curl --get 'http://127.0.0.1:8000/v1/corpus/query' \
+  --data-urlencode 'q=democracia' \
+  --data-urlencode 'group_by=generation'
+```
+
+La tasa `candidate_pages_per_1000` usa como denominador exactamente el mismo subuniverso afectado por los filtros activos. Cero hits no demuestran ausencia histórica.
 
 ### `GET /v1/indigenous/query`
+
+Consulta el ledger preregistrado de lenguas indígenas sin recomputar su selección.
 
 Parámetros repetibles:
 
@@ -31,10 +69,10 @@ Parámetros repetibles:
 
 Parámetros simples:
 
-- `q`: etiqueta descriptiva de consulta;
+- `q`: etiqueta descriptiva de la consulta;
 - `group_by`: `generation | grade_code | wave | language_group | explicit_term`.
 
-Ejemplo local:
+Ejemplo:
 
 ```bash
 curl --get 'http://127.0.0.1:8000/v1/indigenous/query' \
@@ -43,132 +81,126 @@ curl --get 'http://127.0.0.1:8000/v1/indigenous/query' \
   --data-urlencode 'group_by=generation'
 ```
 
-La respuesta no contiene `page_id`, URL de fuente, OCR, snippets, hashes de página/OCR ni pares concretos de similitud.
-
-Cuando está configurado el contexto corpus-wide, la respuesta puede incluir `reuse_context` en el total filtrado y en cada elemento de `breakdown`. Esos conteos describen reutilización/similitud que toca exactamente ese subconjunto; no reclasifican candidatos y permanecen en `exploratory_signal`.
+Cuando `LTMD_REUSE_SIMILARITY_PATH` está configurado junto con el Índice Universal, la respuesta puede incluir `reuse_context` en el total filtrado y en cada `breakdown`. Esa capa permanece `exploratory_signal`, no cambia la membresía del vertical y nunca crea aliases.
 
 ## Configuración privada
 
-Variables obligatorias para el vertical:
+### Vertical indígena
 
 ```text
 LTMD_INDIGENOUS_LEDGER_PATH=/ruta/privada/ltmd_u1_indigenous_languages_candidate_ledger_0_2.csv
 LTMD_GENERATION_SUMMARY_PATH=/ruta/al/ltmd_u1_indigenous_languages_generation_summary_0_2.csv
 ```
 
-`LTMD_GENERATION_SUMMARY_PATH` es opcional: si no se define, se utiliza la tabla pública versionada del repositorio.
+`LTMD_GENERATION_SUMMARY_PATH` es opcional; si no se define, se usa la tabla pública versionada del repositorio.
 
-Contexto corpus-wide opcional:
+### Consulta corpus-wide
 
 ```text
 LTMD_UNIVERSAL_INDEX_PATH=/ruta/privada/ltmd_u1_universal_index_0_1.canonical.sqlite
+LTMD_UNIVERSAL_INDEX_SHA256=aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2
+```
+
+`LTMD_UNIVERSAL_INDEX_PATH` habilita por sí solo `/v1/corpus/query`. `LTMD_UNIVERSAL_INDEX_SHA256` es opcional pero **obligatorio para staging canónico**: si se define, el servidor verifica el archivo y degrada el servicio si no coincide.
+
+### Contexto de reutilización/similitud
+
+```text
 LTMD_REUSE_SIMILARITY_PATH=/ruta/privada/ltmd_u1_reuse_similarity_0_1.sqlite
 ```
 
-Las dos variables corpus-wide forman un par: deben definirse **ambas o ninguna**. Una configuración parcial degrada el servicio en vez de ignorarse silenciosamente.
+El artefacto de reutilización es opcional. Si se define, requiere también `LTMD_UNIVERSAL_INDEX_PATH`. El Índice Universal no requiere el artefacto de reutilización para operar.
 
-Los artefactos privados **no deben**:
+Todos los artefactos privados deben permanecer:
 
-- guardarse dentro del repositorio;
-- colocarse bajo `public_html`;
-- aparecer en logs o respuestas HTTP;
-- enviarse al navegador;
-- copiarse a artefactos públicos de CI.
+- fuera del repositorio Git;
+- fuera de `public_html`;
+- fuera de artefactos públicos de CI;
+- fuera de logs y respuestas HTTP.
 
 ## Ejecución local
 
 ```bash
 python3 -m pip install -r requirements-analytics.txt
 export LTMD_INDIGENOUS_LEDGER_PATH=/ruta/privada/ledger.csv
-# Opcional, pero emparejado:
 export LTMD_UNIVERSAL_INDEX_PATH=/ruta/privada/universal-index.sqlite
+export LTMD_UNIVERSAL_INDEX_SHA256=aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2
 export LTMD_REUSE_SIMILARITY_PATH=/ruta/privada/reuse-similarity.sqlite
 python3 -m flask --app analytics_api.app run --host 127.0.0.1 --port 8000
 ```
 
 ## cPanel / Phusion Passenger
 
-Esta sección se verificó contra la documentación oficial vigente de cPanel el **30 de agosto de 2026**. cPanel documenta Flask como framework WSGI válido y utiliza Phusion Passenger/Application Manager para registrar aplicaciones Python.
+La aplicación usa Flask/WSGI y el repositorio contiene **`passenger_wsgi.py` en la raíz**. La disponibilidad de Application Manager/Setup Python App depende del proveedor de hosting.
 
-El repositorio incluye **`passenger_wsgi.py` en la raíz de la aplicación**, siguiendo la convención documentada por cPanel.
+### Flujo canónico de staging
 
-### Prerrequisitos del hosting
-
-El proveedor/servidor debe disponer de Python 3, `pip`/entorno virtual y Passenger/Application Manager. En cPanel moderno la disponibilidad exacta depende del sistema operativo y de que el proveedor haya habilitado Application Manager y los módulos Passenger correspondientes.
-
-No modificar paquetes de WHM desde esta aplicación si la cuenta no tiene privilegios administrativos. Si Application Manager o Python App no existe en la cuenta, escalar al proveedor de hosting en lugar de improvisar otro runtime dentro de `public_html`.
-
-### Flujo recomendado
-
-1. clonar o actualizar el repositorio en un directorio de aplicación dentro del home de la cuenta y **fuera de `public_html`**;
+1. clonar o actualizar el repositorio dentro del home de la cuenta y **fuera de `public_html`**;
 2. usar ese checkout como application root;
-3. crear/seleccionar un entorno Python 3 para la aplicación;
-4. instalar dependencias:
+3. confirmar que el checkout contiene un `main` igual o posterior al commit que fusiona esta superficie corpus-wide;
+4. crear/seleccionar un entorno Python 3;
+5. instalar:
 
 ```bash
 python3 -m pip install -r requirements-analytics.txt
 ```
 
-5. asegurar que el startup WSGI es `passenger_wsgi.py`;
-6. colocar el ledger privado, el Índice Universal y el artefacto de reutilización/similitud fuera del checkout Git y fuera de `public_html`;
-7. definir `LTMD_INDIGENOUS_LEDGER_PATH`;
-8. opcionalmente definir `LTMD_GENERATION_SUMMARY_PATH`; si se omite se usa la tabla pública del repositorio;
-9. para el backend corpus-wide completo, definir conjuntamente `LTMD_UNIVERSAL_INDEX_PATH` y `LTMD_REUSE_SIMILARITY_PATH`;
-10. registrar/habilitar la aplicación en cPanel Application Manager o el mecanismo Passenger provisto por el hosting;
+6. usar el `passenger_wsgi.py` de la raíz como startup WSGI;
+7. materializar fuera del checkout y fuera de `public_html`:
+   - ledger indígena privado;
+   - Índice Universal U1 canónico descomprimido;
+   - reutilización/similitud U1 descomprimido;
+8. verificar SHA-256 del Índice Universal: `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`;
+9. definir las variables de entorno anteriores;
+10. registrar/habilitar la aplicación en Application Manager/Setup Python App/Passenger;
 11. reiniciar Passenger;
-12. verificar `/health`, `/v1/meta` y una consulta acotada con `reuse_context`;
-13. sólo después conectar una interfaz web.
+12. ejecutar el gate HTTP completo descrito abajo;
+13. sólo tras aprobar staging iniciar/conectar el frontend institucional.
 
 ### Reinicio Passenger
 
-Cuando el proveedor use la convención estándar documentada por cPanel, se puede solicitar reinicio creando o actualizando el archivo:
+Cuando el proveedor use la convención estándar:
 
 ```bash
 mkdir -p tmp
 touch tmp/restart.txt
 ```
 
-La operación debe ejecutarse dentro de la raíz de la aplicación. Si el hosting usa una interfaz específica de **Setup Python App**, usar su acción de reinicio cuando esté disponible.
+Si Setup Python App ofrece un botón/acción propia de reinicio, usar ese mecanismo.
 
-### Referencias oficiales consultadas
+## Gate HTTP de staging
 
-- cPanel & WHM: *How to Install a Python WSGI Application*;
-- cPanel & WHM: *Using Passenger Applications*;
-- cPanel & WHM: *Application Manager*.
+El despliegue no se considera aprobado hasta verificar:
 
-No se fija todavía un dominio ni un origen CORS. Esa decisión corresponde al despliegue de la interfaz institucional y no debe anticiparse en código.
+1. `GET /health` → 200, `status=ok`, `corpus_query_configured=true`;
+2. `GET /v1/meta` → 200, `corpus_index_sha256` igual al SHA canónico y `human_validation_complete=false`;
+3. `GET /v1/corpus/query?q=democracia&group_by=generation` → 200, respuesta `exploratory_signal`, sin contenido privado;
+4. `GET /v1/indigenous/query` con el filtro rarámuri y `group_by=generation` → 200, agregados del ledger preregistrado;
+5. `POST /v1/corpus/query` y `POST /v1/indigenous/query` → 405;
+6. ninguna respuesta contiene rutas privadas, `page_id`, OCR, snippets, IDs de objetos, URL fuente o hashes de página/OCR;
+7. no existe CORS abierto por defecto.
 
 ## Denominadores
 
-Las tasas `pages_per_1000` se calculan únicamente cuando existe un denominador compatible. La versión actual del vertical dispone de denominadores por **generación**. Si una consulta filtra por grado u ola, la API devuelve `pages_per_1000=null` y una advertencia, en lugar de dividir entre un universo que ya no corresponde al filtro.
-
-El contexto de reutilización/similitud no altera ese denominador ni la selección del vertical; sólo agrega conteos sobre las páginas candidatas ya filtradas.
+La superficie corpus-wide calcula denominadores exactos desde el mismo Índice Universal para cualquier combinación de generación, grado y ola. El vertical indígena conserva sus denominadores metodológicos existentes y no los sustituye retrospectivamente por otra selección.
 
 ## Estado epistemológico
 
-Toda respuesta utiliza:
+Toda consulta mantiene:
 
 ```text
 result_state = exploratory_signal
 human_validation_complete = false
 ```
 
-`reuse_context.result_state` también es obligatoriamente `exploratory_signal`.
+Las reglas obligatorias siguen siendo:
 
-La existencia de una API no cambia el estado científico de la evidencia. `search_hit != historical_claim`, `computational_candidate != semantic_ready` y `similarity_candidate != semantic_equivalence` siguen siendo reglas obligatorias.
+- `ocr_available != text_verified`
+- `search_hit != historical_claim`
+- `zero_hits != demonstrated_absence`
+- `computational_candidate != semantic_ready`
+- `similarity_candidate != semantic_equivalence`
 
 ## Límites P0
 
-La API 0.1 no incluye:
-
-- autenticación o cuentas;
-- escritura o anotación;
-- descarga del ledger o de artefactos privados;
-- OCR;
-- fragmentos fuente;
-- pares concretos de reutilización/similitud;
-- IA generativa para interpretar resultados;
-- CORS abierto;
-- rate limiting distribuido.
-
-Autenticación, cuotas y CORS deben introducirse antes de una exposición pública amplia o de funciones comerciales que requieran control de acceso.
+La API no incluye autenticación/cuentas, escritura/anotación, descarga de artefactos privados, OCR/snippets, pares concretos de similitud, CORS abierto, rate limiting distribuido ni interpretación generativa de resultados. Esas capacidades deben diseñarse explícitamente antes de una exposición pública amplia o comercial con control de acceso.

--- a/tests/test_analytics_api.py
+++ b/tests/test_analytics_api.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import sqlite3
 from pathlib import Path
 
 from jsonschema import Draft202012Validator
@@ -81,9 +82,36 @@ def configure(monkeypatch, tmp_path):
     monkeypatch.setenv("LTMD_INDIGENOUS_LEDGER_PATH", str(ledger))
     monkeypatch.setenv("LTMD_GENERATION_SUMMARY_PATH", str(generation))
     monkeypatch.delenv("LTMD_UNIVERSAL_INDEX_PATH", raising=False)
+    monkeypatch.delenv("LTMD_UNIVERSAL_INDEX_SHA256", raising=False)
     monkeypatch.delenv("LTMD_REUSE_SIMILARITY_PATH", raising=False)
     reset_state()
     return ledger
+
+
+def make_corpus_index(path):
+    connection = sqlite3.connect(path)
+    connection.execute("CREATE TABLE index_meta(key TEXT PRIMARY KEY,value TEXT NOT NULL) WITHOUT ROWID")
+    connection.execute(
+        "INSERT INTO index_meta VALUES(?,?)",
+        ("builder_version", json.dumps("LTMD_U1_UNIVERSAL_INDEX_0.1")),
+    )
+    connection.execute(
+        "CREATE TABLE pages(id INTEGER PRIMARY KEY,page_id TEXT,canonical_viewer_key TEXT,wave TEXT,catalog_generation INTEGER,grade_code INTEGER,search_text TEXT)"
+    )
+    connection.execute(
+        "CREATE VIRTUAL TABLE pages_fts USING fts5(search_text,content='pages',content_rowid='id',tokenize='unicode61 remove_diacritics 2')"
+    )
+    connection.executemany(
+        "INSERT INTO pages VALUES(?,?,?,?,?,?,?)",
+        [
+            (1, "cp1", "CB1", "W3", 1993, 5, "democracia y ciudadanía"),
+            (2, "cp2", "CB2", "W7", 2014, 6, "democracia ciencia"),
+            (3, "cp3", "CB3", "W7", 2014, 6, "naturaleza"),
+        ],
+    )
+    connection.execute("INSERT INTO pages_fts(pages_fts) VALUES('rebuild')")
+    connection.commit()
+    connection.close()
 
 
 def test_passenger_root_entry_point_exports_flask_application():
@@ -99,6 +127,7 @@ def test_health_is_safe_and_configured(monkeypatch, tmp_path):
     payload = response.get_json()
     assert payload["status"] == "ok"
     assert payload["candidate_rows_loaded"] == 3
+    assert payload["corpus_query_configured"] is False
     assert payload["reuse_context_configured"] is False
     assert payload["human_validation_complete"] is False
     rendered = repr(payload)
@@ -115,8 +144,70 @@ def test_meta_exposes_filter_vocabulary_not_private_rows(monkeypatch, tmp_path):
     assert payload["filters"]["generation"] == ["1993", "2014"]
     assert "Náhuatl" in payload["filters"]["language_group"]
     assert payload["candidate_rows"] == 3
+    assert payload["corpus_query_configured"] is False
+    assert payload["corpus_index_sha256"] is None
     assert payload["reuse_context_configured"] is False
     assert "page_id" not in repr(payload)
+
+
+def test_corpus_query_endpoint_uses_universal_index_and_schema(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    index = tmp_path / "corpus.sqlite"
+    make_corpus_index(index)
+    expected_sha = api.sha256_file(index)
+    monkeypatch.setenv("LTMD_UNIVERSAL_INDEX_PATH", str(index))
+    monkeypatch.setenv("LTMD_UNIVERSAL_INDEX_SHA256", expected_sha)
+    reset_state()
+
+    client = api.app.test_client()
+    response = client.get(
+        "/v1/corpus/query",
+        query_string=[("q", "democracia"), ("group_by", "generation")],
+    )
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["metrics"]["candidate_pages"] == 2
+    assert payload["metrics"]["candidate_books"] == 2
+    assert payload["metrics"]["corpus_pages_in_scope"] == 3
+    assert payload["metrics"]["corpus_books_in_scope"] == 3
+    assert payload["result_state"] == "exploratory_signal"
+    assert payload["provenance"]["index_sha256"] == expected_sha
+    by_generation = {item["value"]: item["metrics"]["candidate_pages"] for item in payload["breakdown"]}
+    assert by_generation == {"1993": 1, "2014": 1}
+
+    rendered = repr(payload)
+    for forbidden in ("cp1", "cp2", "page_id", "search_text", "source_asset_url", "ocr_sha256"):
+        assert forbidden not in rendered
+
+    schema = json.loads(
+        (Path(__file__).parents[1] / "schemas" / "ltmd_u1_corpus_query_response.schema.json").read_text(encoding="utf-8")
+    )
+    Draft202012Validator(schema).validate(payload)
+
+
+def test_corpus_index_without_reuse_is_valid(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    index = tmp_path / "corpus.sqlite"
+    make_corpus_index(index)
+    monkeypatch.setenv("LTMD_UNIVERSAL_INDEX_PATH", str(index))
+    reset_state()
+    client = api.app.test_client()
+    response = client.get("/health")
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["corpus_query_configured"] is True
+    assert payload["reuse_context_configured"] is False
+
+
+def test_corpus_query_invalid_input_is_400(monkeypatch, tmp_path):
+    configure(monkeypatch, tmp_path)
+    index = tmp_path / "corpus.sqlite"
+    make_corpus_index(index)
+    monkeypatch.setenv("LTMD_UNIVERSAL_INDEX_PATH", str(index))
+    reset_state()
+    client = api.app.test_client()
+    assert client.get("/v1/corpus/query").status_code == 400
+    assert client.get("/v1/corpus/query?q=democracia&group_by=page_id").status_code == 400
 
 
 def test_query_endpoint_uses_exact_unique_counts(monkeypatch, tmp_path):
@@ -159,10 +250,7 @@ def test_query_endpoint_adds_scoped_reuse_context_when_configured(monkeypatch, t
     client = api.app.test_client()
     response = client.get(
         "/v1/indigenous/query",
-        query_string=[
-            ("q", "all candidate pages"),
-            ("group_by", "generation"),
-        ],
+        query_string=[("q", "all candidate pages"), ("group_by", "generation")],
     )
     assert response.status_code == 200
     payload = response.get_json()
@@ -184,18 +272,16 @@ def test_query_endpoint_adds_scoped_reuse_context_when_configured(monkeypatch, t
     Draft202012Validator(schema).validate(payload)
 
 
-def test_partial_reuse_configuration_degrades_service(monkeypatch, tmp_path):
+def test_reuse_without_index_degrades_service(monkeypatch, tmp_path):
     configure(monkeypatch, tmp_path)
-    index = tmp_path / "index.sqlite"
-    index.write_bytes(b"placeholder")
-    monkeypatch.setenv("LTMD_UNIVERSAL_INDEX_PATH", str(index))
-    monkeypatch.delenv("LTMD_REUSE_SIMILARITY_PATH", raising=False)
+    monkeypatch.setenv("LTMD_REUSE_SIMILARITY_PATH", str(tmp_path / "reuse.sqlite"))
     client = api.app.test_client()
     response = client.get("/health")
     assert response.status_code == 503
     payload = response.get_json()
     assert payload["status"] == "degraded"
-    assert payload["reuse_context_configured"] is False
+    assert payload["corpus_query_configured"] is False
+    assert payload["reuse_context_configured"] is True
     assert str(tmp_path) not in repr(payload)
 
 
@@ -213,12 +299,14 @@ def test_service_is_read_only(monkeypatch, tmp_path):
     response = client.post("/v1/indigenous/query")
     assert response.status_code == 405
     assert "read-only" in response.get_json()["error"]
+    assert client.post("/v1/corpus/query").status_code == 405
 
 
 def test_unconfigured_health_does_not_leak_path(monkeypatch):
     monkeypatch.delenv("LTMD_INDIGENOUS_LEDGER_PATH", raising=False)
     monkeypatch.delenv("LTMD_GENERATION_SUMMARY_PATH", raising=False)
     monkeypatch.delenv("LTMD_UNIVERSAL_INDEX_PATH", raising=False)
+    monkeypatch.delenv("LTMD_UNIVERSAL_INDEX_SHA256", raising=False)
     monkeypatch.delenv("LTMD_REUSE_SIMILARITY_PATH", raising=False)
     reset_state()
     client = api.app.test_client()


### PR DESCRIPTION
## Objetivo

Cierra la última deuda de integración antes del staging real: exponer por HTTP el motor corpus-wide ya validado, sin crear un motor paralelo ni cambiar sus reglas científicas.

## Cambios

- nuevo `GET /v1/corpus/query` sobre `LTMD_U1_CORPUS_QUERY_ENGINE_0.1`;
- filtros `generation`, `grade_code`, `wave` y `group_by` generation/grade/wave;
- `LTMD_UNIVERSAL_INDEX_PATH` habilita consulta corpus-wide por sí solo;
- `LTMD_UNIVERSAL_INDEX_SHA256` permite exigir el SHA canónico en staging;
- `LTMD_REUSE_SIMILARITY_PATH` sigue siendo opcional y requiere el Índice Universal;
- `/health` y `/v1/meta` reportan estado corpus-wide sin revelar rutas;
- tests de schema, denominadores, privacidad, configuración index-only y read-only;
- documentación de cPanel actualizada con insumos privados, root `passenger_wsgi.py` y gate HTTP completo.

## Guardas

La salida corpus-wide sigue siendo `exploratory_signal`; no emite OCR, `page_id`, IDs de objetos, snippets, URLs fuente, hashes de página/OCR ni pares concretos. Cero hits no demuestran ausencia histórica.

## Gate esperado de staging

`/health`, `/v1/meta`, `/v1/corpus/query?q=democracia&group_by=generation`, `/v1/indigenous/query` y POST=405. El Índice Universal canónico esperado tiene SHA-256 `aec55cc7dd83c2e1e22d26e3baf8f7ca2e35e32898827ec84e6222edd4bcf7a2`.