### PR TITLE
Metadata: register Zenodo DOI for LTMD v0.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "Si utiliza este proyecto, cite la versión archivada correspondiente. Esta metadata describe la versión científica estable v0.2.0; el DOI se añadirá únicamente después de una publicación real y verificable en Zenodo."
+message: "Si utiliza este proyecto, cite la versión archivada correspondiente en Zenodo. Para v0.2.0 utilice el DOI específico de versión indicado abajo."
 title: "Libro de Texto Mexicano Digital"
 type: software
 authors:
@@ -8,8 +8,9 @@ authors:
     orcid: "https://orcid.org/0000-0002-3168-6725"
 version: "0.2.0"
 date-released: 2026-09-01
+doi: "10.5281/zenodo.22243208"
 repository-code: "https://github.com/fersandovalgtz/libro-texto-mexicano-digital"
-url: "https://github.com/fersandovalgtz/libro-texto-mexicano-digital"
+url: "https://doi.org/10.5281/zenodo.22243208"
 license: "Apache-2.0"
 keywords:
   - libros de texto

--- a/README.en.md
+++ b/README.en.md
@@ -9,6 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-172033?style=flat-square" alt="Release v0.2.0"></a>
+  <a href="https://doi.org/10.5281/zenodo.22243207"><img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22243207-4b5563?style=flat-square" alt="Zenodo concept DOI"></a>
   <a href="CITATION.cff"><img src="https://img.shields.io/badge/citation-CFF%201.2-4b5563?style=flat-square" alt="CFF 1.2"></a>
   <a href="codemeta.json"><img src="https://img.shields.io/badge/metadata-CodeMeta%203.1-3b5b92?style=flat-square" alt="CodeMeta 3.1"></a>
   <a href="FAIR_ASSESSMENT.md"><img src="https://img.shields.io/badge/FAIR%2FFAIR4RS-self--assessment-2d6a4f?style=flat-square" alt="FAIR FAIR4RS"></a>
@@ -46,7 +47,8 @@ Reference corpus cut: **31 August 2026**. Stable software release: **1 September
 | Canonical processing objects | **492 / 542 (90.77%)** |
 | Human semantic validation | **0 / 542** |
 | Scientific release | **v0.2.0** |
-| LTMD DOI | **pending archival deposit; not pre-declared** |
+| Version DOI | **10.5281/zenodo.22243208** |
+| Concept DOI (all versions) | **10.5281/zenodo.22243207** |
 
 The current operational plan is [`docs/LTMD_U1_MASTER_PLAN_0_3.md`](docs/LTMD_U1_MASTER_PLAN_0_3.md). The **18 identities** still outside effective technical coverage are consolidated one-by-one in [`data/catalog/ltmd_u1_retained_source_register.csv`](data/catalog/ltmd_u1_retained_source_register.csv), with resolution policy and provenance requirements in [`docs/LTMD_U1_RETAINED_SOURCE_REGISTER.md`](docs/LTMD_U1_RETAINED_SOURCE_REGISTER.md).
 
@@ -116,7 +118,7 @@ LTMD exposes human- and machine-readable metadata through:
 - GitHub releases and reproducibility records;
 - governance, provenance, contribution, and licensing documentation.
 
-A DOI will only be added after a real and verifiable archival deposit exists.
+Zenodo archived `v0.2.0` under the version DOI **10.5281/zenodo.22243208**. The concept DOI **10.5281/zenodo.22243207** represents the software across all Zenodo versions and resolves to the latest archived version.
 
 ## Rights and licenses
 
@@ -128,9 +130,9 @@ These licenses do **not** automatically apply to source books, PDFs, JPEGs, cove
 
 GitHub can generate citation formats from [`CITATION.cff`](CITATION.cff). For stable scientific release `v0.2.0`:
 
-> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, version 0.2.0. GitHub release. https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.2.0
+> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, version 0.2.0. Zenodo. https://doi.org/10.5281/zenodo.22243208
 
-Once Zenodo or another archival service assigns a persistent identifier to the real deposit, the DOI will be added consistently to the scholarly metadata and citation surface.
+For references intended to track **all future versions**, use the concept DOI: https://doi.org/10.5281/zenodo.22243207.
 
 ## Project lead
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.2.0"><img src="https://img.shields.io/badge/release-v0.2.0-172033?style=flat-square" alt="Release v0.2.0"></a>
+  <a href="https://doi.org/10.5281/zenodo.22243207"><img src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.22243207-4b5563?style=flat-square" alt="DOI conceptual de Zenodo"></a>
   <a href="CITATION.cff"><img src="https://img.shields.io/badge/citación-CFF%201.2-4b5563?style=flat-square" alt="CFF 1.2"></a>
   <a href="codemeta.json"><img src="https://img.shields.io/badge/metadatos-CodeMeta%203.1-3b5b92?style=flat-square" alt="CodeMeta 3.1"></a>
   <a href="FAIR_ASSESSMENT.md"><img src="https://img.shields.io/badge/FAIR%2FFAIR4RS-autoevaluación-2d6a4f?style=flat-square" alt="FAIR FAIR4RS"></a>
