### PR TITLE
Docs: refresh CONALITEG rights inquiry for LTMD-U2

### DIFF
--- a/.github/workflows/test-ltmd-analytics.yml
+++ b/.github/workflows/test-ltmd-analytics.yml
@@ -3,23 +3,6 @@ name: LTMD Analytics tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'analytics_api/**'
-      - 'passenger_wsgi.py'
-      - 'requirements-analytics*.txt'
-      - 'scripts/**'
-      - 'schemas/**'
-      - 'data/analytics/**'
-      - 'data/catalog/**'
-      - 'tests/**'
-      - 'VERSION'
-      - 'CITATION.cff'
-      - 'codemeta.json'
-      - 'CHANGELOG.md'
-      - 'README.md'
-      - 'README.en.md'
-      - 'docs/RELEASE_NOTES_*.md'
-      - '.github/workflows/**'
   push:
     branches: [main]
     paths:

--- a/docs/DRAFT_CONALITEG_RIGHTS_INQUIRY.md
+++ b/docs/DRAFT_CONALITEG_RIGHTS_INQUIRY.md
@@ -1,41 +1,46 @@
 # Borrador de consulta institucional a CONALITEG sobre reutilización académica
 
-**Estado:** borrador; **no enviado**.
+**Estado:** borrador actualizado; **no enviado**.
 
 **Canal institucional identificado:** `info@conaliteg.gob.mx`
 
 ## Asunto sugerido
 
-Consulta sobre uso académico y publicación de datos derivados del Catálogo Histórico de Libros de Texto Gratuitos
+Consulta sobre procesamiento académico y publicación de datos derivados de libros de texto CONALITEG
 
 ## Texto sugerido
 
 A quien corresponda en la Comisión Nacional de Libros de Texto Gratuitos:
 
-Mi nombre es Fernando Sandoval Gutiérrez y desarrollo un proyecto académico de investigación denominado **Libro de Texto Mexicano Digital**, orientado al estudio histórico y computacional de los libros de texto gratuitos de México.
+Mi nombre es Fernando Sandoval Gutiérrez y soy responsable científico del proyecto académico **Libro de Texto Mexicano Digital (LTMD)**, desarrollado con identidad institucional de la Universidad Centro de Estudios Especializados en Educación Superior, Cuauhtémoc. El proyecto estudia histórica y computacionalmente los libros de texto gratuitos de México con criterios de trazabilidad, reproducibilidad y ciencia abierta.
 
-Actualmente realizamos un piloto con cuatro ejemplares de **Ciencias Naturales de quinto grado** disponibles en el Catálogo Histórico de CONALITEG, correspondientes a las generaciones 1972, 1988, 1993 y 2014. El proyecto es de carácter académico y no comercial.
+Trabajamos con dos tipos de fuentes institucionales: materiales del **Catálogo Histórico** y la cohorte vigente de **primaria 2026–2027** publicada en el portal oficial de CONALITEG. Nuestro repositorio público contiene código, metadatos, identificadores, URLs de procedencia, hashes, conteos, métricas y otros derivados no sustitutivos; no redistribuimos por defecto los PDF, imágenes de página ni el OCR íntegro de las obras fuente.
 
-Nuestro procedimiento consulta los visores oficiales y, para fines de análisis, procesa temporalmente las imágenes de página mediante OCR. Las imágenes originales y las transcripciones completas no se publican en nuestro repositorio. Hasta ahora hemos limitado la publicación a código, metadatos bibliográficos y técnicos, URLs de procedencia, métricas de calidad del OCR, conteos, clasificaciones y otros datos derivados que no reproducen sustancialmente el contenido de los libros.
+En la cohorte vigente 2026–2027 identificamos 42 entradas de catálogo correspondientes a 39 objetos fuente únicos. Para verificar procedencia e integridad técnica, los 39 PDF institucionales fueron recorridos temporalmente para conciliar tamaño y calcular SHA-256; los cuerpos fuente se descartaron después del procesamiento y no se publicaron ni conservaron como parte de la capa pública de LTMD.
 
-Con el propósito de actuar con plena claridad respecto de los derechos y términos aplicables, agradecería su orientación sobre los siguientes puntos:
+Adicionalmente observamos que los 39 PDF requieren contraseña para acceso de contenido mediante tres implementaciones independientes de PDF (`pypdf`, PyMuPDF y `pikepdf`) cuando se prueba únicamente contraseña vacía. LTMD **no pretende descubrir, recuperar, adivinar, neutralizar ni eludir contraseñas o controles de acceso**. Registramos ese estado sólo como evidencia técnica y hemos detenido cualquier inferencia sobre texto embebido u OCR hasta contar con una vía legítima y suficientemente clara.
 
