### PR TITLE
W2 DMA 2018: ejecutar downstream FTRL incremental

### DIFF
--- a/.github/workflows/consolidate-ftrl-w2-dma-2018.yml
+++ b/.github/workflows/consolidate-ftrl-w2-dma-2018.yml
@@ -1,0 +1,226 @@
+name: Consolidate FTRL W2 DMA 2018 preservation
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/consolidate-ftrl-w2-dma-2018.yml'
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: consolidate-ftrl-w2-dma-2018-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  consolidate:
+    name: consolidate-w2-dma-2018-preservation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Declare immutable source run and artifact inventory
+        run: |
+          cat > /tmp/source.json <<'JSON'
+          {
+            "source_run_id": 33793062199,
+            "source_commit": "a2b363e4f5770a5222805176ed2a5bb95c9b74c2",
+            "private": {
+              "H2018P3DMA": {"id": 9908240734, "sha256": "1387aff2dad996e587a9e8cb30ffb088644a2272511eafb76f8ec9b73d41665f", "pages": 225},
+              "H2018P4DMA": {"id": 9908255820, "sha256": "2516702a2f954438ee038090837894af64564cc57bc31fe17f3d59bcd824dc6b", "pages": 257},
+              "H2018P5DMA": {"id": 9908262596, "sha256": "0c163f3d7882ba019e87a42eab90bda54f36c24bed6f0009950fa7552df75763", "pages": 225},
+              "H2018P6DMA": {"id": 9908198281, "sha256": "1615926a8a75c51a8140f4381039968af5d594e7aa662e93cd5724cd3fd988ff", "pages": 185}
+            },
+            "public": {
+              "H2018P3DMA": {"id": 9908241489, "sha256": "161ceb8440679194678ad0c1b149e5bae57a68381aefc84250a4483e9ecfbf88", "pages": 225},
+              "H2018P4DMA": {"id": 9908256629, "sha256": "35374d912c875d5b0842c068b93a7b64055db0889ed024814588fc20023e72b0", "pages": 257},
+              "H2018P5DMA": {"id": 9908263399, "sha256": "a0cccbca3d1d5df7eb36d48642423615d9f1d3c6b9c77b673bfae0898067649a", "pages": 225},
+              "H2018P6DMA": {"id": 9908198991, "sha256": "23cfa20af36072f2a14a9d4d85525a1d3d4f4c37b8f8b4c12757f2db33b4a11c", "pages": 185}
+            },
+            "aggregate": {"id": 9908276589, "sha256": "545c8d09a0e979a888e7fe15e8b538dbf93c8203b0da6624c9984b4235e7d0a5"}
+          }
+          JSON
+
+      - name: Require successful immutable source workflow run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import json, os, subprocess
+          src=json.load(open('/tmp/source.json'))
+          raw=subprocess.check_output([
+              'gh','api',f"repos/{os.environ['GITHUB_REPOSITORY']}/actions/runs/{src['source_run_id']}"
+          ], text=True)
+          run=json.loads(raw)
+          assert run['status']=='completed', run['status']
+          assert run['conclusion']=='success', run['conclusion']
+          assert run['head_sha']==src['source_commit'], (run['head_sha'],src['source_commit'])
+          PY
+
+      - name: Download exact source artifact ZIPs and verify GitHub digests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os, subprocess
+          from pathlib import Path
+          src=json.load(open('/tmp/source.json'))
+          root=Path('local/w2-dma-preservation')
+          (root/'private').mkdir(parents=True)
+          (root/'public').mkdir(parents=True)
+
+          def sha(path):
+              h=hashlib.sha256()
+              with path.open('rb') as fh:
+                  for chunk in iter(lambda:fh.read(1024*1024),b''): h.update(chunk)
+              return h.hexdigest()
+
+          def get(aid, expected, dest):
+              url=f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}/actions/artifacts/{aid}/zip"
+              subprocess.run([
+                  'curl','-fsSL','-H',f"Authorization: Bearer {os.environ['GH_TOKEN']}",
+                  '-H','Accept: application/vnd.github+json','-H','X-GitHub-Api-Version: 2022-11-28',
+                  url,'-o',str(dest)
+              ],check=True)
+              observed=sha(dest)
+              assert observed==expected,(dest.name,observed,expected)
+
+          for viewer,item in src['private'].items():
+              get(item['id'],item['sha256'],root/'private'/f'{viewer}.zip')
+          for viewer,item in src['public'].items():
+              get(item['id'],item['sha256'],root/'public'/f'{viewer}.zip')
+          get(src['aggregate']['id'],src['aggregate']['sha256'],root/'public'/'aggregate.zip')
+          print('Verified exact 4 private + 4 public + 1 aggregate source artifact ZIPs')
+          PY
+
+      - name: Validate encrypted-only private handoffs and text-free public evidence
+        run: |
+          python - <<'PY'
+          import json, zipfile
+          from pathlib import Path
+          src=json.load(open('/tmp/source.json'))
+          root=Path('local/w2-dma-preservation')
+          forbidden_private=('_page_ocr.jsonl','_ocr_search.sqlite','.tar.gz')
+          for viewer in src['private']:
+              p=root/'private'/f'{viewer}.zip'
+              with zipfile.ZipFile(p) as z:
+                  names=z.namelist()
+              assert any(n.endswith('_restricted.tar.gz.enc') for n in names), (viewer,names)
+              assert any(n.endswith('_passphrase.rsa-oaep.enc') for n in names), (viewer,names)
+              assert any(n.endswith('_private_handoff_manifest.json') for n in names), (viewer,names)
+              assert not any(n.endswith(forbidden_private) for n in names), (viewer,names)
+
+          forbidden_public=('page_ocr.jsonl','ocr_search.sqlite','restricted.tar.gz','restricted.tar.gz.enc','passphrase.rsa-oaep.enc')
+          for viewer in src['public']:
+              p=root/'public'/f'{viewer}.zip'
+              with zipfile.ZipFile(p) as z:
+                  names=z.namelist()
+              assert not any(n.endswith(forbidden_public) for n in names), (viewer,names)
+              evidence=[n for n in names if n.endswith('_evidence.json')]
+              assert len(evidence)==1,(viewer,names)
+              with zipfile.ZipFile(p) as z:
+                  d=json.loads(z.read(evidence[0]).decode())
+              assert d['status']=='validated' and d['viewer_key']==viewer
+              assert d['text_verified'] is False and d['semantic_ready'] is False
+
+          with zipfile.ZipFile(root/'public'/'aggregate.zip') as z:
+              names=z.namelist(); assert len(names)==1
+              d=json.loads(z.read(names[0]).decode())
+          assert d['status']=='validated'
+          assert d['delta']['source_pages']==892
+          assert d['delta']['canonical_processing_objects']==4
+          assert d['current_partition']['canonical_processing_objects']==61
+          assert d['current_partition']['source_pages']==12837
+          assert d['archival_complete'] is False
+          assert d['text_verified'] is False and d['semantic_ready'] is False
+          print('Private handoffs encrypted-only; public evidence text-free; aggregate exact 4/892')
+          PY
+
+      - name: Build consolidated delta snapshots and preservation manifest
+        run: |
+          python - <<'PY'
+          import hashlib, json, shutil, zipfile
+          from pathlib import Path
+          src=json.load(open('/tmp/source.json'))
+          root=Path('local/w2-dma-preservation')
+          out=root/'consolidated'; out.mkdir()
+
+          private=out/'ltmd-u1-w2-dma-2018-consolidated-private-encrypted-snapshot__4-of-4.zip'
+          public=out/'ltmd-u1-w2-dma-2018-consolidated-public-evidence-snapshot__4-of-4.zip'
+          with zipfile.ZipFile(private,'w',compression=zipfile.ZIP_STORED) as z:
+              for viewer in sorted(src['private']):
+                  z.write(root/'private'/f'{viewer}.zip',arcname=f'private/{viewer}.zip')
+          with zipfile.ZipFile(public,'w',compression=zipfile.ZIP_STORED) as z:
+              for viewer in sorted(src['public']):
+                  z.write(root/'public'/f'{viewer}.zip',arcname=f'books/{viewer}.zip')
+              z.write(root/'public'/'aggregate.zip',arcname='aggregate/ltmd-u1-w2-dma-2018-delta-text-free-evidence.zip')
+
+          def desc(path):
+              h=hashlib.sha256()
+              with path.open('rb') as fh:
+                  for chunk in iter(lambda:fh.read(1024*1024),b''): h.update(chunk)
+              return {'file_name':path.name,'size_bytes':path.stat().st_size,'sha256':h.hexdigest()}
+
+          manifest={
+              'schema':'LTMD_U1_W2_DMA_2018_PRESERVATION_MANIFEST_0.1',
+              'wave':'W2','domain':'matematicas','effective_date':'2026-09-03',
+              'source_run_id':src['source_run_id'],'source_commit':src['source_commit'],
+              'baseline':{'canonical_processing_objects':57,'source_pages':11945,'archival_complete':True},
+              'current_partition':{
+                  'historical_identities':64,'admitted_historical_identities':64,
+                  'canonical_processing_objects':61,'exact_source_aliases':3,
+                  'withheld_identities':0,'source_pages':12837
+              },
+              'delta':{
+                  'viewer_keys':sorted(src['private']),'canonical_processing_objects':4,'source_pages':892,
+                  'book_pages':{v:src['private'][v]['pages'] for v in sorted(src['private'])}
+              },
+              'source_artifacts':src,
+              'private_delta_snapshot':desc(private),
+              'public_delta_snapshot':desc(public),
+              'computationally_validated':True,
+              'persistent_archive_verified':False,
+              'archival_complete':False,
+              'text_verified':False,
+              'semantic_ready':False,
+              'interpretive_limit':'Automated technical validation only; no human text or semantic validation. Persistent Drive readback is required before archival_complete may become true.'
+          }
+          mp=out/'ltmd-u1-w2-dma-2018-preservation-manifest.json'
+          mp.write_text(json.dumps(manifest,indent=2,sort_keys=True)+'\n',encoding='utf-8')
+          bundle=out/'ltmd-u1-w2-dma-2018-preservation-manifest-bundle.zip'
+          with zipfile.ZipFile(bundle,'w',compression=zipfile.ZIP_DEFLATED) as z:
+              z.write(mp,arcname=mp.name)
+          print(json.dumps({'private':desc(private),'public':desc(public),'manifest':desc(mp),'bundle':desc(bundle)},indent=2,sort_keys=True))
+          PY
+
+      - name: Upload consolidated private delta snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-2018-consolidated-private-encrypted-snapshot-4-of-4
+          path: local/w2-dma-preservation/consolidated/ltmd-u1-w2-dma-2018-consolidated-private-encrypted-snapshot__4-of-4.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload consolidated public delta snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-2018-consolidated-public-evidence-snapshot-4-of-4
+          path: local/w2-dma-preservation/consolidated/ltmd-u1-w2-dma-2018-consolidated-public-evidence-snapshot__4-of-4.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload preservation manifest bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-2018-preservation-manifest-bundle
+          path: |
+            local/w2-dma-preservation/consolidated/ltmd-u1-w2-dma-2018-preservation-manifest.json
+            local/w2-dma-preservation/consolidated/ltmd-u1-w2-dma-2018-preservation-manifest-bundle.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/run-ftrl-w2-dma-2018.yml
+++ b/.github/workflows/run-ftrl-w2-dma-2018.yml
@@ -1,0 +1,292 @@
+name: Run FTRL W2 DMA 2018 delta
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/build_ftrl_w2_inputs.py'
+      - 'scripts/run_ftrl_w2_book.py'
+      - 'scripts/validate_ftrl_w2_dma_2018.py'
+      - '.github/workflows/run-ftrl-w2-dma-2018.yml'
+      - 'data/catalog/ltmd_u1_w2_math_reconciled_summary.csv'
+      - 'data/catalog/ltmd_u1_w2_math_reconciled_manifest.csv'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ftrl-w2-dma-2018-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  config-gate:
+    name: validate-w2-dma-2018-config
+    runs-on: ubuntu-latest
+    outputs:
+      viewers: ${{ steps.matrix.outputs.viewers }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile W2 delta scripts
+        run: python -m py_compile scripts/build_ftrl_w2_inputs.py scripts/run_ftrl_w2_book.py scripts/validate_ftrl_w2_dma_2018.py
+      - name: Rebuild current W2 inputs without network
+        run: |
+          python scripts/build_ftrl_w2_inputs.py \
+            --asset-output /tmp/w2_asset_manifest.csv \
+            --processing-output /tmp/w2_processing_inventory.csv
+      - name: Validate current denominator and exact DMA delta
+        id: matrix
+        shell: bash
+        run: |
+          python - <<'PY'
+          import csv, json, os
+          from collections import Counter
+
+          dma = {
+              'H2018P3DMA': 225,
+              'H2018P4DMA': 257,
+              'H2018P5DMA': 225,
+              'H2018P6DMA': 185,
+          }
+          aliases = {
+              'H1982P4MA388': 'H1972P4MA083',
+              'H1982P5MA394': 'H1972P5MA089',
+              'H1982P6MA399': 'H1972P6MA094',
+          }
+          def read(path):
+              with open(path, encoding='utf-8', newline='') as fh:
+                  return list(csv.DictReader(fh))
+
+          assets = read('/tmp/w2_asset_manifest.csv')
+          proc = read('/tmp/w2_processing_inventory.csv')
+          scope = read('data/catalog/ltmd_u1_w2_scope.csv')
+          summary = read('data/catalog/ltmd_u1_w2_math_reconciled_summary.csv')
+          alias_rows = read('data/catalog/ltmd_u1_w2_math_reconciled_exact_aliases.csv')
+          ready = {r['viewer_key'] for r in summary if r['effective_asset_ready'] == '1'}
+          canonical = {r['viewer_key'] for r in proc}
+          observed_aliases = {
+              r['viewer_key']: r['canonical_viewer_key']
+              for r in alias_rows if r['all_effective_pages_byte_identical_aligned'] == '1'
+          }
+          assert len(scope) == 64 and len(summary) == 64
+          assert len(ready) == 64
+          assert observed_aliases == aliases
+          assert len(proc) == 61 and len(assets) == 12837
+          assert ready == canonical | set(aliases)
+          assert canonical.isdisjoint(set(aliases))
+          assert set(dma) <= canonical
+          assert all(r['is_canonical_processing_object'] == '1' for r in proc)
+          assert all(r['technical_identity_covered'] == '1' for r in proc)
+          assert all(r['persistent_internal_source_gaps'] == '0' for r in proc)
+          observed = Counter(r['viewer_key'] for r in assets if r['viewer_key'] in dma)
+          assert dict(observed) == dma, observed
+          assert sum(observed.values()) == 892
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as fh:
+              print('viewers=' + json.dumps(list(dma), separators=(',', ':')), file=fh)
+          print('W2 current partition: 64 historical / 64 admitted / 61 canonical / 3 aliases / 0 withheld / 12837 pages')
+          print('DMA 2018 delta: 4 canonical / 892 pages')
+          PY
+
+  book:
+    name: dma-${{ matrix.viewer }}
+    needs: config-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        viewer: ${{ fromJSON(needs.config-gate.outputs.viewers) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Spanish Tesseract data
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends tesseract-ocr tesseract-ocr-spa
+          tesseract --list-langs | grep -Fx spa
+      - name: Validate private preservation contract
+        run: python scripts/validate_private_corpus_storage_contract.py
+      - name: Execute deterministic W2 DMA book unit
+        run: |
+          python scripts/run_ftrl_w2_book.py \
+            --viewer-key '${{ matrix.viewer }}' \
+            --output-dir local/ftrl-w2
+      - name: Assert public evidence is text-free and non-semantic
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          python - <<'PY'
+          import json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          p = Path(f'local/ftrl-w2/{viewer}/w2_{viewer}_evidence.json')
+          data = json.loads(p.read_text(encoding='utf-8'))
+          assert data['schema'] == 'LTMD_FTRL_W2_BOOK_UNIT_0.2'
+          assert data['status'] == 'validated'
+          assert data['text_verified'] is False
+          assert data['semantic_ready'] is False
+          forbidden = {'ocr_text_raw','search_text','snippet','text','normalized_text'}
+          def walk(x):
+              if isinstance(x, dict):
+                  assert not (forbidden & set(x)), forbidden & set(x)
+                  for v in x.values(): walk(v)
+              elif isinstance(x, list):
+                  for v in x: walk(v)
+          walk(data)
+          PY
+      - name: Build and encrypt restricted book archive
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          set -euo pipefail
+          DIR="local/ftrl-w2/${VIEWER}"
+          HANDOFF="local/private-handoff-w2-${VIEWER}"
+          mkdir -p "$HANDOFF"
+          tar -C "$DIR" -czf "$HANDOFF/w2_${VIEWER}_restricted.tar.gz" \
+            "w2_${VIEWER}_page_ocr.jsonl" \
+            "w2_${VIEWER}_ocr_search.sqlite" \
+            "w2_${VIEWER}_qc_queue.json" \
+            "w2_${VIEWER}_asset_manifest.csv" \
+            "w2_${VIEWER}_run_manifest.json" \
+            "w2_${VIEWER}_qc_summary.json"
+          openssl rand -base64 48 > "/tmp/w2-${VIEWER}.pass"
+          openssl enc -aes-256-cbc -salt -pbkdf2 -iter 250000 \
+            -in "$HANDOFF/w2_${VIEWER}_restricted.tar.gz" \
+            -out "$HANDOFF/w2_${VIEWER}_restricted.tar.gz.enc" \
+            -pass file:"/tmp/w2-${VIEWER}.pass"
+          openssl pkeyutl -encrypt \
+            -pubin -inkey security/ltmd_archive_public.pem \
+            -in "/tmp/w2-${VIEWER}.pass" \
+            -out "$HANDOFF/w2_${VIEWER}_passphrase.rsa-oaep.enc" \
+            -pkeyopt rsa_padding_mode:oaep -pkeyopt rsa_oaep_md:sha256
+          sha256sum "$HANDOFF/w2_${VIEWER}_restricted.tar.gz.enc" "$HANDOFF/w2_${VIEWER}_passphrase.rsa-oaep.enc" > "$HANDOFF/SHA256SUMS.txt"
+          rm -f "$HANDOFF/w2_${VIEWER}_restricted.tar.gz" "/tmp/w2-${VIEWER}.pass"
+      - name: Write text-free encrypted handoff manifest
+        env:
+          VIEWER: ${{ matrix.viewer }}
+          GH_RUN_ID: ${{ github.run_id }}
+          GH_SHA: ${{ github.sha }}
+        run: |
+          python - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          viewer = os.environ['VIEWER']
+          handoff = Path(f'local/private-handoff-w2-{viewer}')
+          evidence = json.loads(Path(f'local/ftrl-w2/{viewer}/w2_{viewer}_evidence.json').read_text(encoding='utf-8'))
+          public_key = Path('security/ltmd_archive_public.pem')
+          public_key_sha256 = hashlib.sha256(public_key.read_bytes()).hexdigest()
+          assert public_key_sha256 == '78852eafbaa332247f99e23508ac157b5b906c6c3bf3aeb0af1dfe8d57579c2d'
+          def desc(name):
+              p = handoff / name
+              h = hashlib.sha256()
+              with p.open('rb') as fh:
+                  for chunk in iter(lambda: fh.read(1024*1024), b''): h.update(chunk)
+              return {'name': name, 'bytes': p.stat().st_size, 'sha256': h.hexdigest()}
+          payload = f'w2_{viewer}_restricted.tar.gz.enc'
+          key = f'w2_{viewer}_passphrase.rsa-oaep.enc'
+          manifest = {
+              'schema':'LTMD_PRIVATE_FTRL_W2_DMA_2018_HANDOFF_0.1',
+              'wave':'W2',
+              'viewer_key':viewer,
+              'page_records':evidence['page_records'],
+              'source_commit':os.environ['GH_SHA'],
+              'workflow_run_id':os.environ['GH_RUN_ID'],
+              'encryption':{
+                  'payload':'AES-256-CBC + PBKDF2-SHA256, 250000 iterations',
+                  'key_wrap':'RSA-4096 OAEP SHA-256',
+                  'public_key_sha256':public_key_sha256,
+              },
+              'files':[desc(payload), desc(key), desc('SHA256SUMS.txt')],
+              'plaintext_restricted_outputs_uploaded':False,
+              'destination_policy':'private persistent archive required before archival_complete may be promoted',
+              'archival_complete':False,
+              'text_verified':False,
+              'semantic_ready':False,
+          }
+          (handoff / f'w2_{viewer}_private_handoff_manifest.json').write_text(
+              json.dumps(manifest, indent=2, sort_keys=True)+'\n', encoding='utf-8'
+          )
+          PY
+      - name: Prove plaintext archive is absent
+        env:
+          VIEWER: ${{ matrix.viewer }}
+        run: |
+          HANDOFF="local/private-handoff-w2-${VIEWER}"
+          test ! -f "$HANDOFF/w2_${VIEWER}_restricted.tar.gz"
+          test -f "$HANDOFF/w2_${VIEWER}_restricted.tar.gz.enc"
+          test -f "$HANDOFF/w2_${VIEWER}_passphrase.rsa-oaep.enc"
+      - name: Upload encrypted private handoff only
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-${{ matrix.viewer }}-private-encrypted
+          path: local/private-handoff-w2-${{ matrix.viewer }}/
+          if-no-files-found: error
+          retention-days: 3
+      - name: Upload text-free computational evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-${{ matrix.viewer }}-text-free-evidence
+          path: |
+            local/ftrl-w2/${{ matrix.viewer }}/w2_${{ matrix.viewer }}_evidence.json
+            local/ftrl-w2/${{ matrix.viewer }}/w2_${{ matrix.viewer }}_run_manifest.json
+            local/ftrl-w2/${{ matrix.viewer }}/w2_${{ matrix.viewer }}_qc_summary.json
+            local/ftrl-w2/${{ matrix.viewer }}/w2_${{ matrix.viewer }}_asset_manifest.csv
+          if-no-files-found: error
+          retention-days: 30
+
+  aggregate:
+    name: validate-w2-dma-2018-delta
+    needs: book
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Download all text-free DMA evidence
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ltmd-u1-w2-dma-*-text-free-evidence
+          path: local/w2-dma-evidence
+          merge-multiple: false
+      - name: Rebuild current W2 admitted inputs
+        run: |
+          mkdir -p local/w2-expected
+          python scripts/build_ftrl_w2_inputs.py \
+            --asset-output local/w2-expected/asset_manifest.csv \
+            --processing-output local/w2-expected/processing_inventory.csv
+      - name: Validate exact DMA 2018 delta against archived baseline
+        run: |
+          python scripts/validate_ftrl_w2_dma_2018.py \
+            --evidence-root local/w2-dma-evidence \
+            --asset-manifest local/w2-expected/asset_manifest.csv \
+            --processing-inventory local/w2-expected/processing_inventory.csv \
+            --baseline-closure data/research/ltmd_u1_w2_archival_closure.json \
+            --output local/ltmd_u1_w2_dma_2018_delta_evidence.json
+      - name: Upload delta text-free evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: ltmd-u1-w2-dma-2018-delta-text-free-evidence
+          path: local/ltmd_u1_w2_dma_2018_delta_evidence.json
+          if-no-files-found: error
+          retention-days: 30
+      - name: State epistemic result
+        run: |
+          echo 'Success means the 4-book / 892-page DMA 2018 delta is computationally validated.'
+          echo 'It does not mean archival_complete, text_verified, semantic_ready, or human validation.'
+
+  report-failure:
+    name: report-w2-dma-failure
+    if: failure()
+    needs: [config-gate, book, aggregate]
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo 'W2 DMA 2018 did not complete every downstream gate.'
+          echo 'Do not promote archival, text, semantic, or completion-ledger state.'

--- a/scripts/build_ftrl_w2_inputs.py
+++ b/scripts/build_ftrl_w2_inputs.py
@@ -13,14 +13,18 @@ import re
 from collections import Counter
 from pathlib import Path
 
-VERSION = "LTMD_U1_W2_FTRL_INPUTS_0.1"
+VERSION = "LTMD_U1_W2_FTRL_INPUTS_0.2"
 EXPECTED_HISTORICAL = 64
-EXPECTED_ADMITTED = 60
-EXPECTED_CANONICAL = 57
+EXPECTED_ADMITTED = 64
+EXPECTED_CANONICAL = 61
 EXPECTED_ALIASES = 3
-EXPECTED_WITHHELD = 4
-EXPECTED_PAGES = 11945
-WITHHELD = {"H2018P3DMA", "H2018P4DMA", "H2018P5DMA", "H2018P6DMA"}
+EXPECTED_PAGES = 12837
+DMA_2018_PAGES = {
+    "H2018P3DMA": 225,
+    "H2018P4DMA": 257,
+    "H2018P5DMA": 225,
+    "H2018P6DMA": 185,
+}
 EXPECTED_ALIAS = {
     "H1982P4MA388": "H1972P4MA083",
     "H1982P5MA394": "H1972P5MA089",
@@ -73,11 +77,11 @@ def main() -> None:
     assert set(summary_by) == set(scope_by)
 
     ready = {k for k, r in summary_by.items() if n(r, "effective_asset_ready") == 1}
-    withheld = set(scope_by) - ready
+    unresolved = set(scope_by) - ready
     assert len(ready) == EXPECTED_ADMITTED
-    assert len(withheld) == EXPECTED_WITHHELD
-    assert withheld == WITHHELD
-    assert all(n(summary_by[k], "effective_unresolved") > 0 for k in WITHHELD)
+    assert not unresolved, unresolved
+    assert set(DMA_2018_PAGES) <= ready
+    assert all(n(summary_by[k], "effective_unresolved") == 0 for k in DMA_2018_PAGES)
 
     alias_map = {
         r["viewer_key"]: r["canonical_viewer_key"]
@@ -92,6 +96,7 @@ def main() -> None:
     canonical_keys = ready - set(alias_map)
     assert len(canonical_keys) == EXPECTED_CANONICAL
     assert set(alias_map.values()) <= canonical_keys
+    assert set(DMA_2018_PAGES) <= canonical_keys
 
     pfields = [
         "processing_version", "viewer_key", "catalog_generation", "grade_code", "title_core",
@@ -108,6 +113,8 @@ def main() -> None:
         assert n(s, "effective_unresolved") == 0
         assert n(s, "effective_real_jpeg") > 0
         assert n(s, "declared_rows") == n(s, "effective_real_jpeg") + n(s, "terminal_synthetic")
+        if viewer in DMA_2018_PAGES:
+            assert n(s, "effective_real_jpeg") == DMA_2018_PAGES[viewer]
         pout.append({
             "processing_version": VERSION,
             "viewer_key": viewer,
@@ -123,9 +130,9 @@ def main() -> None:
             "persistent_internal_source_gaps": 0,
             "source_processing_basis": f"{s['reconcile_version']}:effective_asset_ready",
             "interpretive_limit": (
-                "technical FTRL only; four DMA 2018 identities remain active retentions; "
+                "technical FTRL only; DMA 2018 routing is resolved from institutional source evidence; "
                 "three admitted historical identities are exact full-sequence aliases; "
-                "OCR availability does not imply text verification or semantic validation"
+                "OCR availability does not imply human text verification or semantic validation"
             ),
         })
     assert len(pout) == EXPECTED_CANONICAL
@@ -176,7 +183,8 @@ def main() -> None:
     assert counts == expected_counts, (counts - expected_counts, expected_counts - counts)
     assert len(aout) == len(seen) == EXPECTED_PAGES
     assert sum(expected_counts.values()) == EXPECTED_PAGES
-    assert not ({r["viewer_key"] for r in aout} & WITHHELD)
+    assert {k: counts[k] for k in DMA_2018_PAGES} == DMA_2018_PAGES
+    assert sum(counts[k] for k in DMA_2018_PAGES) == 892
     assert not ({r["viewer_key"] for r in aout} & set(EXPECTED_ALIAS))
 
     write(Path(args.processing_output), pout, pfields)
@@ -184,7 +192,8 @@ def main() -> None:
     print(
         "Built W2 FTRL inputs: "
         f"historical={EXPECTED_HISTORICAL}, admitted={EXPECTED_ADMITTED}, "
-        f"canonical={len(pout)}, aliases={len(alias_map)}, withheld={len(withheld)}, pages={len(aout)}"
+        f"canonical={len(pout)}, aliases={len(alias_map)}, pages={len(aout)}, "
+        "dma2018=4/892"
     )
 
 

--- a/scripts/run_ftrl_w2_book.py
+++ b/scripts/run_ftrl_w2_book.py
@@ -19,12 +19,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 EXPECTED_HISTORICAL = 64
-EXPECTED_ADMITTED = 60
-EXPECTED_CANONICAL = 57
+EXPECTED_ADMITTED = 64
+EXPECTED_CANONICAL = 61
 EXPECTED_ALIASES = 3
-EXPECTED_WITHHELD = 4
-EXPECTED_TOTAL = 11945
-SCHEMA = "LTMD_FTRL_W2_BOOK_UNIT_0.1"
+EXPECTED_WITHHELD = 0
+EXPECTED_TOTAL = 12837
+SCHEMA = "LTMD_FTRL_W2_BOOK_UNIT_0.2"
 NETWORK_RETRY_ATTEMPTS = 4
 NETWORK_RETRY_MARKERS = (
     "urlerror", "timeouterror", "timed out", "temporary failure",
@@ -258,13 +258,14 @@ def main() -> None:
         "text_free_products": [descriptor(unit_asset), descriptor(run_manifest), descriptor(qc_summary)],
         "execution": rm.get("execution"),
         "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "text_verified": False,
+        "semantic_ready": False,
         "epistemic_guards": [
-            "computationally_validated != archival_complete",
+            "routing_resolved != downstream_processed",
+            "downstream_processed != ftrl_validated",
+            "ftrl_validated != text_verified",
+            "text_verified != semantic_ready",
             "ocr_available != text_verified",
-            "corpus_ready != semantic_ready",
-            "source_alias_requires_full_sequence_byte_identity",
-            "retained_source_identity != alias_candidate",
-            "dma_2018 != dma_2019_without_documentary_or_cryptographic_proof",
             "search_hit != historical_claim",
             "zero_hits != demonstrated_absence",
         ],

--- a/scripts/validate_ftrl_w2_dma_2018.py
+++ b/scripts/validate_ftrl_w2_dma_2018.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate the incremental FTRL downstream for the four resolved W2 DMA 2018 books.
+
+This validator deliberately preserves the 57-book / 11,945-page archival baseline
+as historical evidence and validates only the newly admitted 4-book / 892-page
+delta against the current 61-book / 12,837-page W2 source partition.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+DMA_2018 = {
+    "H2018P3DMA": 225,
+    "H2018P4DMA": 257,
+    "H2018P5DMA": 225,
+    "H2018P6DMA": 185,
+}
+EXPECTED_DELTA_PAGES = 892
+EXPECTED_HISTORICAL = 64
+EXPECTED_ADMITTED = 64
+EXPECTED_CANONICAL = 61
+EXPECTED_ALIASES = 3
+EXPECTED_WITHHELD = 0
+EXPECTED_TOTAL = 12837
+BASELINE_CANONICAL = 57
+BASELINE_PAGES = 11945
+SCHEMA = "LTMD_FTRL_W2_DMA_2018_DELTA_EVIDENCE_0.1"
+BOOK_SCHEMA = "LTMD_FTRL_W2_BOOK_UNIT_0.2"
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(encoding="utf-8", newline="") as fh:
+        return list(csv.DictReader(fh))
+
+
+def page_key_hash(viewer_key: str, page_index: int) -> str:
+    return hashlib.sha256(f"{viewer_key}:src{page_index:04d}".encode("utf-8")).hexdigest()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--evidence-root", type=Path, required=True)
+    ap.add_argument("--asset-manifest", type=Path, required=True)
+    ap.add_argument("--processing-inventory", type=Path, required=True)
+    ap.add_argument("--baseline-closure", type=Path, required=True)
+    ap.add_argument("--output", type=Path, required=True)
+    args = ap.parse_args()
+
+    proc = read_csv(args.processing_inventory)
+    assets = read_csv(args.asset_manifest)
+    if len(proc) != EXPECTED_CANONICAL:
+        raise SystemExit(f"expected {EXPECTED_CANONICAL} current W2 canonical rows, found {len(proc)}")
+    if len(assets) != EXPECTED_TOTAL:
+        raise SystemExit(f"expected {EXPECTED_TOTAL} current W2 source pages, found {len(assets)}")
+
+    proc_by = {r["viewer_key"]: r for r in proc}
+    if set(DMA_2018) - set(proc_by):
+        raise SystemExit("one or more DMA 2018 identities are absent from current canonical inventory")
+    if any(
+        proc_by[v]["technical_identity_covered"] != "1"
+        or proc_by[v]["is_canonical_processing_object"] != "1"
+        or proc_by[v]["persistent_internal_source_gaps"] != "0"
+        for v in DMA_2018
+    ):
+        raise SystemExit("DMA 2018 current processing inventory is not technically admissible")
+
+    delta_assets = [r for r in assets if r["viewer_key"] in DMA_2018]
+    counts = Counter(r["viewer_key"] for r in delta_assets)
+    if dict(counts) != DMA_2018:
+        raise SystemExit(f"DMA 2018 source-page count drift: {dict(counts)}")
+    if len(delta_assets) != EXPECTED_DELTA_PAGES:
+        raise SystemExit("DMA 2018 delta page denominator drift")
+
+    expected_hashes = {
+        page_key_hash(r["viewer_key"], int(r["source_image_index"])) for r in delta_assets
+    }
+    if len(expected_hashes) != EXPECTED_DELTA_PAGES:
+        raise SystemExit("DMA 2018 page-key collision or duplicate")
+
+    baseline = json.loads(args.baseline_closure.read_text(encoding="utf-8"))
+    if not baseline.get("archival_complete"):
+        raise SystemExit("historical W2 baseline is not archival_complete")
+    bf = baseline.get("ftrl", {})
+    if int(bf.get("canonical_processing_objects", -1)) != BASELINE_CANONICAL:
+        raise SystemExit("historical W2 baseline canonical denominator drift")
+    if int(bf.get("source_pages", -1)) != BASELINE_PAGES:
+        raise SystemExit("historical W2 baseline page denominator drift")
+    exceptions = baseline.get("source_exceptions", {}).get("viewer_keys", [])
+    if set(exceptions) != set(DMA_2018):
+        raise SystemExit("historical W2 baseline does not document the exact DMA 2018 retention set")
+
+    evidence_files = sorted(args.evidence_root.rglob("w2_*_evidence.json"))
+    if len(evidence_files) != len(DMA_2018):
+        raise SystemExit(f"expected 4 DMA 2018 evidence files, found {len(evidence_files)}")
+
+    seen_viewers: set[str] = set()
+    union_hashes: set[str] = set()
+    book_records: dict[str, int] = {}
+    sqlite_records = 0
+    fts_records = 0
+    qc_records = 0
+    product_hashes: list[dict[str, object]] = []
+
+    partition_checks = {
+        "historical_identities": EXPECTED_HISTORICAL,
+        "admitted_historical_identities": EXPECTED_ADMITTED,
+        "canonical_processing_objects": EXPECTED_CANONICAL,
+        "exact_source_aliases": EXPECTED_ALIASES,
+        "withheld_identities": EXPECTED_WITHHELD,
+        "full_admitted_canonical_source_pages": EXPECTED_TOTAL,
+    }
+
+    for path in evidence_files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("schema") != BOOK_SCHEMA:
+            raise SystemExit(f"unexpected DMA 2018 book evidence schema: {path}")
+        if data.get("status") != "validated" or data.get("wave") != "W2":
+            raise SystemExit(f"non-validated or foreign DMA 2018 evidence: {path}")
+        viewer = data.get("viewer_key")
+        if viewer not in DMA_2018 or viewer in seen_viewers:
+            raise SystemExit(f"unexpected or duplicate DMA 2018 viewer evidence: {viewer}")
+        seen_viewers.add(viewer)
+
+        pages = int(data["page_records"])
+        if pages != DMA_2018[viewer]:
+            raise SystemExit(f"DMA 2018 evidence page drift for {viewer}: {pages}")
+        hashes = list(data["page_key_hashes"])
+        if len(hashes) != pages or len(set(hashes)) != pages:
+            raise SystemExit(f"duplicate/missing DMA 2018 page hashes for {viewer}")
+        if union_hashes & set(hashes):
+            raise SystemExit(f"cross-book DMA 2018 page hash overlap for {viewer}")
+        union_hashes.update(hashes)
+
+        partition = data["source_partition"]
+        if any(int(partition[k]) != v for k, v in partition_checks.items()):
+            raise SystemExit(f"current W2 source partition drift for {viewer}")
+
+        validation = data["validation"]
+        if validation["sqlite_integrity"] != "ok":
+            raise SystemExit(f"SQLite integrity failure for {viewer}")
+        if (
+            int(validation["sqlite_pages"]) != pages
+            or int(validation["fts_rows"]) != pages
+            or int(validation["qc_page_records"]) != pages
+        ):
+            raise SystemExit(f"DMA 2018 validation cardinality drift for {viewer}")
+        sqlite_records += int(validation["sqlite_pages"])
+        fts_records += int(validation["fts_rows"])
+        qc_records += int(validation["qc_page_records"])
+        book_records[viewer] = pages
+
+        if data.get("text_verified") is not False or data.get("semantic_ready") is not False:
+            raise SystemExit(f"forbidden semantic/text promotion in {viewer}")
+
+        for group in ("restricted_products", "text_free_products"):
+            if len(data[group]) != 3:
+                raise SystemExit(f"unexpected product count for {viewer}: {group}")
+            for item in data[group]:
+                if len(item["sha256"]) != 64 or int(item["bytes"]) <= 0:
+                    raise SystemExit(f"invalid product descriptor for {viewer}")
+                product_hashes.append({
+                    "viewer_key": viewer,
+                    "class": group,
+                    "name": item["name"],
+                    "bytes": item["bytes"],
+                    "sha256": item["sha256"],
+                })
+
+    if seen_viewers != set(DMA_2018):
+        raise SystemExit("DMA 2018 evidence viewer union is not exhaustive")
+    if union_hashes != expected_hashes or len(union_hashes) != EXPECTED_DELTA_PAGES:
+        raise SystemExit("DMA 2018 page evidence union is not exact and exhaustive")
+    if not (sqlite_records == fts_records == qc_records == EXPECTED_DELTA_PAGES):
+        raise SystemExit("DMA 2018 SQLite/FTS/QC cardinality drift")
+
+    out = {
+        "schema": SCHEMA,
+        "status": "validated",
+        "wave": "W2",
+        "domain": "Matemáticas",
+        "mode": "incremental_downstream_after_routing_resolution",
+        "baseline": {
+            "archival_closure": str(args.baseline_closure),
+            "canonical_processing_objects": BASELINE_CANONICAL,
+            "source_pages": BASELINE_PAGES,
+            "archival_complete": True,
+        },
+        "current_partition": {
+            "historical_identities": EXPECTED_HISTORICAL,
+            "admitted_historical_identities": EXPECTED_ADMITTED,
+            "canonical_processing_objects": EXPECTED_CANONICAL,
+            "exact_source_aliases": EXPECTED_ALIASES,
+            "withheld_identities": EXPECTED_WITHHELD,
+            "source_pages": EXPECTED_TOTAL,
+        },
+        "delta": {
+            "viewer_keys": sorted(DMA_2018),
+            "canonical_processing_objects": len(DMA_2018),
+            "book_page_records": dict(sorted(book_records.items())),
+            "source_pages": EXPECTED_DELTA_PAGES,
+            "unique_page_key_hashes": len(union_hashes),
+            "sqlite_page_rows": sqlite_records,
+            "fts_rows": fts_records,
+            "qc_page_records": qc_records,
+        },
+        "products": sorted(product_hashes, key=lambda x: (x["viewer_key"], x["class"], x["name"])),
+        "computationally_validated": True,
+        "archival_complete": False,
+        "text_verified": False,
+        "semantic_ready": False,
+        "epistemic_guards": [
+            "routing_resolved != downstream_processed",
+            "downstream_processed != ftrl_validated",
+            "ftrl_validated != text_verified",
+            "text_verified != semantic_ready",
+            "incremental_validation != archival_completion",
+            "search_hit != historical_claim",
+        ],
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(out, indent=2, ensure_ascii=False, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({"status": "ok", "books": 4, "pages": EXPECTED_DELTA_PAGES, "output": str(args.output)}, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Objetivo

Materializa el downstream técnico pendiente de #167 para las cuatro identidades DMA 2018 cuya resolución de routing ya quedó probada en #4 / PR #165:

- `H2018P3DMA` — 225 páginas fuente
- `H2018P4DMA` — 257 páginas fuente
- `H2018P5DMA` — 225 páginas fuente
- `H2018P6DMA` — 185 páginas fuente

Delta exacto: **4 objetos canónicos / 892 páginas**.

## Cambio de partición W2

La evidencia reconciliada actual implica:

- 64 identidades históricas
- 64 admitidas técnicamente
- 3 aliases exactos
- 61 objetos canónicos de procesamiento
- 12,837 páginas fuente
- 0 identidades retenidas por routing

La clausura archivística histórica de W2 de 2026-08-30 se conserva sin reescritura como baseline de **57 objetos / 11,945 páginas**. Este PR valida únicamente el delta posterior de 4/892.

## Implementación

- actualiza `build_ftrl_w2_inputs.py` al denominador vigente;
- actualiza el runner por libro para la partición 64/64/61/3/0/12837;
- añade `validate_ftrl_w2_dma_2018.py`, que exige la unión exacta de los cuatro DMA y 892 páginas;
- añade un workflow incremental que ejecuta Tesseract/SQLite/FTS/QC por libro;
- cifra cualquier producto restringido antes de subirlo como handoff temporal;
- publica únicamente evidencia text-free, hashes y metadatos técnicos.

## Guardas epistemológicas y jurídicas

Este PR **no** realiza validación humana. Mantiene explícitamente:

- `text_verified=false`
- `semantic_ready=false`
- `archival_complete=false` para el delta hasta preservación persistente y reverificación

No publica JPEG, PDF ni OCR íntegro. No elude controles de acceso. Respeta el semáforo jurídico de #2.

## Cierre

Refs #167. No cerrar #167 hasta que el workflow incremental complete validación computacional y el delta restringido quede preservado de forma persistente con hashes verificados.