### PR TITLE
QA: endurecer gobernanza, colaboración y mantenibilidad del repositorio

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Error técnico reproducible
+description: Reporte de fallo en código, pipeline, documentación ejecutable o infraestructura.
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Gracias por documentar el problema. No incluya secretos, credenciales, datos personales ni materiales fuente restringidos.
+  - type: input
+    id: version
+    attributes:
+      label: Versión o commit
+      description: Tag, release o SHA en el que observó el problema.
+      placeholder: v0.1.0-rc.1 o 7b241e7...
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema observado
+      description: Describa el comportamiento actual y el esperado.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Pasos mínimos para reproducir
+      description: Incluya comandos, rutas públicas y entradas mínimas necesarias.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidencia
+      description: Logs no sensibles, hashes, identificadores, mensajes de error o resultados de validadores.
+  - type: dropdown
+    id: scientific-impact
+    attributes:
+      label: ¿Puede afectar resultados científicos o integridad de datos?
+      options:
+        - "No"
+        - "Sí"
+        - "No estoy seguro"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmaciones
+      options:
+        - label: Busqué issues existentes sobre el mismo problema.
+          required: true
+        - label: El reporte no contiene secretos ni materiales restringidos.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Política de seguridad
+    url: https://github.com/fersandovalgtz/libro-texto-mexicano-digital/blob/main/SECURITY.md
+    about: No publique vulnerabilidades, credenciales o información sensible en un issue público.
+  - name: Guía de soporte
+    url: https://github.com/fersandovalgtz/libro-texto-mexicano-digital/blob/main/SUPPORT.md
+    about: Consulte qué canal corresponde antes de reportar soporte, datos o materiales fuente.