-1. ¿Está permitido realizar extracción OCR de los libros disponibles en el Catálogo Histórico para investigación académica no comercial cuando las imágenes y el OCR completo se conservan únicamente como material de trabajo y no se redistribuyen?
-2. ¿Puede publicarse abiertamente un dataset derivado que contenga metadatos, identificadores de página, URLs oficiales, conteos, métricas, etiquetas analíticas, frecuencias y hashes, sin incluir las imágenes originales ni el texto íntegro?
-3. ¿Existe alguna autorización, licencia o política específica para publicar transcripciones OCR parciales o completas de materiales del Catálogo Histórico en repositorios académicos como GitHub o Zenodo? De ser así, ¿qué límites, atribuciones o condiciones deben observarse?
-4. Para documentar metodología y resultados, ¿pueden reproducirse fragmentos textuales breves de los libros como ejemplos de investigación, debidamente citados? ¿Existe alguna extensión o condición recomendada por la institución?
-5. ¿Puede utilizarse una miniatura de portada o de una página en una interfaz académica o publicación científica, o se requiere autorización específica, particularmente cuando la portada incorpora una obra artística?
-6. ¿Los derechos o autorizaciones sobre estos usos deben solicitarse a CONALITEG, a la Secretaría de Educación Pública —por ejemplo, al área responsable de materiales educativos— o a otra instancia dependiendo de la edición?
-7. ¿Existe algún documento de términos de uso específico del **Catálogo Histórico** distinto de los términos generales de gob.mx que debamos considerar?
+Con el propósito de mantener una política compatible con los derechos de autor y con las condiciones institucionales aplicables, agradecería su orientación sobre los siguientes puntos:
 
-Nuestro interés es mantener una política de ciencia abierta compatible con los derechos de autor y con las condiciones institucionales aplicables. En todo caso conservaríamos atribución completa y enlaces a las fuentes oficiales.
+1. ¿Está permitido realizar procesamiento local u OCR de los libros disponibles en el Catálogo Histórico para investigación académica cuando las imágenes y el OCR completo se conservan únicamente como material de trabajo privado y no se redistribuyen?
+2. ¿La misma posibilidad aplica a los materiales del catálogo vigente 2026–2027, o existen condiciones distintas para la colección contemporánea?
+3. ¿Puede publicarse abiertamente un dataset derivado que contenga metadatos, identificadores, URLs oficiales, hashes, conteos, métricas, etiquetas analíticas, frecuencias y otros resultados no sustitutivos, sin incluir imágenes originales ni texto íntegro?
+4. ¿Existe alguna autorización, licencia o política específica para publicar transcripciones OCR parciales o completas de materiales CONALITEG en repositorios académicos como GitHub o Zenodo? De existir, ¿qué límites, atribuciones o condiciones deben observarse?
+5. Para documentar metodología y resultados, ¿pueden reproducirse fragmentos textuales breves como ejemplos de investigación debidamente citados? ¿Existe alguna extensión o condición recomendada por la institución?
+6. ¿Puede utilizarse una miniatura de portada o de una página en una interfaz académica o publicación científica, o se requiere autorización específica, particularmente cuando la portada incorpora obra artística o material de terceros?
+7. ¿Los derechos o autorizaciones sobre estos usos deben solicitarse a CONALITEG, a la Secretaría de Educación Pública o a otra instancia dependiendo de la edición y de sus titulares?
+8. ¿Existen términos de uso específicos del Catálogo Histórico o del catálogo vigente 2026–2027 distintos de los términos generales de gob.mx?
+9. En el caso de materiales que el visor oficial permite consultar públicamente pero cuyo PDF exige contraseña para acceso de contenido mediante software PDF independiente, ¿existe una vía institucional autorizada para investigación computacional/OCR, o debe entenderse que ese tipo de procesamiento requiere una autorización expresa previa?
 
-Agradezco mucho cualquier orientación o canal institucional al que debamos dirigir esta consulta.
+Nuestro interés es mantener una política de ciencia abierta compatible con los derechos aplicables, preservar atribución y procedencia institucional y evitar cualquier redistribución o procesamiento no autorizado. Si estas preguntas corresponden a otra área de CONALITEG o de la SEP, agradecería mucho que nos indicaran el canal competente.
+
+Agradezco su orientación.
 
 Atentamente,
 
 **Fernando Sandoval Gutiérrez**  
-Proyecto *Libro de Texto Mexicano Digital*
+Responsable científico — *Libro de Texto Mexicano Digital (LTMD)*  
+Universidad Centro de Estudios Especializados en Educación Superior, Cuauhtémoc
 
 ## Registro antes del envío
 
@@ -48,6 +53,6 @@ Antes de enviar este mensaje se deberá registrar:
 - cualquier adjunto o liga incluida;
 - respuesta y fecha de recepción;
 - nombre/cargo del funcionario que responda, si está disponible;
-- interpretación operativa resultante y cambios requeridos en `DATA_GOVERNANCE.md`.
+- interpretación operativa resultante y cambios requeridos en `DATA_GOVERNANCE.md`, `RIGHTS_PUBLICATION_MATRIX.md` y el issue #2.
 
 No debe asumirse que el silencio o la ausencia de respuesta equivale a autorización.


### PR DESCRIPTION
Actualiza la consulta institucional preparada en `docs/DRAFT_CONALITEG_RIGHTS_INQUIRY.md` para incorporar la cohorte U2 2026–2027 y el estado técnico observado de acceso de contenido. La consulta distingue Catálogo Histórico vs. catálogo vigente, mantiene la no redistribución por defecto y deja explícito que LTMD no pretende descubrir, recuperar, adivinar ni eludir contraseñas o controles de acceso. No cambia estados científicos ni habilita OCR; sólo actualiza documentación jurídica-operativa y sigue sin enviar la consulta.