@@ -66,7 +67,8 @@ Corte documental de referencia: **31 de agosto de 2026**. Release estable de sof
 | Objetos canónicos de procesamiento | **492 / 542 (90.77%)** |
 | Validación semántica humana | **0 / 542** |
 | Release científica | **v0.2.0** |
-| DOI de LTMD | **pendiente de depósito; no se anticipa** |
+| DOI de versión | **10.5281/zenodo.22243208** |
+| DOI conceptual (todas las versiones) | **10.5281/zenodo.22243207** |
 
 ### Cobertura U1
 
@@ -172,7 +174,7 @@ LTMD expone metadatos para humanos y máquinas mediante:
 - releases de GitHub con notas y reportes de reproducibilidad;
 - documentación de procedencia, gobernanza y licencias.
 
-**No se declara DOI de LTMD hasta que exista un depósito real y verificable.** Esta decisión evita crear identificadores ficticios o inconsistentes entre GitHub y un archivo de preservación.
+Zenodo archivó `v0.2.0` con el DOI específico de versión **10.5281/zenodo.22243208**. El DOI conceptual **10.5281/zenodo.22243207** representa el software a través de todas sus versiones depositadas en Zenodo y resuelve a la versión archivada más reciente.
 
 ## Derechos y licencias
 
@@ -188,9 +190,9 @@ Las contribuciones son bienvenidas cuando preservan procedencia, reproducibilida
 
 GitHub puede generar citas desde [`CITATION.cff`](CITATION.cff). Para la release científica estable `v0.2.0`:
 
-> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, versión 0.2.0. GitHub release. https://github.com/fersandovalgtz/libro-texto-mexicano-digital/releases/tag/v0.2.0
+> Sandoval Gutierrez, Fernando. 2026. *Libro de Texto Mexicano Digital*, versión 0.2.0. Zenodo. https://doi.org/10.5281/zenodo.22243208
 
-Cuando exista un depósito real en Zenodo u otro archivo con identificador persistente, el DOI deberá incorporarse de forma coherente a `CITATION.cff`, `codemeta.json`, la release y esta sección.
+Para referencias que deban seguir **todas las versiones futuras**, utilice el DOI conceptual: https://doi.org/10.5281/zenodo.22243207.
 
 ## Responsable
 

--- a/codemeta.json
+++ b/codemeta.json
@@ -6,6 +6,7 @@
   "description": "Infraestructura abierta de investigación para el estudio longitudinal de los libros de texto mexicanos mediante historia de la educación, humanidades digitales, análisis computacional y ciencia abierta. La versión estable 0.2.0 consolida LTMD-U1, FTRL, LTMD Analytics 0.1, Automated Benchmark 0.1, Documentary Genealogy Benchmark 0.2 y controles reforzados de reproducibilidad y gobernanza, manteniendo separados los resultados computacionales de la validación humana y la interpretación histórica.",
   "codeRepository": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital",
   "issueTracker": "https://github.com/fersandovalgtz/libro-texto-mexicano-digital/issues",
+  "identifier": "https://doi.org/10.5281/zenodo.22243208",
   "version": "0.2.0",
   "datePublished": "2026-09-01",
   "developmentStatus": "active",


### PR DESCRIPTION
## Objetivo

Cerrar la publicación científica de LTMD v0.2.0 registrando los identificadores persistentes ya asignados por Zenodo, sin modificar retrospectivamente el tag archivado.

## DOI verificados en el registro Zenodo

- DOI específico de versión v0.2.0: `10.5281/zenodo.22243208`
- DOI conceptual de todas las versiones: `10.5281/zenodo.22243207`

## Cambios

- `CITATION.cff`: incorpora el DOI específico de v0.2.0 y lo convierte en la URL canónica de citación de esa versión.
- `codemeta.json`: incorpora el identificador DOI específico de la release estable.
- `README.md` y `README.en.md`: eliminan el estado DOI pendiente, muestran ambos DOI, añaden badge del DOI conceptual y actualizan la cita recomendada.

## Política de versionado

El DOI específico se usa para citar exactamente v0.2.0. El DOI conceptual se documenta para referencias que deban seguir el conjunto de versiones del software. El tag `v0.2.0` permanece inmutable y sigue apuntando a `5199ebd95fedfbd207409331258ee8d8ac99bbbc`.

## Condición de merge

Integrar únicamente si pasan los gates obligatorios del repositorio.