### PR TITLE
Docs: reconcile U1 W2 DMA 2018 routing closure

### DIFF
--- a/docs/LTMD_U1_W2_COMPLETION.md
+++ b/docs/LTMD_U1_W2_COMPLETION.md
@@ -1,39 +1,55 @@
 # LTMD-U1 W2 — cierre técnico de Matemáticas
 
-Versión: `LTMD_U1_W2_COMPLETION_0.1`.
+Versión: `LTMD_U1_W2_COMPLETION_0.2`.
 
 ## Resultado ejecutivo
 
 - Universo congelado: **64 visores**.
-- Identidades con activos efectivamente resueltos: **60/64**.
-- Excepciones de routing conservadas: **4/64**.
-- JPEG recuperados criptográficamente: **2**.
-- Posiciones no resueltas en las excepciones: **892**.
+- Identidades con routing institucional resuelto: **64/64**.
+- Excepciones de routing activas: **0/64**.
+- JPEG recuperados criptográficamente en `H2008P4MA276`: **2**.
 - Aliases documentales byte-idénticos: **3**.
-- Contenidos canónicos computados: **57**.
+- Contenidos canónicos computados en el corte OCR/PAGESTRUCT/FRAGSEG ya cerrado: **57**.
+- Identidades representadas por ese corte downstream histórico: **60/64**.
 
-## OCR 0.2
+## Cierre de routing DMA 2018 — 2 de septiembre de 2026
+
+Los cuatro visores `H2018P3DMA`, `H2018P4DMA`, `H2018P5DMA` y `H2018P6DMA` dejaron de ser excepciones de routing después de una reverificación independiente read-only.
+
+La ejecución GitHub Actions `33680203778` terminó en `success` y verificó el gate definido para las rutas institucionales. La evidencia técnica quedó en el artefacto `9866142958`, digest `sha256:e128a04a05b66835b53fa35870ef10203fdd9de5fe5fcd6b96c9f2229ff65a19`.
+
+El cierre de routing **no** convierte esas cuatro identidades en OCR/FTRL validadas. Tampoco demuestra alias con 2019.
+
+## OCR 0.2 — corte histórico
 
 - Páginas canónicas procesadas: **11,945**.
 - SHA-256 verificados: **11,945/11,945**.
 - Texto detectado: **11,812**.
 - `no_text_detected`: **133**.
-- `unresolved`: **0**.
+- `unresolved`: **0** dentro de los 57 contenidos computados.
 
-## PAGESTRUCT 0.2
+## PAGESTRUCT 0.2 — corte histórico
 
 - Páginas clasificadas: **11,945**.
 - Páginas elegibles para FRAGSEG: **10,145**.
 
-## FRAGSEG 0.2
+## FRAGSEG 0.2 — corte histórico
 
 - Páginas con ≥1 fragmento: **10,145**.
 - Fragmentos técnicos: **135,727**.
 
-## Cobertura
+## Cobertura y siguiente capa
 
-Los 57 contenidos canónicos reciben procesamiento directo. Los 3 aliases heredan únicamente cobertura técnica efectiva después de demostrar identidad completa de sus páginas. Los 4 DMA 2018 permanecen como excepciones explícitas y no se imputan.
+Los 57 contenidos canónicos reciben el procesamiento downstream histórico ya cerrado. Los tres aliases exact-byte heredan cobertura sólo bajo la prueba criptográfica registrada. Los cuatro DMA 2018 ahora tienen routing resuelto, pero deben pasar por una ejecución downstream específica antes de promover su estado en OCR, PAGESTRUCT, FRAGSEG o FTRL.
 
 ## Límite epistemológico
 
-Este cierre es técnico. Matemáticas no recibe automáticamente el clasificador semántico desarrollado para Ciencias Naturales; `fragseg_ready` no equivale a `semantic_ready`.
+Este cierre separa explícitamente dos capas:
+
+`routing_resolved != downstream_processed`
+
+`downstream_processed != ftrl_validated`
+
+`ftrl_validated != semantic_ready`
+
+La resolución de una ruta técnica no autoriza inferencias semánticas ni equivalencias documentales entre ciclos.

--- a/docs/LTMD_U1_W2_MATHEMATICS_STATUS_0_1.md
+++ b/docs/LTMD_U1_W2_MATHEMATICS_STATUS_0_1.md
@@ -1,7 +1,7 @@
 # LTMD-U1 W2 — estado técnico de Matemáticas 0.1
 
