### PR TITLE
CI: split preservation handoff for Drive transfer limits

### DIFF
--- a/.github/workflows/repository-quality.yml
+++ b/.github/workflows/repository-quality.yml
@@ -60,7 +60,7 @@ jobs:
           BUNDLE_SIZE=$(stat -c%s preservation/repository.bundle)
           TREE_SIZE=$(stat -c%s preservation/repository-tree.zip)
           {
-            echo 'schema=LTMD_REPO_PRESERVATION_ARTIFACT_0.1'
+            echo 'schema=LTMD_REPO_PRESERVATION_ARTIFACT_0.2'
             echo "source_sha=${GITHUB_SHA}"
             echo "source_ref=${GITHUB_REF}"
             echo "bundle_size=${BUNDLE_SIZE}"
@@ -68,14 +68,33 @@ jobs:
             echo "tree_size=${TREE_SIZE}"
             echo "tree_sha256=${TREE_SHA}"
             echo 'bundle_verify=git bundle verify repository.bundle'
+            echo 'transport=separate-artifacts-for-drive-handoff'
           } > preservation/manifest.txt
           git bundle verify preservation/repository.bundle
 
-      - name: Upload preservation snapshot
+      - name: Upload preservation Git bundle
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: ltmd-repo-preservation-${{ github.sha }}
-          path: preservation/
+          name: ltmd-repo-bundle-${{ github.sha }}
+          path: preservation/repository.bundle
+          retention-days: 14
+          compression-level: 0
+
+      - name: Upload preservation tree
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-repo-tree-${{ github.sha }}
+          path: preservation/repository-tree.zip
+          retention-days: 14
+          compression-level: 0
+
+      - name: Upload preservation manifest
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-repo-manifest-${{ github.sha }}
+          path: preservation/manifest.txt
           retention-days: 14
           compression-level: 0


### PR DESCRIPTION
## Objetivo

Adaptar el handoff de preservación a los límites de transferencia del conector de Google Drive sin alterar el contenido preservado ni ampliar la superficie de workflows.

## Cambio

`Repository quality` continúa construyendo exactamente dos objetos de preservación más manifiesto:

- `repository.bundle` — historial Git reconstructible;
- `repository-tree.zip` — árbol exacto del `HEAD`;
- `manifest.txt` — commit/ref, tamaños, SHA-256 y comando de verificación.

En lugar de envolver los tres objetos en un único artefacto de ~189 MB, se publican como **tres artefactos temporales separados**, cada uno compatible con la transferencia a Drive. Los hashes del bundle y del árbol siguen calculándose sobre los bytes originales, antes del empaquetado de Actions.

## Gobernanza

- se mantienen sólo cuatro workflows activos;
- `permissions: contents: read`;
- no hay escritura a Git ni `git push`;
- sólo `push` a `main`/`workflow_dispatch` generan preservación; PR sólo valida calidad;
- Actions sigue siendo handoff temporal: el cierre archivístico exige copia persistente y verificada en Drive.

## Condición de merge

No integrar mientras fallen los gates obligatorios. Tras el merge, transferir los tres artefactos del nuevo `main` a la carpeta canónica U2 `01_REPO_SNAPSHOTS`, verificar hashes y privacidad, y registrar el snapshot en Notion.