### PR TITLE
CI: emit reconstructible repository preservation artifact

### DIFF
--- a/.github/workflows/repository-quality.yml
+++ b/.github/workflows/repository-quality.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   repository-quality:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,3 +46,36 @@ jobs:
             fi
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Build preservation snapshot
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p preservation
+          git bundle create preservation/repository.bundle --all
+          git archive --format=zip --output=preservation/repository-tree.zip HEAD
+          BUNDLE_SHA=$(sha256sum preservation/repository.bundle | awk '{print $1}')
+          TREE_SHA=$(sha256sum preservation/repository-tree.zip | awk '{print $1}')
+          BUNDLE_SIZE=$(stat -c%s preservation/repository.bundle)
+          TREE_SIZE=$(stat -c%s preservation/repository-tree.zip)
+          {
+            echo 'schema=LTMD_REPO_PRESERVATION_ARTIFACT_0.1'
+            echo "source_sha=${GITHUB_SHA}"
+            echo "source_ref=${GITHUB_REF}"
+            echo "bundle_size=${BUNDLE_SIZE}"
+            echo "bundle_sha256=${BUNDLE_SHA}"
+            echo "tree_size=${TREE_SIZE}"
+            echo "tree_sha256=${TREE_SHA}"
+            echo 'bundle_verify=git bundle verify repository.bundle'
+          } > preservation/manifest.txt
+          git bundle verify preservation/repository.bundle
+
+      - name: Upload preservation snapshot
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-repo-preservation-${{ github.sha }}
+          path: preservation/
+          retention-days: 14
+          compression-level: 0


### PR DESCRIPTION
## Objetivo

Hacer operativa la regla canónica GitHub ↔ Google Drive sin volver a ampliar la superficie de Actions.

## Cambio

Se extiende el workflow canónico `Repository quality` —sin crear un quinto workflow— para que, **únicamente en `push` a `main` o ejecución manual**, genere un paquete reconstructible de preservación:

- `repository.bundle`: bundle Git con historial/ref disponibles en el checkout de profundidad completa;
- `repository-tree.zip`: árbol exacto del `HEAD` preservado;
- `manifest.txt`: commit/ref, tamaños y SHA-256 de ambos objetos;
- verificación local mediante `git bundle verify` antes de publicar el artefacto.

El artefacto se publica temporalmente mediante `actions/upload-artifact@v4`, con retención de 14 días y sin compresión adicional. Los eventos `pull_request` siguen ejecutando únicamente la auditoría de calidad y **no** construyen el paquete pesado.

## Gobernanza y seguridad

- `permissions: contents: read` permanece intacto;
- no existe `git push`, escritura a `main` ni permiso `contents: write`;
- no se crea un workflow adicional;
- el artefacto de Actions es sólo un handoff temporal: la preservación no se declara completa hasta copiarlo a la carpeta canónica privada de Google Drive y verificar integridad/privacidad;
- el snapshot contiene únicamente el repositorio Git y su árbol versionado, no fuentes privadas externas, PDF/JPEG de terceros ni OCR restringido fuera de Git.

## Motivación

LTMD exige que los cambios metodológicos, de corpus, release o arquitectura queden preservados persistentemente en Drive. Este cambio permite que cada `push` sustantivo a `main` produzca un objeto reconstructible y verificable que ChatGPT pueda transferir al archivo canónico de Drive.

## Condición de merge

No integrar mientras fallen los gates obligatorios del repositorio. Después del merge, descargar el artefacto del `push` resultante, copiarlo a `LTMD-U2/00_CANON_y_manifiestos/01_REPO_SNAPSHOTS`, verificar SHA-256 y `shared=false`, y registrar el checkpoint en Notion.