-Corte actualizado: 29 de agosto de 2026.  
-Estado: **capa técnica 0.2 completada; gate post-W11 satisfecho; FTRL pendiente de ejecución/archivo; semántica no abierta**.
+Corte actualizado: 2 de septiembre de 2026.  
+Estado: **routing institucional resuelto 64/64; downstream técnico histórico aún cubre 60/64 identidades; semántica no abierta**.
 
 ## Universo congelado
 
@@ -9,77 +9,47 @@ W2 contiene **64 visores** de Matemáticas dentro de LTMD-U1. `claves.json` decl
 
 ## Resolución de activos
 
-La auditoría SHA-256 por 64 shards produjo:
+La auditoría actual conserva **64/64 identidades con routing institucional efectivo demostrado**.
 
-- 59 visores `direct_asset_ready`;
-- 1 visor con dos huecos internos: `H2008P4MA276`;
-- 4 visores DMA 2018 con ruta declarada no servida: `H2018P3DMA`, `H2018P4DMA`, `H2018P5DMA`, `H2018P6DMA`.
+El caso `H2008P4MA276` conserva dos huecos internos recuperados de forma unívoca mediante alineamiento de vecinos byte-idénticos, offset fijo y cero discrepancias. El manifiesto reconciliado mantiene la anomalía original y la fuente efectiva.
 
-Los dos huecos de `H2008P4MA276` fueron recuperados de forma unívoca mediante alineamiento de vecinos byte-idénticos, offset fijo y cero discrepancias. El manifiesto reconciliado conserva la anomalía original y añade la fuente efectiva.
+Los cuatro DMA 2018 que antes estaban retenidos fueron reverificados de forma independiente el 2 de septiembre de 2026:
 
-Resultado reconciliado:
+- `H2018P3DMA`;
+- `H2018P4DMA`;
+- `H2018P5DMA`;
+- `H2018P6DMA`.
 
-- **60/64 identidades con activos efectivamente resueltos**;
-- **4/64 excepciones de routing aún no resueltas**;
-- **2 JPEG recuperados criptográficamente**;
-- ningún visor 2018 DMA recibe crédito por mera similitud de título, grado o cardinalidad.
+La ejecución read-only `33680203778` terminó en `success` sobre `24d583372286c64459816da75d07cc8ee9914609`. El gate exigió 892 JPEG institucionales servidos en total, cuatro 404 terminales esperados, cero huecos internos, cero errores y coincidencia SHA-256 contra la evidencia técnica previamente versionada. El artefacto `u1-w2-dma2018-reverification` quedó registrado como `9866142958`, digest `sha256:e128a04a05b66835b53fa35870ef10203fdd9de5fe5fcd6b96c9f2229ff65a19`.
 
-## Dependencia documental y cómputo único
+Este resultado satisface el criterio de cierre de routing del issue #4. No demuestra identidad con las ediciones 2019 y no autoriza alias entre ciclos.
 
-Entre los visores completos se demostraron tres aliases de contenido exacto, página por página, con SHA-256 y byte-size:
+## Cobertura downstream histórica
 
-- `H1982P4MA388` → canónico `H1972P4MA083`, 258 JPEG;
-- `H1982P5MA394` → canónico `H1972P5MA089`, 304 JPEG;
-- `H1982P6MA399` → canónico `H1972P6MA094`, 194 JPEG.
+La resolución de routing no promueve automáticamente OCR, PAGESTRUCT, FRAGSEG o FTRL.
 
-Por tanto, las 60 identidades efectivamente resueltas corresponden a **57 contenidos canónicos que requieren cómputo**. Los tres aliases conservan identidad documental propia, pero no se vuelven a OCRizar ni segmentar.
+La capa técnica ya cerrada antes de esta reverificación continúa representando **60/64 identidades de catálogo** mediante **57 contenidos canónicos** y tres aliases exact-byte. Los cuatro DMA 2018 recién resueltos quedan pendientes de una ejecución downstream específica antes de cualquier promoción adicional.
 
-## DMA 2018
-
-La comparación de configuración 2018↔2019 mostró el mismo `ag_pages` por grado, pero `ag_clave` distinto. Esa evidencia es insuficiente para declarar identidad documental o byte-alias. Los cuatro DMA 2018 permanecen explícitamente fuera del cómputo mientras no exista una prueba documental o criptográfica suficiente.
-
-## OCR técnico 0.2 — COMPLETADO
-
-La capa `LTMD_U1_W2_MATH_OCR_0.2` procesó los 57 contenidos canónicos y representa 60/64 identidades de catálogo mediante tres aliases exactos.
+## OCR técnico 0.2 — corte histórico cerrado
 
 - **11,945/11,945 páginas fuente canónicas verificadas por SHA-256**;
 - **11,812/11,945 (98.89%)** con texto detectado;
 - **133** `no_text_detected`;
