### PR TITLE
CI: migrate evidence-integrity workflow to read-only

### DIFF
--- a/.github/workflows/build-ltmd-u1-evidence-integrity.yml
+++ b/.github/workflows/build-ltmd-u1-evidence-integrity.yml
@@ -25,7 +25,7 @@ on:
     types: [completed]
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: build-ltmd-u1-evidence-integrity
@@ -39,24 +39,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Build and publish deterministic integrity ledger
+
+      - name: Build deterministic integrity ledger
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          for attempt in 1 2 3; do
-            git fetch origin main
-            git reset --hard origin/main
-            python3 scripts/build_ltmd_u1_evidence_integrity.py
-            git add data/catalog/ltmd_u1_evidence_integrity.csv docs/LTMD_U1_EVIDENCE_INTEGRITY.md
-            if git diff --cached --quiet; then
-              exit 0
-            fi
-            git commit -m 'data: refresh U1 public evidence integrity ledger'
-            if git push origin HEAD:main; then
-              exit 0
-            fi
-            sleep $((attempt * 2))
-          done
-          exit 1
+          python3 scripts/build_ltmd_u1_evidence_integrity.py
+          if git diff --quiet -- data/catalog/ltmd_u1_evidence_integrity.csv docs/LTMD_U1_EVIDENCE_INTEGRITY.md; then
+            echo 'Integrity ledger is already synchronized with the checked-out revision.'
+          else
+            echo '::notice::Generated integrity ledger differs from the checked-out revision; review the uploaded artifact and promote changes through a pull request.'
+            git diff --stat -- data/catalog/ltmd_u1_evidence_integrity.csv docs/LTMD_U1_EVIDENCE_INTEGRITY.md
+          fi
+
+      - name: Upload generated integrity ledger
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-evidence-integrity
+          path: |
+            data/catalog/ltmd_u1_evidence_integrity.csv
+            docs/LTMD_U1_EVIDENCE_INTEGRITY.md
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -18,7 +18,7 @@ on:
       - 'README.md'
       - 'README.en.md'
       - 'docs/RELEASE_NOTES_*.md'
-      - '.github/workflows/test-ltmd-analytics.yml'
+      - '.github/workflows/**'
   push:
     branches: [main]
     paths:
@@ -36,7 +36,7 @@ on:
       - 'README.md'
       - 'README.en.md'
       - 'docs/RELEASE_NOTES_*.md'
-      - '.github/workflows/test-ltmd-analytics.yml'
+      - '.github/workflows/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Migrates one legacy write-capable workflow under #133.

Changes:
- `contents: write` → `contents: read`;
- removes direct commits and pushes to protected `main`;
- preserves deterministic regeneration of the public evidence-integrity ledger;
- uploads generated CSV/Markdown as a 14-day Actions artifact for review and PR-based promotion;
- emits a notice, rather than a false failure, when generated outputs differ from the checked-out revision.

This addresses the failing run observed after publishing `v0.2.0-rc.1` without weakening the repository ruleset. It is governance/CI maintenance only and does not alter the frozen release tag or scientific interpretation.