--- a/.github/ISSUE_TEMPLATE/data_methodology.yml
+++ b/.github/ISSUE_TEMPLATE/data_methodology.yml
@@ -1,0 +1,63 @@
+name: Datos, procedencia o metodología
+description: Reporte de discrepancia documental, problema de datos o propuesta metodológica.
+title: "[Data/Method] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use este formulario cuando el asunto afecte identidad documental, cobertura, procedencia, hashes, relaciones, denominadores, estados de validación o reglas metodológicas.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Área principal
+      options:
+        - Identidad documental / metadatos
+        - Cobertura / denominadores
+        - Procedencia / hashes / manifiestos
+        - OCR / PAGESTRUCT / FRAGSEG / FTRL
+        - Reutilización / similitud documental
+        - Validación humana / estados semánticos
+        - Metodología / contrato de datos
+        - Otro
+    validations:
+      required: true
+  - type: input
+    id: identifiers
+    attributes:
+      label: Identificadores afectados
+      description: viewer_key, book_id, wave, ruta pública, SHA u otro identificador reproducible.
+  - type: textarea
+    id: observation
+    attributes:
+      label: Discrepancia o propuesta
+      description: Explique exactamente qué observa y qué debería revisarse.
+    validations:
+      required: true
+  - type: textarea
+    id: provenance
+    attributes:
+      label: Evidencia y procedencia
+      description: Cite la fuente o artefacto verificable. No adjunte material restringido si no existe base jurídica para redistribuirlo.
+    validations:
+      required: true
+  - type: dropdown
+    id: validation-state
+    attributes:
+      label: Estado epistemológico de la evidencia
+      options:
+        - Evidencia documental/técnica verificable
+        - Señal computacional exploratoria
+        - Validación humana documentada
+        - Hipótesis todavía no verificada
+        - No estoy seguro
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmaciones
+      options:
+        - label: No estoy promoviendo una señal automática a `semantic_ready` sin evidencia humana válida.
+          required: true
+        - label: He distinguido el material fuente del derivado o metadato de LTMD.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Propuesta de capacidad
+description: Nueva función para LTMD Open, investigación reproducible o interoperabilidad.
+title: "[Feature] "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema de investigación o mantenimiento
+      description: Describa el problema antes de proponer la solución.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Capacidad propuesta
+      description: Explique qué debería hacer LTMD y para quién.
+    validations:
+      required: true
+  - type: dropdown
+    id: value
+    attributes:
+      label: Valor principal
+      description: La propuesta debe fortalecer al menos una dimensión justificable.
+      options:
+        - Aumenta valor científico verificable
+        - Reduce trabajo del investigador
+        - Mejora trazabilidad o reproducibilidad
+        - Mejora interoperabilidad o reutilización
+        - Fortalece una capacidad operada sostenible
+        - Otro, con justificación
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidencia, caso de uso o estándar relacionado
+      description: Añada ejemplos, referencias, estándares o flujo de investigación que justifiquen la propuesta.
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Riesgos y fronteras
+      description: Considere derechos de terceros, privacidad, costo computacional, compatibilidad y estados de validación.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmaciones
+      options:
+        - label: La propuesta distingue LTMD Open de servicios operados cuando corresponde.
+          required: true
+        - label: La propuesta no depende de publicar materiales fuente restringidos.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,43 @@
+## Propósito
+
+Describa qué cambia y por qué.
+
+## Tipo de cambio
+
+- [ ] Código / infraestructura
+- [ ] Datos o metadatos derivados
+- [ ] Metodología / contrato científico
+- [ ] Documentación
+- [ ] CI / seguridad / mantenimiento
+- [ ] Otro
+
+## Evidencia y procedencia
+
+Indique las fuentes, identificadores documentales, issues, decisiones o artefactos que sustentan el cambio. Si no aplica, explique por qué.
+
+## Validación ejecutada
+
+Incluya comandos, pruebas, validadores o verificaciones realizadas y su resultado.
+
+## Impacto científico
+
+- [ ] No cambia denominadores, definiciones, estados de validación ni interpretación científica.
+- [ ] Cambia alguno de esos elementos y la modificación está documentada explícitamente.
+- [ ] No promueve `corpus_ready` a `semantic_ready` sin referencia humana válida.
+- [ ] No convierte `search_hit` o `computational_candidate` en afirmación histórica validada.
+
+## Derechos y privacidad
+
+- [ ] No incorpora secretos, credenciales, rutas privadas ni datos personales.
+- [ ] No redistribuye materiales fuente de terceros sin fundamento jurídico explícito.
+- [ ] Los artefactos locales/restringidos permanecen fuera de Git cuando corresponde.
+
+## Reproducibilidad y compatibilidad
+
+- [ ] Actualicé pruebas, contratos, documentación o changelog cuando el cambio lo requiere.
+- [ ] El cambio preserva procedencia e identificadores existentes o documenta cualquier migración.
+- [ ] Consideré compatibilidad con releases y consumidores existentes.
+
+## Riesgos / límites
+
+Describa incertidumbres, excepciones, deuda técnica o efectos no cubiertos por este PR.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(actions)"
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(python)"

--- a/.github/workflows/repository-quality.yml
+++ b/.github/workflows/repository-quality.yml
@@ -1,0 +1,46 @@
+name: Repository quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  repository-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compile quality auditor
+        run: python -m py_compile scripts/audit_repository_quality.py
+
+      - name: Audit repository surface
+        run: python scripts/audit_repository_quality.py --json repository-quality-report.json
+
+      - name: Publish job summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## LTMD repository quality"
+            echo
+            echo '```json'
+            if [ -f repository-quality-report.json ]; then
+              cat repository-quality-report.json
+            else
+              echo '{"status":"audit did not produce a report"}'
+            fi
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Todos los cambios notables de **Libro de Texto Mexicano Digital (LTMD)** se docu
 
 Cambios acumulados en `main` posteriores a `v0.1.0-rc.1`. Esta sección **no** modifica retrospectivamente el alcance de la release del 15 de agosto de 2026.
 