-- **0 unresolved**;
-- OCR íntegro no persistido; sólo métricas y controles de procedencia.
+- **0 unresolved** dentro del universo computado de 57 contenidos canónicos.
 
-El combine final de OCR terminó en `success`; no fue necesario usar el workflow de recuperación preparado como contingencia.
-
-## PAGESTRUCT 0.2 — COMPLETADO
+## PAGESTRUCT 0.2 — corte histórico cerrado
 
 - **11,945** páginas clasificadas;
 - **10,145** páginas elegibles para FRAGSEG.
 
-## FRAGSEG 0.2 — COMPLETADO
+## FRAGSEG 0.2 — corte histórico cerrado
 
 - **10,145** páginas con al menos un fragmento;
 - **135,727** fragmentos técnicos.
 
-El cierre técnico está documentado en `docs/LTMD_U1_W2_COMPLETION.md`. Esta capa no constituye por sí misma validación FTRL, cierre archivístico ni validación semántica.
+## FTRL
 
-## Reactivación FTRL — 29 de agosto de 2026
-
-W11 cerró en `main` y sus controles post-merge requeridos quedaron verdes. La rama canónica `ftrl/w2-matematicas` fue sincronizada con el `main` resultante (`a1f8c248966d5210860fce8651a9975a89560f9c`). Con ello queda satisfecho el gate secuencial W11 → W2 y puede iniciarse la ejecución FTRL de Matemáticas.
-
-La apertura de W2 **no** promueve todavía estados del completion ledger. Hasta que exista validación distribuida exhaustiva y preservación privada persistente verificada:
-
-- las 60 identidades fuente-admitidas permanecen `pending`;
-- los cuatro DMA 2018 permanecen `blocked_active_retention`;
-- `archival_status` permanece `not_started`;
-- `text_verified=false` y `semantic_ready=false`.
-
-El contrato de activación queda fijado en `docs/LTMD_U1_W2_FTRL_ACTIVATION_0_1.md`.
-
-## Pipeline vigente
-
-`57 canónicos técnicos ✅ → FTRL distribuido → evidencia pública text-free + handoff privado cifrado → validación exhaustiva → preservación persistente verificada → promoción canónica de 60 identidades`
-
-Los tres aliases sólo pueden heredar cobertura FTRL tras conservar la prueba exact-byte ya registrada. Los cuatro DMA 2018 permanecen fuera de esa cadena y no pueden ser sustituidos por ediciones 2019.
+La resolución de routing de los cuatro DMA 2018 no equivale a validación FTRL. Cualquier procesamiento posterior debe ejecutarse y preservarse como etapa separada con sus propios gates.
 
 ## Regla epistemológica
 
@@ -88,5 +58,5 @@ Los tres aliases sólo pueden heredar cobertura FTRL tras conservar la prueba ex
 - `fragseg_ready` no equivale a `ftrl_validated`;
 - `ftrl_validated` no equivale a `semantic_ready`;
 - un alias exacto permite reutilizar cómputo, pero no elimina la identidad de catálogo;
-- una recuperación puntual de página no demuestra identidad bibliográfica entre libros completos;
-- ninguna transición del ledger puede inferirse de evidencia temporal o de un job incompleto: requiere cómputo validado y cierre archivístico verificable.
+- una ruta institucional recuperada no demuestra identidad bibliográfica entre libros de ciclos distintos;
+- ninguna transición del ledger se infiere de la resolución de routing: requiere cómputo validado y cierre archivístico verificable.


### PR DESCRIPTION
Reconciles the canonical W2 Mathematics documentation after the independent read-only reverification of the four DMA 2018 viewers.

Key points:
- records routing as resolved for 64/64 W2 identities;
- cites successful run 33680203778 and artifact 9866142958;
- preserves the distinction `routing_resolved != downstream_processed`;
- does not promote OCR, PAGESTRUCT, FRAGSEG, FTRL or semantic states for the four newly route-resolved identities;
- does not infer aliases with 2019.

Closes the documentation debt associated with issue #4 after the routing criterion was independently satisfied.