+### Calidad del repositorio y arquitectura pública
+
+- Definida explícitamente la frontera **LTMD Open / LTMD Research / LTMD Services**, manteniendo este repositorio como superficie canónica abierta de código, metodología, contratos, metadatos, hashes y derivados publicables.
+- Añadidos `SUPPORT.md`, plantilla científica de pull request y formularios diferenciados para errores técnicos, datos/metodología y propuestas de capacidad.
+- Añadido Dependabot para GitHub Actions y dependencias Python con cadencia semanal.
+- Añadido `scripts/audit_repository_quality.py` y el workflow `repository-quality.yml` para verificar la superficie normativa, exclusión de rutas privadas/locales, metadatos básicos y deuda de permisos en workflows.
+- Elevado `SCIENTIFIC_REPOSITORY_STANDARD.md` con controles explícitos de seguridad de automatización, gobernanza de `main`, triage, límites de producto y mantenimiento progresivo.
+- Actualizada la autoevaluación FAIR/FAIR4RS para reflejar la nueva superficie comunitaria y registrar como brechas externas la protección efectiva de `main` y la auditoría gradual de permisos de workflows heredados.
+
 ### Expansión LTMD-U1
 
 - Cerrado el censo operativo en **542/542 identidades** del universo U1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,19 @@ LTMD recibe contribuciones que mejoren datos, código, documentación, reproduci
 ## Antes de proponer cambios
 
 - abra o vincule un issue cuando el cambio modifique metodología, contratos, cobertura o resultados;
+- utilice el formulario de issue que corresponda para distinguir errores técnicos, discrepancias de datos/metodología y nuevas capacidades;
 - identifique la fuente o evidencia que sustenta la modificación;
 - no incorpore libros, páginas, imágenes u otros materiales de terceros al repositorio sin base jurídica clara;
-- mantenga separadas correcciones técnicas, propuestas semánticas y validaciones humanas.
+- mantenga separadas correcciones técnicas, propuestas semánticas y validaciones humanas;
+- revise `docs/LTMD_PRODUCT_BOUNDARIES.md` cuando el cambio afecte la frontera entre LTMD Open y superficies operadas.
+
+## Flujo de ramas y pull requests
+
+Los cambios a `main` deben entrar normalmente mediante una rama específica y un pull request. Evite commits directos a `main`, salvo una intervención excepcional cuya urgencia y razón queden documentadas.
+
+La plantilla de pull request forma parte del control de calidad: debe declarar propósito, evidencia, validación ejecutada, impacto científico, derechos, privacidad, reproducibilidad y riesgos. Los pull requests deben mantenerse pequeños y auditables cuando sea posible.
+
+El título debe indicar el área modificada y la descripción debe permitir a otra persona comprender qué se cambió, por qué, cómo se verificó y qué consecuencias científicas o de compatibilidad tiene.
 
 ## Requisitos mínimos
 
@@ -18,16 +28,24 @@ Toda contribución debe:
 3. incluir o actualizar pruebas, manifiestos o documentación cuando cambie comportamiento verificable;
 4. actualizar `CHANGELOG.md` cuando afecte una release futura o una interfaz científica;
 5. no elevar automáticamente un estado técnico a `semantic_ready`;
-6. documentar incertidumbres, excepciones y resultados negativos relevantes.
+6. documentar incertidumbres, excepciones y resultados negativos relevantes;
+7. no incorporar secretos, credenciales, rutas privadas o artefactos locales restringidos;
+8. pasar los controles automatizados aplicables antes de integrarse a `main`.
 
-## Pull requests
+## Cambios metodológicos o de datos
 
-Los pull requests deben ser pequeños y auditables cuando sea posible. El título debe indicar el área modificada y la descripción debe incluir: propósito, evidencia, archivos afectados, pruebas ejecutadas y consecuencias científicas o de compatibilidad.
+Una modificación de denominadores, reglas de inclusión, identidad documental, procedencia, estados de validación, contratos o interpretación de resultados exige evidencia explícita. No debe ocultarse dentro de un refactor o una corrección editorial.
+
+`corpus_ready != semantic_ready`, `search_hit != historical_claim` y `computational_candidate != semantic_ready` son reglas de no regresión.
+
+## Dependencias y automatización
+
+Las actualizaciones de dependencias deben revisarse como cualquier otro cambio. Los workflows deben operar con el menor conjunto de permisos de `GITHUB_TOKEN` necesario y no deben introducir secretos en el repositorio o en artefactos públicos.
 
 ## Atribución
 
 Las contribuciones sustantivas deben reconocerse de acuerdo con su naturaleza y alcance. Cuando una contribución tenga relevancia académica, puede documentarse con roles CRediT u otro esquema apropiado en una release posterior.
 
-## Conducta y seguridad
+## Conducta, soporte y seguridad
 
-Consulte `CODE_OF_CONDUCT.md` y `SECURITY.md`. Los problemas de seguridad no deben publicarse con detalles explotables antes de que exista una vía razonable de mitigación.
+Consulte `CODE_OF_CONDUCT.md`, `SUPPORT.md` y `SECURITY.md`. Los problemas de seguridad no deben publicarse con detalles explotables antes de que exista una vía razonable de mitigación.

--- a/FAIR_ASSESSMENT.md
+++ b/FAIR_ASSESSMENT.md
@@ -7,15 +7,17 @@ Esta autoevaluación describe el estado de **Libro de Texto Mexicano Digital (LT
 | Findable | parcial-avanzado | Repositorio público, `CITATION.cff`, `codemeta.json`, versionado y releases. Falta asignar DOI real a la release cuando exista depósito efectivo en Zenodo. |
 | Accessible | avanzado | Código, documentación y derivados publicables accesibles en GitHub; fuentes de terceros se reconstruyen de acuerdo con las restricciones documentadas. |
 | Interoperable | parcial-avanzado | Metadatos legibles por máquina, CSV/JSON y contratos metodológicos; la interoperabilidad semántica depende de cada capa y no se presume antes de validación. |
-| Reusable | avanzado con límites | Licencia Apache-2.0 para software propio, `DATA_LICENSE.md` para derivados licenciables, procedencia, versiones, protocolos y documentación de incertidumbre. |
+| Reusable | avanzado con límites | Licencia Apache-2.0 para software propio, `DATA_LICENSE.md` para derivados licenciables, procedencia, versiones, protocolos, documentación de incertidumbre y frontera explícita entre infraestructura abierta y servicios operados. |
 | FAIR4RS: identificación | parcial-avanzado | Releases y tags distinguen versiones; el DOI persistente se incorporará únicamente tras un depósito real. |
 | FAIR4RS: metadatos | avanzado | `CITATION.cff` + CodeMeta 3.1 + README + documentación metodológica. |
-| FAIR4RS: ejecutabilidad/reproducibilidad | avanzado | Dependencias de release, scripts versionados, GitHub Actions, manifiestos, hashes y reportes de integridad. |
-| FAIR4RS: comunidad/contribución | mejorado en esta revisión | `CONTRIBUTING.md`, gobernanza, seguridad y reglas para cambios metodológicos. |
+| FAIR4RS: ejecutabilidad/reproducibilidad | avanzado | Dependencias de release, scripts versionados, GitHub Actions, manifiestos, hashes, reportes de integridad y auditoría automatizada de la superficie del repositorio. |
+| FAIR4RS: comunidad/contribución | avanzado | `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, gobernanza, plantilla científica de PR y formularios diferenciados de issues. |
 
 ## Evidencia de madurez
 
 LTMD conserva explícitamente versiones, denominadores, excepciones, relaciones documentales, integridad criptográfica y límites de la automatización. La distinción `corpus_ready` / `semantic_ready` es un control epistemológico central: la completitud técnica no se comunica como validez semántica.
+
+La superficie pública diferencia además **LTMD Open** de **LTMD Research** y **LTMD Services**. Esta separación documenta qué puede publicarse como infraestructura científica abierta y qué pertenece a una instancia operada, sin transformar materiales fuente de terceros en activos exclusivos ni alterar las obligaciones de procedencia.
 
 ## Brechas abiertas
 
@@ -23,7 +25,9 @@ LTMD conserva explícitamente versiones, denominadores, excepciones, relaciones 
 2. **Validación humana semántica**: continúa pendiente donde el protocolo la exige; los estados técnicos no deben promoverse automáticamente.
 3. **Preservación externa adicional**: conviene mantener releases archivadas y, cuando el corte sea estable, registrar preservación complementaria además de GitHub.
 4. **Metadatos de datos específicos**: las futuras releases pueden añadir JSON-LD/Dataset metadata por producto cuando la granularidad lo justifique.
+5. **Protección efectiva de `main`**: el contenido del repositorio ya define el flujo por pull request y status checks, pero la protección de rama es una configuración externa a Git y debe verificarse y habilitarse en GitHub.
+6. **Permisos explícitos en workflows heredados**: los controles nuevos usan mínimo privilegio; los workflows históricos sin `permissions:` explícito deben auditarse gradualmente antes de endurecerlos para evitar regresiones operativas.
 
 ## Criterio de actualización
 
-Esta autoevaluación debe revisarse en cada release mayor o cuando cambien persistent identifiers, licencias, contratos de datos, política de acceso o alcance de validación.
+Esta autoevaluación debe revisarse en cada release mayor o cuando cambien persistent identifiers, licencias, contratos de datos, política de acceso, alcance de validación, superficie pública o controles de publicación.

--- a/SCIENTIFIC_REPOSITORY_STANDARD.md
+++ b/SCIENTIFIC_REPOSITORY_STANDARD.md
@@ -29,15 +29,52 @@ LTMD distingue fuente, procesamiento técnico, derivado computacional, validaci�
 
 Antes de una release deben ejecutarse las validaciones automatizadas aplicables y documentarse failures, blockers y excepciones. Los cambios en definiciones, contratos, denominadores o reglas de análisis requieren documentación explícita.
 
-## 6. FAIR / FAIR4RS
+El repositorio debe mantener controles automatizados sobre su propia superficie de publicación: archivos normativos, metadatos, exclusión de artefactos privados/locales, plantillas de contribución y workflows críticos. Los controles nuevos no deben romper silenciosamente pipelines heredados; la deuda detectada debe convertirse en advertencia o migración explícita hasta que pueda elevarse con seguridad a gate obligatorio.
+
+## 6. Seguridad de automatización
+
+Los workflows deben declarar el menor conjunto de permisos de `GITHUB_TOKEN` que requieran. Los secretos no se versionan ni se incorporan a artefactos públicos. Las dependencias automatizadas deben actualizarse mediante cambios revisables y trazables.
+
+Los workflows existentes sin permisos explícitos deben auditarse progresivamente antes de imponer cambios masivos que puedan alterar su comportamiento.
+
+## 7. Gobernanza de cambios
+
+`main` es la rama canónica y debe tratarse como superficie de publicación. Los cambios ordinarios deben entrar por ramas específicas y pull requests auditables. La plantilla de pull request debe exigir propósito, evidencia, validación, impacto científico, derechos, privacidad, reproducibilidad y riesgos.
+
+Cuando la configuración de GitHub lo permita, `main` debe protegerse frente a borrados o force-push y exigir los status checks críticos antes de integrar cambios. La configuración efectiva de GitHub debe verificarse separadamente porque no forma parte del contenido versionado del repositorio.
+
+## 8. Salud comunitaria y triage
+
+El repositorio debe mantener, en ubicaciones reconocidas por GitHub, al menos:
+
+- `README.md`;
+- `LICENSE` y política diferenciada de datos;
+- `CONTRIBUTING.md`;
+- `CODE_OF_CONDUCT.md`;
+- `SECURITY.md`;
+- `SUPPORT.md`;
+- plantilla de pull request;
+- formularios diferenciados para errores técnicos, problemas de datos/metodología y propuestas de capacidad.
+
+El triage debe impedir que una corrección técnica, una discrepancia documental y una afirmación científica nueva se traten como equivalentes.
+
+## 9. FAIR / FAIR4RS
 
 Cada release debe maximizar descubribilidad, acceso, interoperabilidad y reutilización mediante identificadores, metadatos, formatos documentados, licencias, procedencia y versionado. `FAIR_ASSESSMENT.md` debe actualizarse cuando cambien estas condiciones.
 
-## 7. Comunicación científica
+Para datos y derivados, la reutilización exige además procedencia suficientemente detallada, licencia clara cuando exista capacidad jurídica para otorgarla y uso de formatos y convenciones sostenibles para la comunidad.
+
+## 10. Fronteras de producto y publicación
+
+El repositorio público corresponde a **LTMD Open**. Las superficies operadas **LTMD Research** y **LTMD Services** pueden utilizar la infraestructura abierta sin alterar las licencias ni convertir materiales fuente de terceros en activos exclusivos.
+
+`docs/LTMD_PRODUCT_BOUNDARIES.md` es normativo para decidir qué pertenece al repositorio público y qué debe permanecer en infraestructura operada o privada.
+
+## 11. Comunicación científica
 
 El README debe permitir comprender en pocos minutos: qué investiga LTMD, qué estado científico tiene, qué está validado y qué no, cómo reproducir el trabajo, cómo citarlo y dónde encontrar la documentación técnica. La complejidad detallada debe enlazarse a `docs/` en lugar de convertir la portada del repositorio en un cuaderno de laboratorio completo.
 
-## 8. Releases
+## 12. Releases
 
 Una release pública debe incluir como mínimo:
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,30 @@
+# Soporte y canales de reporte
+
+LTMD distingue soporte técnico, calidad de datos, discusión metodológica y seguridad para que cada reporte conserve la evidencia adecuada.
+
+## Issues públicos
+
+Utilice un issue para:
+
+- errores reproducibles de código o documentación;
+- discrepancias de metadatos, cobertura, hashes o relaciones documentales;
+- propuestas metodológicas o de funcionalidad;
+- problemas de reproducibilidad que no impliquen información sensible.
+
+Antes de abrirlo, busque incidencias existentes y aporte el identificador documental, archivo, comando, versión o commit necesarios para reproducir el problema.
+
+## Seguridad
+
+No publique credenciales, secretos, rutas privadas, datos personales ni detalles explotables. Consulte `SECURITY.md` y utilice un canal privado cuando el reporte tenga implicaciones de seguridad.
+
+## Materiales fuente y derechos
+
+Las solicitudes de redistribución de libros, páginas, imágenes u OCR íntegro no se tramitan como soporte técnico ordinario. LTMD no presume derechos sobre materiales fuente de SEP/CONALITEG o terceros y mantiene esas decisiones separadas del código y de los derivados propios.
+
+## LTMD Research y LTMD Services
+
+El soporte de superficies operadas, cuentas, disponibilidad, contratos o servicios institucionales pertenece a los canales de la instancia correspondiente y no debe mezclarse con incidencias del repositorio abierto, salvo que el problema sea reproducible en LTMD Open.
+
+## Alcance
+
+La existencia de un issue no implica aceptación de una interpretación científica ni compromiso de incorporación. Los cambios que afecten metodología, denominadores, estados de validación o procedencia requieren evidencia y revisión acordes con `CONTRIBUTING.md` y `SCIENTIFIC_REPOSITORY_STANDARD.md`.

--- a/docs/LTMD_PRODUCT_BOUNDARIES.md
+++ b/docs/LTMD_PRODUCT_BOUNDARIES.md
@@ -1,0 +1,66 @@
+# LTMD: límites entre infraestructura abierta y servicios operados
+
+**Estado:** documento normativo de arquitectura pública  
+**Fecha de adopción:** 31 de agosto de 2026
+
+Libro de Texto Mexicano Digital (LTMD) combina una infraestructura científica abierta con superficies operadas de investigación y servicios. Esta separación evita confundir apertura científica, derechos sobre materiales fuente y capacidades comerciales.
+
+## 1. LTMD Open
+
+Este repositorio constituye la superficie canónica de **LTMD Open**. Publica, cuando jurídica y científicamente corresponde:
+
+- código y contratos técnicos;
+- metodología, protocolos y documentación;
+- metadatos, hashes y manifiestos de integridad;
+- esquemas y derivados originales publicables;
+- pruebas, validadores y mecanismos de reproducibilidad;
+- releases, citación, procedencia y gobernanza.
+
+LTMD Open debe permanecer auditable y reproducible. Una capacidad comercial no justifica degradar la trazabilidad, ocultar metodología necesaria para interpretar resultados ni reescribir retroactivamente una release.
+
+## 2. LTMD Research
+
+**LTMD Research** es la superficie operada orientada al trabajo de investigación. Puede ofrecer búsqueda avanzada, comparación longitudinal, visualización, exportación, espacios de trabajo, colaboración, cómputo y otras capacidades gestionadas.
+
+La existencia de LTMD Research no convierte los materiales fuente de terceros en activos exclusivos de LTMD. Tampoco modifica por sí sola las licencias del software o de los derivados publicados en este repositorio.
+
+## 3. LTMD Services
+
+**LTMD Services** agrupa capacidades operadas o especializadas, por ejemplo API, estudios y datasets derivados a medida, soporte, curaduría y validación especializada.
+
+Los servicios deben respetar las mismas fronteras epistemológicas del repositorio: una señal automática no se presenta como validación humana y un resultado de búsqueda no se convierte por sí mismo en afirmación histórica.
+
+## 4. Frontera de datos y derechos
+
+Por defecto, permanecen fuera del repositorio público:
+
+- PDF, JPEG, páginas o reproducciones extensas de materiales fuente de terceros cuando no exista fundamento jurídico suficiente para redistribuirlos;
+- OCR íntegro reconstruido a partir de esos materiales cuando pueda operar como sustituto de la fuente;
+- índices full-text, caches, bases SQLite y otros artefactos locales que contengan texto fuente restringido;
+- credenciales, secretos, rutas privadas y ledgers operativos que no deban publicarse.
+
+GitHub puede publicar código de reconstrucción, contratos, métricas, hashes y agregados no sustitutivos cuando sean lícitos y científicamente defendibles.
+
+## 5. Identidad institucional y autoría científica
+
+La identidad de producto puede presentarse institucionalmente como **Universidad CEEES → LTMD / LTMD Research / LTMD Services**. La institucionalización de la marca no debe borrar autoría, procedencia o responsabilidad científica cuando éstas sean necesarias para citación, ORCID, licencias, propiedad intelectual, releases o integridad metodológica.
+
+## 6. Regla de no regresión
+
+Toda contribución pública debe preservar al menos estas separaciones:
+
+`source_material != open_licensed_asset`
+
+`ocr_available != text_verified`
+
+`search_hit != historical_claim`
+
+`computational_candidate != semantic_ready`
+
+`operated_service != exclusive_ownership_of_source_material`
+
+## 7. Criterio para nuevas funciones
+
+Una nueva función se prioriza si aumenta valor científico verificable, reduce trabajo del investigador, mejora trazabilidad o fortalece una capacidad operada sostenible. Si no satisface con claridad al menos uno de esos criterios, debe justificarse antes de incorporarse al núcleo.
+
+Este documento define límites de producto y publicación. No sustituye `LICENSE`, `DATA_LICENSE.md`, `GOVERNANCE.md`, `PROVENANCE.md` ni los protocolos científicos específicos.

--- a/scripts/audit_repository_quality.py
+++ b/scripts/audit_repository_quality.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Audit LTMD's public repository surface without external dependencies.
+
+The audit is intentionally conservative: it verifies controls that can be
+established from the checked-out repository and does not claim to certify
+GitHub settings, legal status, scientific validity, or FAIR compliance.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+REQUIRED_FILES = (
+    "README.md",
+    "README.en.md",
+    "LICENSE",
+    "DATA_LICENSE.md",
+    "CITATION.cff",
+    "codemeta.json",
+    "CHANGELOG.md",
+    "CONTRIBUTING.md",
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "SUPPORT.md",
+    "GOVERNANCE.md",
+    "PROVENANCE.md",
+    "FAIR_ASSESSMENT.md",
+    "SCIENTIFIC_REPOSITORY_STANDARD.md",
+    "docs/LTMD_PRODUCT_BOUNDARIES.md",
+    ".github/PULL_REQUEST_TEMPLATE.md",
+    ".github/ISSUE_TEMPLATE/bug_report.yml",
+    ".github/ISSUE_TEMPLATE/data_methodology.yml",
+    ".github/ISSUE_TEMPLATE/feature_request.yml",
+    ".github/ISSUE_TEMPLATE/config.yml",
+    ".github/dependabot.yml",
+    ".github/workflows/release-preflight.yml",
+    ".github/workflows/repository-quality.yml",
+)
+
+REQUIRED_GITIGNORE_RULES = (
+    "local/",
+    "private/",
+    ".env",
+    ".env.*",
+    "*.pdf",
+)
+
+FORBIDDEN_TRACKED_PREFIXES = ("local/", "private/")
+FORBIDDEN_TRACKED_NAMES = {".env"}
+
+
+def fail(message: str, failures: list[str]) -> None:
+    failures.append(message)
+    print(f"FAIL: {message}")
+
+
+def tracked_files() -> list[str]:
+    proc = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        stdout=subprocess.PIPE,
+    )
+    return [item.decode("utf-8") for item in proc.stdout.split(b"\0") if item]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json",
+        dest="json_path",
+        help="Optional path for a machine-readable audit report.",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    for relative in REQUIRED_FILES:
+        if not (ROOT / relative).is_file():
+            fail(f"missing required repository surface: {relative}", failures)
+
+    gitignore_path = ROOT / ".gitignore"
+    if not gitignore_path.is_file():
+        fail("missing .gitignore", failures)
+        gitignore = ""
+    else:
+        gitignore = gitignore_path.read_text(encoding="utf-8")
+
+    for rule in REQUIRED_GITIGNORE_RULES:
+        if rule not in gitignore.splitlines():
+            fail(f".gitignore does not contain required rule: {rule}", failures)
+
+    try:
+        tracked = tracked_files()
+    except (subprocess.CalledProcessError, UnicodeDecodeError) as exc:
+        fail(f"unable to inspect tracked files: {exc}", failures)
+        tracked = []
+
+    for path in tracked:
+        if path in FORBIDDEN_TRACKED_NAMES or any(
+            path.startswith(prefix) for prefix in FORBIDDEN_TRACKED_PREFIXES
+        ):
+            fail(f"restricted local/private path is tracked: {path}", failures)
+
+    codemeta_path = ROOT / "codemeta.json"
+    if codemeta_path.is_file():
+        try:
+            codemeta = json.loads(codemeta_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            fail(f"codemeta.json is not valid UTF-8 JSON: {exc}", failures)
+        else:
+            for key in ("@context", "@type", "name", "codeRepository", "version", "license", "author"):
+                if key not in codemeta:
+                    fail(f"codemeta.json missing key: {key}", failures)
+
+    workflows_dir = ROOT / ".github" / "workflows"
+    workflows_without_permissions: list[str] = []
+    if workflows_dir.is_dir():
+        for path in sorted(workflows_dir.glob("*.y*ml")):
+            text = path.read_text(encoding="utf-8")
+            if "permissions:" not in text:
+                workflows_without_permissions.append(str(path.relative_to(ROOT)))
+
+    if workflows_without_permissions:
+        warning = (
+            f"{len(workflows_without_permissions)} workflow(s) do not declare explicit "
+            "GITHUB_TOKEN permissions; audit progressively before changing legacy jobs"
+        )
+        warnings.append(warning)
+        print(f"WARNING: {warning}")
+        for path in workflows_without_permissions:
+            print(f"  - {path}")
+
+    report = {
+        "audit": "LTMD repository quality",
+        "status": "pass" if not failures else "fail",
+        "required_files_checked": len(REQUIRED_FILES),
+        "tracked_files_checked": len(tracked),
+        "failures": failures,
+        "warnings": warnings,
+        "scope_note": (
+            "Repository-content audit only; branch protection, GitHub security settings, "
+            "legal review, scientific validity and external FAIR certification are out of scope."
+        ),
+    }
+
+    if args.json_path:
+        output = ROOT / args.json_path
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Objetivo

Elevar LTMD al nivel de un repositorio científico-digital mantenible y auditable, tomando como referencia las prácticas de community health de GitHub, mínimo privilegio en Actions y principios FAIR/FAIR4RS, sin alterar resultados científicos ni releases históricas.

## Cambios principales

- documenta la frontera pública LTMD Open / LTMD Research / LTMD Services;
- añade SUPPORT, plantilla científica de PR y formularios diferenciados de issues;
- añade Dependabot para GitHub Actions y Python;
- incorpora un auditor reproducible de calidad del repositorio y un workflow dedicado;
- endurece CONTRIBUTING y el estándar científico con flujo por PR, seguridad de automatización y controles de publicación;
- actualiza FAIR_ASSESSMENT y CHANGELOG en Unreleased;
- mantiene rutas privadas/locales y materiales fuente restringidos fuera de Git.

## Principios preservados

- no cambia U1, denominadores, hashes, OCR, estados semánticos ni resultados;
- no reescribe v0.1.0-rc.1;
- no inventa DOI ni certificación FAIR;
- no promociona señales computacionales a evidencia humana;
- no modifica licencias existentes.

## Pendiente externo a Git

`main` está actualmente sin protección. El estándar actualizado recomienda protección frente a force-push/borrado y status checks obligatorios, pero esa configuración vive en GitHub Settings y no puede representarse mediante un archivo versionado. La rama de este PR se creó directamente desde `7b241e7eaadb28cf12d3d8d77bc0b1b9affa3967`.
